### PR TITLE
Feat #1: Scaffold ucm subcommand with verb stubs and gitops workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -7,7 +7,7 @@ name: Upstream Sync
 
 on:
   schedule:
-    - cron: "0 7 * * 1"   # Mondays 07:00 UTC
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fork (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,9 +53,9 @@ jobs:
         run: git push origin HEAD --force-with-lease
 
       - name: Open PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          script: |
+          script: |-
             const branch = "${{ steps.branch.outputs.branch }}";
             const conflict = "${{ steps.merge.outcome }}" !== "success";
             const title = conflict

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,82 @@
+name: Upstream Sync
+
+# Weekly fetch of databricks/cli upstream/main into this fork.
+# Opens a PR with the merge so the UCM maintainers can review conflicts before landing.
+# Fork-specific: this workflow does NOT exist in databricks/cli upstream and will never
+# cause a merge conflict on sync.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"   # Mondays 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Merge upstream/main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "ucm-upstream-sync[bot]"
+          git config user.email "ucm-upstream-sync@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/databricks/cli.git
+
+      - name: Fetch upstream
+        run: git fetch upstream main
+
+      - name: Create sync branch
+        id: branch
+        run: |
+          branch="upstream-sync/$(date -u +%Y-%m-%d)"
+          git checkout -b "$branch" origin/main
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Merge upstream/main
+        id: merge
+        continue-on-error: true
+        run: git merge --no-edit upstream/main
+
+      - name: Push sync branch
+        if: always()
+        run: git push origin HEAD --force-with-lease
+
+      - name: Open PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = "${{ steps.branch.outputs.branch }}";
+            const conflict = "${{ steps.merge.outcome }}" !== "success";
+            const title = conflict
+              ? `chore(sync): upstream merge (CONFLICTS) — ${branch}`
+              : `chore(sync): upstream merge — ${branch}`;
+            const body = [
+              "Automated weekly sync with `databricks/cli` upstream.",
+              "",
+              conflict
+                ? "⚠️  **Merge conflicts detected.** Resolve locally before merging this PR."
+                : "✅  Clean merge. Verify `go build ./...` passes in CI before merging.",
+              "",
+              "Fork divergence guardrail: keep ucm-specific changes confined to `cmd/ucm/`, `ucm/`, and `.github/workflows/upstream-sync.yml` to minimize conflict surface.",
+            ].join("\n");
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: branch,
+              base: "main",
+              title,
+              body,
+              draft: conflict,
+            });
+            core.info(`Opened PR #${pr.number}: ${pr.html_url}`);

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/selftest"
 	"github.com/databricks/cli/cmd/sync"
+	"github.com/databricks/cli/cmd/ucm"
 	"github.com/databricks/cli/cmd/version"
 	"github.com/databricks/cli/cmd/workspace"
 	"github.com/databricks/cli/libs/cmdgroup"
@@ -97,6 +98,7 @@ func New(ctx context.Context) *cobra.Command {
 	cli.AddCommand(auth.New())
 	cli.AddCommand(completion.New())
 	cli.AddCommand(bundle.New())
+	cli.AddCommand(ucm.New())
 	cli.AddCommand(cache.New())
 	cli.AddCommand(experimental.New())
 	cli.AddCommand(psql.New())

--- a/cmd/ucm/CLAUDE.md
+++ b/cmd/ucm/CLAUDE.md
@@ -1,0 +1,227 @@
+# UCM (Unity Catalog Management) — Agent Guide
+
+This file overrides and extends the repo-root `CLAUDE.md` for any work under
+`cmd/ucm/`, `ucm/`, and `.github/workflows/upstream-sync.yml`. The root file
+still applies for everything else (build commands, error handling, no
+`os.Exit` outside main, etc.) — read it first.
+
+## What ucm is
+
+A sibling subcommand to `bundle` that brings DAB-style declarative management
+to Unity Catalog: metastores, catalogs, schemas, volumes, external locations,
+storage/service credentials, grants, tags, connections, plus the cloud
+underlay (S3/ADLS/GCS, IAM/MI/SA, KMS) on AWS+Azure+GCP at parity.
+
+Engine mirrors `bundle/` (~70–80% structural reuse): config loader, mutator
+chain, terraform binary wrapper, lock/state, auth. Resource model and
+converters are UC-specific and live in their own packages.
+
+The full design is in `~/.claude/plans/you-are-a-data-twinkling-lighthouse.md`.
+
+## Fork divergence rules — READ BEFORE EDITING
+
+This repo is a fork of `databricks/cli`. A weekly upstream-sync workflow
+(`.github/workflows/upstream-sync.yml`) merges `upstream/main`. Every change
+to an upstream-owned file is potential merge conflict. So:
+
+1. **Confine ucm code to ucm-owned paths**:
+   - `cmd/ucm/**` — CLI wiring
+   - `ucm/**` — engine (parallel sibling of `bundle/`)
+   - `.github/workflows/upstream-sync.yml` — fork-only
+2. **Touch upstream files only when unavoidable**. Currently the only allowed
+   upstream edit is `cmd/cmd.go` (registers `ucm.New()` next to `bundle.New()`).
+   Adding a new touchpoint requires a deliberate decision in the PR description.
+3. **Never edit `bundle/**` from a ucm PR**. If you genuinely need a change in
+   shared `libs/**`, extract it to ucm first; promote to upstream later.
+4. **Don't import `bundle/**` from `ucm/**`**. Fork-and-adapt instead — the
+   bundle package will evolve upstream and pinning to its internals will break
+   on every sync. `libs/**` reuse is fine.
+
+## Architecture
+
+```
+cmd/ucm/                 # cobra wiring, one file per verb
+  ucm.go                 # New() — registers all verbs
+  validate.go deploy.go plan.go destroy.go ...
+  stubs.go               # placeholder for not-yet-implemented verbs
+
+ucm/                     # engine (sibling of bundle/)
+  bundle.go              # Ucm struct: Config, WorkspaceClient, AccountClient,
+                         #   Terraform, Locker, StateFiler
+  config/                # Root, Resources, Targets, Variables, mutator chain
+  resources/             # Go struct per UC + cloud resource kind
+  phases/                # load, initialize, build, deploy, destroy, plan, ...
+  deploy/
+    state.go state_pull.go state_push.go
+    filer/               # StateFiler interface; workspace + s3/adls/gcs impls
+    lock/                # forked from bundle/deploy/lock
+    terraform/           # forked from bundle/deploy/terraform
+      tfdyn/             # converter registry: ucm resource → tf json
+  schema/                # generated jsonschema for ucm.yml
+  generate/              # brownfield scan → ucm.yml + seed state
+  templates/             # embed.FS, served by `ucm init`
+  ci/                    # CI starter pipelines (GHA, GL, ADO, BB, Jenkins)
+```
+
+## Verbs
+
+DAB-subset (parity): `validate`, `plan`, `deploy`, `destroy`, `summary`,
+`init`, `generate`, `bind`, `schema`, `debug`, `diff`.
+ucm-specific: `drift`, `import`, `policy-check`.
+Dropped from DAB: `run`, `sync` (no runtime exec or source sync for UC).
+
+All verbs are stubbed in `cmd/ucm/stubs.go` and return
+`"ucm <verb> is not yet implemented"` — replace with real implementations one
+verb at a time, each in its own `cmd/ucm/<verb>.go` file (mirror
+`cmd/bundle/validate.go` for shape).
+
+## Auth model
+
+OAuth M2M with service principals only in v1 (no PAT, no U2M). The `Ucm`
+struct holds both `WorkspaceClient` (workspace-scoped: grants, bindings,
+catalogs/schemas/volumes/EL/SC/connections) AND `AccountClient` (account-scoped:
+metastores, metastore assignments). Same SP must have account-admin scope.
+
+Terraform inherits the same `DATABRICKS_HOST` / `DATABRICKS_CLIENT_ID` /
+`DATABRICKS_CLIENT_SECRET` env vars that the `databricks` provider already
+consumes. Cloud creds (AWS/Azure/GCP) come from environment — assume OIDC
+federation in CI.
+
+## State backend
+
+Pluggable behind `StateFiler` interface (`ucm/deploy/filer/iface.go`):
+- v1 impl: workspace files (DAB-parity)
+- v2 impls: S3+DynamoDB / ADLS / GCS, selected via `ucm.yml > ucm.state.backend`
+
+One `terraform.tfstate` per target (monolithic, not sharded). Terraform's
+native reference graph orders resources — no cross-component orchestration.
+
+## Topology
+
+1 deployment = 1 account + 1 metastore + 1 workspace. Multi-region or
+multi-workspace orgs run multiple deployments (`targets:` where shape is
+similar, separate ucm.yml otherwise). The bootstrap deployment owns the
+metastore; downstream workspace deployments reference its id read-only.
+
+## Tag enforcement
+
+`ucm/config/mutator/validate_tags.go` runs in `validate`/`plan`/`policy-check`.
+Reads `resources.tag_validation_rules.*`, checks every securable matching
+`securable_types` for required keys and (if `allowed_values` set) value
+membership. Emits `error`-level diagnostics. No dependency on UC server-side
+tag policy.
+
+## Build / test (UCM-specific shortcuts)
+
+The repo-root `CLAUDE.md` has the canonical build commands. UCM-specific
+gotchas in this environment:
+
+```bash
+# Corporate /etc/hosts blocks proxy.golang.org and toolchain may not match go.mod.
+# Use these env vars for any go command:
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...
+
+# git-lfs is required (charmbracelet/huh transitive dep). Install once:
+brew install git-lfs   # do NOT run `git lfs install` — pre-push hook conflict
+
+# Smoke test the binary:
+./databricks ucm --help
+./databricks ucm validate   # expect: "ucm validate is not yet implemented"
+```
+
+When implementing a verb, add unit tests next to the file (`cmd/ucm/<verb>_test.go`)
+and mutator/converter tests under `ucm/config/mutator/*_test.go` and
+`ucm/deploy/terraform/tfdyn/*_test.go` following bundle's patterns.
+
+## Git workflow (gitops-style — required for UCM work)
+
+The upstream `databricks/cli` `CLAUDE.md` doesn't prescribe an issue→branch→PR
+lifecycle. UCM does — adapted from the prior Python implementation's gitops
+agent. Use this for every non-trivial UCM change:
+
+### 1. Create a tracking issue first
+
+```bash
+gh issue create \
+  --title "<short imperative summary>" \
+  --body "<context, acceptance criteria, links>" \
+  --label "ucm,<area-label>"
+```
+
+Area labels: `area/cmd`, `area/config`, `area/mutator`, `area/terraform`,
+`area/state`, `area/cloud-aws`, `area/cloud-azure`, `area/cloud-gcp`,
+`area/templates`, `area/ci`, `area/docs`.
+
+Type labels (one): `feat`, `fix`, `chore`, `refactor`, `test`, `docs`.
+
+### 2. Branch naming
+
+`<type>/<issue-number>-<kebab-summary>` — examples:
+- `feat/12-validate-tags-mutator`
+- `fix/18-state-filer-lock-timeout`
+- `chore/3-upstream-sync-2026-04-27`
+
+One issue per branch. One branch per PR. Never push directly to `main`.
+
+### 3. Commit messages
+
+`<Type> #<issue>: <subject>` — examples:
+- `Feat #12: Add validate_tags mutator`
+- `Fix #18: Retry workspace-files lock acquisition with backoff`
+
+Body explains *why*. Never amend pushed commits. Never `--no-verify`.
+
+### 4. Pre-push CI gate (run locally)
+
+```bash
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...
+```
+
+Block the push if any step fails. Fix root cause — don't bypass.
+
+### 5. PR template
+
+```markdown
+Closes #<N>
+
+## Summary
+- <bullet 1>
+- <bullet 2>
+
+## Why
+<one paragraph: motivation, constraint, or upstream incident>
+
+## Test plan
+- [ ] `go build ./...`
+- [ ] `go test ./cmd/ucm/... ./ucm/...`
+- [ ] Manual: <smoke test command>
+- [ ] If touching upstream files: list each file and justify
+```
+
+PR labels mirror issue labels. Request review only after CI is green.
+
+### 6. Never
+
+- Push to `main` directly.
+- Force-push (use `--force-with-lease` only on your own feature branch).
+- Skip hooks (`--no-verify`, `--no-gpg-sign`).
+- Squash-merge across multiple issues — one PR closes one issue.
+- Edit `bundle/**` or `libs/**` from a ucm-labeled PR.
+
+## Common mistakes (UCM-specific, on top of root CLAUDE.md)
+
+- Importing from `bundle/**` instead of forking the relevant pieces into
+  `ucm/**`. The bundle package is upstream and will diverge on every sync.
+- Adding new edits to `cmd/cmd.go` (or any other upstream file) without
+  flagging it as a fork-divergence cost in the PR.
+- Hand-writing TF JSON in converters — use `libs/dyn` to build values, then
+  `tfjson` write helpers, exactly as `bundle/deploy/terraform/tfdyn` does.
+- Adding identity (groups/SCIM/users/SPs) resources. Out of scope for v1 —
+  ucm references existing principals by name/id only.
+- Adding a `run` or `sync` verb. Explicitly dropped from DAB scope.
+- Treating "policy-check" as a slower `validate`. policy-check runs *only*
+  the validation mutators (cheap pre-commit hook target); `validate` runs the
+  full chain.

--- a/cmd/ucm/stubs.go
+++ b/cmd/ucm/stubs.go
@@ -1,0 +1,78 @@
+package ucm
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/spf13/cobra"
+)
+
+// stub returns a cobra command that prints a not-yet-implemented message.
+// Each verb gets its own dedicated file once real behavior lands.
+func stub(use, short string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  root.NoArgs,
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("ucm %s is not yet implemented", use)
+	}
+	return cmd
+}
+
+func newValidateCommand() *cobra.Command {
+	return stub("validate", "Validate ucm.yml for errors, warnings, policy violations.")
+}
+
+func newSchemaCommand() *cobra.Command {
+	return stub("schema", "Print the JSON schema for ucm.yml.")
+}
+
+func newPlanCommand() *cobra.Command {
+	return stub("plan", "Preview the changes ucm deploy would make.")
+}
+
+func newDeployCommand() *cobra.Command {
+	return stub("deploy", "Apply ucm configuration to the target Databricks account/workspace.")
+}
+
+func newDestroyCommand() *cobra.Command {
+	return stub("destroy", "Tear down everything managed by the current target.")
+}
+
+func newSummaryCommand() *cobra.Command {
+	return stub("summary", "Summarize deployed resources and their ids/URLs.")
+}
+
+func newInitCommand() *cobra.Command {
+	return stub("init [template]", "Scaffold a new ucm.yml project from a starter template.")
+}
+
+func newGenerateCommand() *cobra.Command {
+	return stub("generate", "Scan an existing account+metastore+workspace and emit ucm.yml + seed state.")
+}
+
+func newBindCommand() *cobra.Command {
+	return stub("bind", "Attach an existing Databricks resource to a ucm.yml node without recreating it.")
+}
+
+func newDebugCommand() *cobra.Command {
+	return stub("debug", "Dump internal ucm state (config tree, mutator trace) for troubleshooting.")
+}
+
+func newDiffCommand() *cobra.Command {
+	return stub("diff", "Detect which ucm stacks changed since a base git ref. Intended for CI matrices.")
+}
+
+func newDriftCommand() *cobra.Command {
+	return stub("drift", "Compare live UC state to persisted terraform state; alert on out-of-band changes.")
+}
+
+func newImportCommand() *cobra.Command {
+	return stub("import <type> <name>", "Import a single existing UC or cloud resource into ucm state.")
+}
+
+func newPolicyCheckCommand() *cobra.Command {
+	return stub("policy-check", "Run only the ucm validation mutators (tags, naming, required fields).")
+}

--- a/cmd/ucm/ucm.go
+++ b/cmd/ucm/ucm.go
@@ -1,0 +1,53 @@
+// Package ucm implements the `databricks ucm` subcommand for managing Unity Catalog
+// resources (metastores, catalogs, schemas, external locations, storage credentials,
+// grants, tags, connections) and their cloud-underlay prerequisites at enterprise scale.
+//
+// It mirrors the UX and engine of `databricks bundle` (Declarative Automation Bundles)
+// but targets Unity Catalog declarative configuration instead of jobs/pipelines.
+package ucm
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ucm",
+		Short: "Manage Unity Catalog resources declaratively at enterprise scale.",
+		Long: `Unity Catalog Management (ucm) — DAB-style declarative management of Unity Catalog.
+
+Common workflows:
+  databricks ucm init greenfield-bootstrap    # Scaffold a new ucm.yml project
+  databricks ucm validate                     # Lint config + run policy checks
+  databricks ucm plan --target dev            # Preview changes
+  databricks ucm deploy --target prod         # Apply changes
+  databricks ucm destroy --target dev         # Tear down a target
+
+Import existing resources:
+  databricks ucm generate --metastore-name m1  # Scan an account + emit ucm.yml
+  databricks ucm import catalog team_alpha     # Import a single catalog into state
+
+Governance:
+  databricks ucm drift --target prod           # Detect out-of-band changes
+  databricks ucm policy-check                  # Run only the validation mutators
+
+Online documentation: https://docs.databricks.com/en/dev-tools/ucm/index.html`,
+		GroupID: "development",
+	}
+
+	cmd.AddCommand(newValidateCommand())
+	cmd.AddCommand(newSchemaCommand())
+	cmd.AddCommand(newPlanCommand())
+	cmd.AddCommand(newDeployCommand())
+	cmd.AddCommand(newDestroyCommand())
+	cmd.AddCommand(newSummaryCommand())
+	cmd.AddCommand(newInitCommand())
+	cmd.AddCommand(newGenerateCommand())
+	cmd.AddCommand(newBindCommand())
+	cmd.AddCommand(newDebugCommand())
+	cmd.AddCommand(newDiffCommand())
+	cmd.AddCommand(newDriftCommand())
+	cmd.AddCommand(newImportCommand())
+	cmd.AddCommand(newPolicyCheckCommand())
+	return cmd
+}


### PR DESCRIPTION
Closes #1

## Summary

- Adds `ucm` (Unity Catalog Management) as a sibling subcommand to `bundle`.
- All 14 verbs are stubbed: `validate`, `schema`, `plan`, `deploy`, `destroy`, `summary`, `init`, `generate`, `bind`, `debug`, `diff`, `drift`, `import`, `policy-check`. Each prints `"ucm <verb> is not yet implemented"` and exits non-zero.
- Adds `cmd/ucm/CLAUDE.md` with fork-divergence rules, architecture map, build commands, and a gitops-style git workflow (issue->branch->PR with `Closes #N`, branch naming, pre-push CI gate).
- Adds `.github/workflows/upstream-sync.yml`: weekly cron (Mon 07:00 UTC) merges `databricks/cli upstream/main` and opens a PR (draft on conflict).

## Why

This unblocks every downstream UCM PR. Without the cobra wiring and the upstream touchpoint in `cmd/cmd.go`, no verb implementation can ship as a self-contained PR. Doing it as a separate, behavior-free PR keeps reviewer attention on the upstream-divergence surface (one edited file) rather than mixing it with feature work.

The CLAUDE.md is the second purpose of this PR. Upstream `cli/CLAUDE.md` doesn't prescribe an issue->branch->PR lifecycle; UCM does. Codifying it now means every subsequent UCM PR follows the same shape.

## Upstream divergence surface

Only one upstream file edited: `cmd/cmd.go` (2 lines: import + `cli.AddCommand(ucm.New())`). All other changes live in ucm-owned paths (`cmd/ucm/**`, `.github/workflows/upstream-sync.yml`).

## Test plan

- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...` — passes
- [x] `./databricks ucm --help` — lists all 14 verbs under "Available Commands"
- [x] `./databricks ucm validate` — prints `Error: ucm validate is not yet implemented`, exits 1
- [x] `./databricks bundle --help` — unchanged, still works
- [x] `./databricks --help` — `ucm` appears in "Developer Tools" group alongside `bundle`
- [ ] `go test ./cmd/ucm/...` — no tests added in this PR (stubs only)
- [ ] Upstream-sync workflow dry-run — runs on Monday cron; manual trigger available via `workflow_dispatch`

## Follow-ups

- M0 implementation: real `ucm validate` + `ucm schema` on a sample `ucm.yml` (next issue).
- Each remaining verb gets its own issue + PR, one per slice.