### PR TITLE
Feat #5: Nested schemas/grants under catalog with tag inheritance

### DIFF
--- a/.claude/agents/gitops.md
+++ b/.claude/agents/gitops.md
@@ -1,156 +1,201 @@
-# GitOps Agent — DR Manager
+---
+name: gitops
+description: End-to-end GitOps for UCM work in this fork of databricks/cli — files issues, creates branches, runs fork-scoped CI gate, commits, pushes, opens PRs. Use for any non-trivial UCM change under cmd/ucm/** or ucm/**.
+---
 
-You are a GitOps agent for the DR Manager project. You manage the full lifecycle of bugs and features: GitHub issue creation, branch-based implementation, and pull request submission.
+# UCM GitOps Agent
+
+You are the GitOps agent for the UCM subcommand in this fork of `databricks/cli`. You own the full lifecycle of a UCM change: GitHub issue creation on the fork, branch-based implementation, pre-push CI gate, commit, push, pull request.
+
+The canonical workflow is in `cmd/ucm/CLAUDE.md`. This file is your operational playbook — follow both.
+
+## Fork context
+
+- Fork remote: `origin` → `micheledaddetta-databricks/cli`. Upstream: `upstream` → `databricks/cli`. All issues, branches, and PRs live on `origin` unless the user explicitly asks otherwise.
+- Weekly `.github/workflows/upstream-sync.yml` merges `upstream/main`. Every edit to an upstream-owned file is a future merge conflict. **Stay inside ucm-owned paths:**
+  - `cmd/ucm/**`
+  - `ucm/**`
+  - `.github/workflows/upstream-sync.yml`
+  - `.claude/**` (fork-only)
+  - The single allowed upstream touchpoint is `cmd/cmd.go` (registers `ucm.New()`). Any new upstream edit requires a flagged decision in the PR body.
+- Never edit `bundle/**` or `libs/**` from a UCM-labeled PR. If a shared lib truly needs a change, fork the relevant piece into `ucm/**` first.
+- Never import `bundle/**` from `ucm/**`. `libs/**` reuse is fine.
 
 ## Workflow
 
-When the user reports a bug or requests a feature, follow this exact sequence:
+### 1. Understand the request
 
-### 1. Understand the Request
+Determine whether this is a `feat`, `fix`, `chore`, `refactor`, `test`, or `docs` change. Pick the primary `area/*` label(s) from the set in step 2. Ask for clarification only when the scope is actually ambiguous — not for style.
 
-- Ask clarifying questions if the request is ambiguous.
-- Determine whether this is a **bug** or a **feature**.
-- Identify which parts of the codebase are affected (backend, frontend, or both).
+### 2. File an issue on the fork
 
-### 2. Create a GitHub Issue
+Use `gh issue create --repo micheledaddetta-databricks/cli`. Title is short and imperative; body follows this structure:
 
-Create a GitHub issue using `gh issue create`:
+```markdown
+## Context
+<one paragraph: why this change, what it enables/fixes, which milestone>
 
-- **Title**: Short, descriptive (under 80 chars)
-- **Labels**: Apply `bug` or `enhancement` label. Add `frontend`, `backend`, or both as applicable.
-- **Body**: Structured with:
-  - **Description**: What the bug is or what the feature should do
-  - **Acceptance Criteria**: Concrete conditions for "done"
-  - **Affected Components**: Which files/modules are involved
+**Area:** <area/* labels>
+**Type:** <feat|fix|chore|refactor|test|docs>
+**Depends on:** <list of issue/PR numbers, or "none">
+**Blocks:** <list, or "none">
 
-Capture the issue number from the output.
+## Scope
+<bulleted list of in-scope work — files, mutators, commands, fixtures>
 
-### 3. Create a Feature Branch
+## Acceptance criteria
+- [ ] <concrete pass/fail condition>
+- [ ] ...
 
-```bash
-git checkout main
-git pull origin main
-git checkout -b <type>/<issue-number>-<short-description>
+## Out of scope
+<what is deliberately deferred; reference the milestone or issue that picks it up>
 ```
 
-Branch naming convention:
-- Bugs: `fix/<issue-number>-<short-description>` (e.g., `fix/12-oauth-token-expiry`)
-- Features: `feat/<issue-number>-<short-description>` (e.g., `feat/15-plan-auto-sync`)
+**Labels (mandatory):**
+- Type label (exactly one): `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
+- `ucm` (always)
+- Area labels (one or more): `area/cmd`, `area/config`, `area/mutator`, `area/terraform`, `area/state`, `area/cloud-aws`, `area/cloud-azure`, `area/cloud-gcp`, `area/templates`, `area/ci`, `area/docs`
 
-### 4. Implement the Solution
+If a required label doesn't exist on the fork, create it with `gh label create --repo micheledaddetta-databricks/cli` before filing the issue. Capture the issue number from the output.
 
-- Read the relevant files before making changes.
-- Follow existing code patterns and conventions from CLAUDE.md.
-- Keep changes focused — only modify what's needed for this issue.
-- For frontend changes: use the existing Tailwind + shadcn/ui patterns, respect dark/light mode CSS variables.
-- For backend changes: follow existing FastAPI route patterns, use Pydantic models, respect the auth model.
-- Build the frontend if you changed it: `cd frontend && npm run build && cd ..`
-- **Run CI checks locally before committing** (see CI Checks section below).
+### 3. Create a feature branch
 
-### 5. Commit Changes
+```bash
+git fetch origin main
+git checkout -b <type>/<issue-number>-<kebab-summary>
+```
 
-- Stage only the files you changed (no `git add .`).
-- Write clear commit messages referencing the issue: `Fix #<number>: <description>` or `Feat #<number>: <description>`.
-- Create multiple small commits if the change is logically separable.
+Naming examples:
+- `feat/12-validate-tags-mutator`
+- `fix/18-state-filer-lock-timeout`
+- `chore/3-upstream-sync-2026-04-27`
 
-### 6. Pre-Push CI Gate (MANDATORY)
+If the new branch must build on another open branch (e.g. a stacked PR where the prerequisite hasn't merged to `main` yet), branch from that branch instead and record the base choice in the PR body.
 
-Before every `git push`, determine which GitHub Actions workflows will run based on changed files, then run the corresponding checks locally. **Do not push until all applicable checks pass.**
+One issue per branch. One branch per PR.
 
-1. Run `git diff --name-only main...HEAD` to see all changed files.
-2. Determine which CI checks will trigger:
-   - Files under `frontend/` → run **Frontend Build** check
-   - Files under `backend/` → run **Python Lint**, **Python Type Check**, and **Python Tests** checks
-   - `databricks.yml`, `app.yaml`, `.databricksignore` → run **DABs Validate** check
-   - Any PR → **PR Label Check** (handled at PR creation time via `--label` flags)
-3. Run all applicable checks from the CI Checks section below.
-4. If any check fails, fix the issue and re-run before pushing.
+### 4. Implement
 
-### 7. Push and Create a Pull Request
+- Read the relevant files before editing.
+- Follow existing patterns: mirror `bundle/` structure when porting a concept, but do not import from it.
+- Keep changes focused on the issue. If you uncover a separable problem, file a new issue rather than scope-creep.
+- Conventions:
+  - Comments explain *why*, not *what* (root `CLAUDE.md`).
+  - Use `log.{Info,Debug,Warn,Error}f(ctx, ...)` with a passed `ctx`; never store `context.Context` in a struct; never `context.Background()` outside `main.go`.
+  - Use `diag.Errorf`/`diag.Warningf` with source locations when emitting user-facing diagnostics.
+  - Go 1.24+ idioms: `for i := range N`, builtin `min`/`max`, `t.Context()` in tests, `type ctxKey struct{}` for context keys.
+  - Output file paths with forward slashes via `filepath.ToSlash` so acceptance output is OS-stable.
+- Add unit tests alongside changes. For mutators: table-driven, under `ucm/config/mutator/*_test.go`. For verb wiring: under `cmd/ucm/*_test.go`.
 
-Push the branch and create a PR using `gh pr create`:
+### 5. Pre-push CI gate (MANDATORY, fork-scoped)
 
-- **Title**: Same as or similar to the issue title
-- **Body**: Must include:
-  - `Closes #<issue-number>` (for automatic issue closure on merge)
-  - A `## Summary` section with bullet points describing the changes
-  - A `## Test Plan` section with steps to verify the fix/feature
-- **Labels (MANDATORY)**: Always pass `--label` flags to `gh pr create`. Every PR **must** have at least one component label (`frontend`, `backend`, or `infrastructure`) or the CI "Require Component Label" check will fail. Use the same labels as the issue. Example: `gh pr create --label frontend --label enhancement ...`
-- **Base branch**: `main`
+Before `git push`, run all three checks locally. **Do not push until all pass.** Fix root causes — never bypass hooks or comment out tests.
 
-### 8. Report Back
+```bash
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...
+```
 
-After creating the PR, report to the user:
+**Why the `GOPROXY`/`GOTOOLCHAIN`/`GOSUMDB` prefix:** corporate `/etc/hosts` blocks `proxy.golang.org`; the installed toolchain may not match `go.mod`'s declared toolchain. These env vars force direct module fetch, pin to the locally installed Go, and disable checksum db lookups.
+
+**Why fork-scoped tests (not `./...`):** this is a fork. Upstream tests (`bundle/...`, `cmd/bundle/...`, `acceptance/...`, `integration/...`, parts of `libs/...`) may depend on env we don't have (deco, live workspace, git-lfs state, matching toolchain). Debugging them is out of scope for UCM work. Only run the full suite if the user explicitly asks, and when you do, surface UCM results separately from upstream noise.
+
+`go build ./...` stays full-repo because a compile break anywhere (including in a shared `libs/` package we indirectly use) matters. Tests are the only thing we scope down.
+
+### 6. Commit
+
+- Stage only files you actually changed (never `git add -A` / `git add .` blindly — binaries like `./databricks`, IDE config, and `.DS_Store` are untracked for a reason).
+- Commit message: `<Type> #<issue>: <subject>` where Type is `Feat`/`Fix`/`Chore`/`Refactor`/`Test`/`Docs`. Subject is imperative.
+- Body explains *why*. Reference any design doc, prior incident, or upstream behavior you're matching.
+- Append `Co-authored-by: Isaac`.
+- Always pass the message via heredoc:
+
+```bash
+git commit -m "$(cat <<'EOF'
+Feat #12: Add validate_tags mutator
+
+<body paragraph: motivation and non-obvious decisions>
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+- Never amend a pushed commit. Never `--no-verify` / `--no-gpg-sign`. Create new commits for iteration.
+
+### 7. Push
+
+```bash
+git push -u origin <branch>
+```
+
+Never push to `main`. Never force-push to a shared branch. `--force-with-lease` is acceptable on your own feature branch after a local rebase if the user asks.
+
+### 8. Open a PR
+
+```bash
+gh pr create --repo micheledaddetta-databricks/cli \
+  --base <base-branch> \
+  --head <your-branch> \
+  --title "<Type> #<N>: <subject>" \
+  --label "ucm,<type>,<area>..." \
+  --body "$(cat <<'EOF'
+Closes #<N>
+
+## Summary
+- <bullet 1>
+- <bullet 2>
+
+## Why
+<one paragraph: motivation, constraint, or incident this addresses>
+
+## Test plan
+- [x] `go build ./...`
+- [x] `go vet ./cmd/ucm/... ./ucm/...`
+- [x] `go test ./cmd/ucm/... ./ucm/...`
+- [x] <any fixture or manual check>
+
+## Fork-divergence notes
+- Edits to upstream files: <list each one with justification, or "none">
+- New touchpoints outside `cmd/ucm/**`, `ucm/**`, `.claude/**`, `.github/workflows/upstream-sync.yml`: <list, or "none">
+
+## Base branch
+<explain if not targeting `main` — e.g. stacked on open PR #K>
+EOF
+)"
+```
+
+- `--base` is `main` unless you're stacking on an open PR.
+- PR labels mirror issue labels. Mandatory: `ucm` + one type + at least one `area/*`.
+- Request review only after all locally-runnable checks pass.
+
+### 9. Report back
+
+Give the user:
 - Issue URL
 - PR URL
-- Summary of changes made
-- Any follow-up items or things to verify manually
+- One-sentence summary of what shipped
+- Any deferred items or follow-up issues you filed
 
-## Rules
+## Rules (never break)
 
-- **Never push directly to `main`**. Always use feature branches + PRs.
-- **Never force push**. If there are conflicts, rebase locally and push normally.
-- **One issue per branch**. Don't bundle unrelated changes.
-- **Always read before editing**. Understand existing code before modifying it.
-- **Keep PRs focused**. If the fix reveals a separate issue, create a new issue for it rather than scope-creeping the current PR.
-- **Reference the issue in every commit and the PR body**.
-- **Don't skip the frontend build** if you touched frontend files — the deployed app serves from `frontend/dist/`.
+- Never push to `main` directly.
+- Never force-push to `main` or any shared branch.
+- Never `--no-verify` or bypass commit signing.
+- Never edit `bundle/**` or upstream `libs/**` from a UCM PR.
+- Never add a `run` or `sync` verb (explicitly dropped from DAB scope for UCM).
+- Never add identity resources (groups/users/SPs) — out of scope for v1; UCM references existing principals by name/id only.
+- Never remove or skip failing tests to make CI green. Fix the root cause. If a test is genuinely not applicable to the fork, that's a discussion with the user — not a silent delete.
+- Never commit secrets, binaries, `.DS_Store`, or IDE-generated files. The untracked `./databricks` binary from `make build` is a build artifact, not a deliverable.
+- Never use `git rebase -i`, `git add -i`, or any other flag that requires an interactive editor — they're not supported in this environment. If you must rebase, use the env-prefixed non-interactive form documented in the root `CLAUDE.md`.
 
-## GitHub Labels
+## Common mistakes (UCM-specific)
 
-Ensure these labels exist (create them if they don't):
-- `bug` — Something isn't working
-- `enhancement` — New feature or improvement
-- `frontend` — Changes to React/TypeScript frontend
-- `backend` — Changes to Python/FastAPI backend
-- `infrastructure` — DABs config, CI/CD, deployment
-
-## CI Checks (GitHub Actions)
-
-The following checks run automatically on every PR. **Run them locally before pushing** to avoid CI failures:
-
-1. **Frontend Build** (triggers on `frontend/**` changes):
-   ```bash
-   cd frontend && npx tsc --noEmit && npm run build && cd ..
-   ```
-
-2. **Python Lint** (triggers on `backend/**` changes):
-   ```bash
-   pip install ruff  # if not installed
-   ruff check backend/
-   ruff format --check backend/
-   ```
-   Fix lint issues with `ruff check --fix backend/` and format with `ruff format backend/`.
-
-3. **Python Type Check** (triggers on `backend/**` changes):
-   ```bash
-   pip install mypy types-psycopg2  # if not installed
-   mypy backend/ --ignore-missing-imports --no-strict-optional
-   ```
-
-4. **Python Tests** (triggers on `backend/**` changes):
-   ```bash
-   pip install -r backend/requirements-test.txt  # if not installed
-   cd backend && python -m pytest tests/ -v --timeout=30 --tb=short && cd ..
-   ```
-
-5. **PR Label Check** (always runs — **will block merge if missing**):
-   Every PR must have at least one component label: `frontend`, `backend`, or `infrastructure`.
-   **You MUST pass `--label` flags in the `gh pr create` command.** Forgetting labels causes CI failure.
-   Determine which labels apply: if frontend files changed → `frontend`, if backend files changed → `backend`, if CI/DABs/config changed → `infrastructure`. Add all that apply.
-
-6. **DABs Validate** (triggers on `databricks.yml`, `app.yaml`, `.databricksignore` changes):
-   ```bash
-   databricks bundle validate
-   ```
-
-If any check fails locally, fix the issues before committing. If ruff reports formatting issues, run `ruff format backend/` to auto-fix.
-
-## Project Context
-
-This is a Databricks App deployed via DABs. Read CLAUDE.md for full architecture details. Key points:
-- Frontend: React + TypeScript + Vite + Tailwind + shadcn/ui
-- Backend: Python FastAPI with Lakebase (PostgreSQL)
-- Auth: OBO + cross-account OAuth2 + Service Principal
-- Deploy: `databricks bundle deploy -p dr-manager`
-- The app URL is: https://dr-manager-7474653243743734.aws.databricksapps.com
+- Importing from `bundle/**` — will break on every upstream sync. Fork-and-adapt into `ucm/**` instead.
+- Running `go test ./...` and then chasing failures in upstream packages. Scope to `./cmd/ucm/... ./ucm/...`.
+- Hand-writing Terraform JSON in converters — build `dyn.Value` trees and use the `tfjson` writers like `bundle/deploy/terraform/tfdyn` does.
+- Forgetting the `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off` prefix and landing in a broken `proxy.golang.org` timeout or toolchain-mismatch loop.
+- Adding a new upstream-file edit (e.g. to `cmd/cmd.go`) without calling it out in the PR body as a fork-divergence cost.
+- Targeting `main` when the branch is actually stacked on another open PR — produces a bloated diff that reviewers can't read.
+- Treating `policy-check` as a slower `validate`. `policy-check` runs *only* the validation mutators (cheap pre-commit hook); `validate` runs the full chain.

--- a/.claude/agents/gitops.md
+++ b/.claude/agents/gitops.md
@@ -1,0 +1,156 @@
+# GitOps Agent — DR Manager
+
+You are a GitOps agent for the DR Manager project. You manage the full lifecycle of bugs and features: GitHub issue creation, branch-based implementation, and pull request submission.
+
+## Workflow
+
+When the user reports a bug or requests a feature, follow this exact sequence:
+
+### 1. Understand the Request
+
+- Ask clarifying questions if the request is ambiguous.
+- Determine whether this is a **bug** or a **feature**.
+- Identify which parts of the codebase are affected (backend, frontend, or both).
+
+### 2. Create a GitHub Issue
+
+Create a GitHub issue using `gh issue create`:
+
+- **Title**: Short, descriptive (under 80 chars)
+- **Labels**: Apply `bug` or `enhancement` label. Add `frontend`, `backend`, or both as applicable.
+- **Body**: Structured with:
+  - **Description**: What the bug is or what the feature should do
+  - **Acceptance Criteria**: Concrete conditions for "done"
+  - **Affected Components**: Which files/modules are involved
+
+Capture the issue number from the output.
+
+### 3. Create a Feature Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b <type>/<issue-number>-<short-description>
+```
+
+Branch naming convention:
+- Bugs: `fix/<issue-number>-<short-description>` (e.g., `fix/12-oauth-token-expiry`)
+- Features: `feat/<issue-number>-<short-description>` (e.g., `feat/15-plan-auto-sync`)
+
+### 4. Implement the Solution
+
+- Read the relevant files before making changes.
+- Follow existing code patterns and conventions from CLAUDE.md.
+- Keep changes focused — only modify what's needed for this issue.
+- For frontend changes: use the existing Tailwind + shadcn/ui patterns, respect dark/light mode CSS variables.
+- For backend changes: follow existing FastAPI route patterns, use Pydantic models, respect the auth model.
+- Build the frontend if you changed it: `cd frontend && npm run build && cd ..`
+- **Run CI checks locally before committing** (see CI Checks section below).
+
+### 5. Commit Changes
+
+- Stage only the files you changed (no `git add .`).
+- Write clear commit messages referencing the issue: `Fix #<number>: <description>` or `Feat #<number>: <description>`.
+- Create multiple small commits if the change is logically separable.
+
+### 6. Pre-Push CI Gate (MANDATORY)
+
+Before every `git push`, determine which GitHub Actions workflows will run based on changed files, then run the corresponding checks locally. **Do not push until all applicable checks pass.**
+
+1. Run `git diff --name-only main...HEAD` to see all changed files.
+2. Determine which CI checks will trigger:
+   - Files under `frontend/` → run **Frontend Build** check
+   - Files under `backend/` → run **Python Lint**, **Python Type Check**, and **Python Tests** checks
+   - `databricks.yml`, `app.yaml`, `.databricksignore` → run **DABs Validate** check
+   - Any PR → **PR Label Check** (handled at PR creation time via `--label` flags)
+3. Run all applicable checks from the CI Checks section below.
+4. If any check fails, fix the issue and re-run before pushing.
+
+### 7. Push and Create a Pull Request
+
+Push the branch and create a PR using `gh pr create`:
+
+- **Title**: Same as or similar to the issue title
+- **Body**: Must include:
+  - `Closes #<issue-number>` (for automatic issue closure on merge)
+  - A `## Summary` section with bullet points describing the changes
+  - A `## Test Plan` section with steps to verify the fix/feature
+- **Labels (MANDATORY)**: Always pass `--label` flags to `gh pr create`. Every PR **must** have at least one component label (`frontend`, `backend`, or `infrastructure`) or the CI "Require Component Label" check will fail. Use the same labels as the issue. Example: `gh pr create --label frontend --label enhancement ...`
+- **Base branch**: `main`
+
+### 8. Report Back
+
+After creating the PR, report to the user:
+- Issue URL
+- PR URL
+- Summary of changes made
+- Any follow-up items or things to verify manually
+
+## Rules
+
+- **Never push directly to `main`**. Always use feature branches + PRs.
+- **Never force push**. If there are conflicts, rebase locally and push normally.
+- **One issue per branch**. Don't bundle unrelated changes.
+- **Always read before editing**. Understand existing code before modifying it.
+- **Keep PRs focused**. If the fix reveals a separate issue, create a new issue for it rather than scope-creeping the current PR.
+- **Reference the issue in every commit and the PR body**.
+- **Don't skip the frontend build** if you touched frontend files — the deployed app serves from `frontend/dist/`.
+
+## GitHub Labels
+
+Ensure these labels exist (create them if they don't):
+- `bug` — Something isn't working
+- `enhancement` — New feature or improvement
+- `frontend` — Changes to React/TypeScript frontend
+- `backend` — Changes to Python/FastAPI backend
+- `infrastructure` — DABs config, CI/CD, deployment
+
+## CI Checks (GitHub Actions)
+
+The following checks run automatically on every PR. **Run them locally before pushing** to avoid CI failures:
+
+1. **Frontend Build** (triggers on `frontend/**` changes):
+   ```bash
+   cd frontend && npx tsc --noEmit && npm run build && cd ..
+   ```
+
+2. **Python Lint** (triggers on `backend/**` changes):
+   ```bash
+   pip install ruff  # if not installed
+   ruff check backend/
+   ruff format --check backend/
+   ```
+   Fix lint issues with `ruff check --fix backend/` and format with `ruff format backend/`.
+
+3. **Python Type Check** (triggers on `backend/**` changes):
+   ```bash
+   pip install mypy types-psycopg2  # if not installed
+   mypy backend/ --ignore-missing-imports --no-strict-optional
+   ```
+
+4. **Python Tests** (triggers on `backend/**` changes):
+   ```bash
+   pip install -r backend/requirements-test.txt  # if not installed
+   cd backend && python -m pytest tests/ -v --timeout=30 --tb=short && cd ..
+   ```
+
+5. **PR Label Check** (always runs — **will block merge if missing**):
+   Every PR must have at least one component label: `frontend`, `backend`, or `infrastructure`.
+   **You MUST pass `--label` flags in the `gh pr create` command.** Forgetting labels causes CI failure.
+   Determine which labels apply: if frontend files changed → `frontend`, if backend files changed → `backend`, if CI/DABs/config changed → `infrastructure`. Add all that apply.
+
+6. **DABs Validate** (triggers on `databricks.yml`, `app.yaml`, `.databricksignore` changes):
+   ```bash
+   databricks bundle validate
+   ```
+
+If any check fails locally, fix the issues before committing. If ruff reports formatting issues, run `ruff format backend/` to auto-fix.
+
+## Project Context
+
+This is a Databricks App deployed via DABs. Read CLAUDE.md for full architecture details. Key points:
+- Frontend: React + TypeScript + Vite + Tailwind + shadcn/ui
+- Backend: Python FastAPI with Lakebase (PostgreSQL)
+- Auth: OBO + cross-account OAuth2 + Service Principal
+- Deploy: `databricks bundle deploy -p dr-manager`
+- The app URL is: https://dr-manager-7474653243743734.aws.databricksapps.com

--- a/cmd/ucm/testdata/collision/ucm.yml
+++ b/cmd/ucm/testdata/collision/ucm.yml
@@ -1,0 +1,26 @@
+ucm:
+  name: fixture-collision
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      schemas:
+        bronze:
+          name: bronze
+          tags:
+            cost_center: "1234"
+            data_owner: alpha
+            classification: internal
+
+  schemas:
+    bronze:
+      name: bronze
+      catalog: team_alpha
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal

--- a/cmd/ucm/testdata/inherit_opt_out/ucm.yml
+++ b/cmd/ucm/testdata/inherit_opt_out/ucm.yml
@@ -1,0 +1,24 @@
+ucm:
+  name: fixture-inherit-opt-out
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal
+      schemas:
+        bronze:
+          name: bronze
+          tag_inherit: false
+          # no tags — ValidateTags should complain because inheritance is off
+
+  tag_validation_rules:
+    enforce_ownership:
+      securable_types: [catalog, schema]
+      required: [cost_center, data_owner, classification]

--- a/cmd/ucm/testdata/nested/ucm.yml
+++ b/cmd/ucm/testdata/nested/ucm.yml
@@ -1,0 +1,41 @@
+ucm:
+  name: fixture-nested
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      comment: alpha catalog
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal
+      schemas:
+        bronze:
+          name: bronze
+          # catalog, cost_center, data_owner, classification all inherited
+          grants:
+            bronze_reader:
+              principal: alpha-readers
+              privileges: [USE_SCHEMA, SELECT]
+        silver:
+          name: silver
+          tag_inherit: false
+          tags:
+            cost_center: "1234"
+            data_owner: alpha
+            classification: internal
+      grants:
+        alpha_read:
+          principal: alpha-readers
+          privileges: [USE_CATALOG, SELECT]
+
+  tag_validation_rules:
+    enforce_ownership:
+      securable_types: [catalog, schema]
+      required: [cost_center, data_owner, classification]
+      allowed_values:
+        classification: [public, internal, confidential, restricted]

--- a/cmd/ucm/validate_test.go
+++ b/cmd/ucm/validate_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 // runValidate invokes the cobra ucm-subtree in a temp cwd set to fixtureDir
-// and returns stdout, stderr, and whatever the Execute call returned.
+// and returns stdout, diag-stream output (cmdio stderr), and whatever the
+// Execute call returned.
 func runValidate(t *testing.T, fixtureDir string) (string, string, error) {
 	t.Helper()
 
@@ -32,13 +33,13 @@ func runValidate(t *testing.T, fixtureDir string) (string, string, error) {
 	cmd.SetErr(&errOut)
 	cmd.SetArgs([]string{"validate"})
 
-	ctx, _ := cmdio.NewTestContextWithStderr(context.Background())
+	ctx, diagOut := cmdio.NewTestContextWithStderr(context.Background())
 	ctx = logdiag.InitContext(ctx)
 	logdiag.SetRoot(ctx, fixtureDir)
 	cmd.SetContext(ctx)
 
 	err = cmd.Execute()
-	return out.String(), errOut.String(), err
+	return out.String(), diagOut.String() + errOut.String(), err
 }
 
 func TestCmd_Validate_ValidFixturePasses(t *testing.T) {
@@ -52,6 +53,26 @@ func TestCmd_Validate_ValidFixturePasses(t *testing.T) {
 func TestCmd_Validate_MissingTagFixtureFails(t *testing.T) {
 	_, _, err := runValidate(t, filepath.Join("testdata", "missing_tag"))
 	require.Error(t, err)
+}
+
+func TestCmd_Validate_NestedFixturePasses(t *testing.T) {
+	stdout, stderr, err := runValidate(t, filepath.Join("testdata", "nested"))
+	t.Logf("stdout=%q", stdout)
+	t.Logf("stderr=%q", stderr)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Validation OK!")
+}
+
+func TestCmd_Validate_CollisionFixtureFails(t *testing.T) {
+	_, stderr, err := runValidate(t, filepath.Join("testdata", "collision"))
+	require.Error(t, err)
+	assert.Contains(t, stderr, "declared both as a flat entry and nested")
+}
+
+func TestCmd_Validate_InheritOptOutFailsTagRule(t *testing.T) {
+	_, stderr, err := runValidate(t, filepath.Join("testdata", "inherit_opt_out"))
+	require.Error(t, err)
+	assert.Contains(t, stderr, "requires tag")
 }
 
 func TestCmd_Schema_ProducesValidJSON(t *testing.T) {

--- a/ucm/config/mutator/flatten_nested_resources.go
+++ b/ucm/config/mutator/flatten_nested_resources.go
@@ -1,0 +1,246 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/ucm"
+)
+
+type flattenNestedResources struct{}
+
+// FlattenNestedResources unrolls the nested forms of schemas and grants
+// (declared under a catalog, or grants declared under a schema) into the flat
+// Root.Resources.{Schemas,Grants} maps. Injects parent references so the
+// post-flatten tree is indistinguishable from a purely flat declaration.
+//
+// Runs first in the load phase, before any other mutator reads the resources
+// tree. After it runs, catalog.schemas, catalog.grants, and schema.grants are
+// all nil.
+//
+// Collision handling: a nested entry whose key already exists as a flat entry
+// emits a diag.Error pointing at the nested location. Same for a user-supplied
+// field that conflicts with the injected parent reference (e.g. a nested
+// schema that sets `catalog: other`).
+func FlattenNestedResources() ucm.Mutator { return &flattenNestedResources{} }
+
+func (m *flattenNestedResources) Name() string { return "FlattenNestedResources" }
+
+func (m *flattenNestedResources) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	err := u.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
+		resourcesValue := root.Get("resources")
+		resources, ok := resourcesValue.AsMap()
+		if !ok {
+			return root, nil
+		}
+
+		catalogsValue, _ := resources.GetByString("catalogs")
+		catalogs, ok := catalogsValue.AsMap()
+		if !ok {
+			return root, nil
+		}
+
+		flatSchemas, _ := resources.GetByString("schemas")
+		flatGrants, _ := resources.GetByString("grants")
+		schemasMap := mapOrNew(flatSchemas)
+		grantsMap := mapOrNew(flatGrants)
+
+		newCatalogs := dyn.NewMapping()
+		for _, cp := range catalogs.Pairs() {
+			catalogName := cp.Key.MustString()
+			catalogBody, ok := cp.Value.AsMap()
+			if !ok {
+				newCatalogs.SetLoc(catalogName, cp.Key.Locations(), cp.Value)
+				continue
+			}
+
+			if nested, ok := catalogBody.GetByString("schemas"); ok {
+				diags = append(diags, liftNestedSchemas(catalogName, nested, &schemasMap, &grantsMap)...)
+			}
+			if nested, ok := catalogBody.GetByString("grants"); ok {
+				diags = append(diags, liftNestedCatalogGrants(catalogName, nested, &grantsMap)...)
+			}
+
+			stripped := removeKeys(catalogBody, "schemas", "grants")
+			newCatalogs.SetLoc(catalogName, cp.Key.Locations(), dyn.NewValue(stripped, cp.Value.Locations()))
+		}
+
+		newResources := resources.Clone()
+		newResources.SetLoc("catalogs", nil, dyn.NewValue(newCatalogs, catalogsValue.Locations()))
+		if schemasMap.Len() > 0 {
+			newResources.SetLoc("schemas", nil, dyn.NewValue(schemasMap, flatSchemas.Locations()))
+		}
+		if grantsMap.Len() > 0 {
+			newResources.SetLoc("grants", nil, dyn.NewValue(grantsMap, flatGrants.Locations()))
+		}
+
+		return dyn.SetByPath(root, dyn.NewPath(dyn.Key("resources")),
+			dyn.NewValue(newResources, resourcesValue.Locations()))
+	})
+	if err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	return diags
+}
+
+// liftNestedSchemas moves catalog.schemas into the top-level schemas map,
+// injecting `catalog` and processing any schema-nested grants.
+func liftNestedSchemas(catalogName string, nested dyn.Value, schemas, grants *dyn.Mapping) diag.Diagnostics {
+	var diags diag.Diagnostics
+	nestedMap, ok := nested.AsMap()
+	if !ok {
+		return diags
+	}
+	for _, sp := range nestedMap.Pairs() {
+		schemaName := sp.Key.MustString()
+		schemaValue, ok := sp.Value.AsMap()
+		if !ok {
+			continue
+		}
+		updated := schemaValue.Clone()
+
+		if d := injectStringField(&updated, "catalog", catalogName,
+			fmt.Sprintf("schema %q nested under catalog %q", schemaName, catalogName),
+			sp.Key.Locations()); d != nil {
+			diags = append(diags, d...)
+		}
+
+		if nestedGrants, ok := updated.GetByString("grants"); ok {
+			diags = append(diags, liftNestedSchemaGrants(schemaName, nestedGrants, grants)...)
+		}
+
+		flatValue := dyn.NewValue(removeKeys(updated, "grants"), sp.Value.Locations())
+
+		if existing, ok := schemas.GetPairByString(schemaName); ok {
+			diags = append(diags, collisionDiag("schema", schemaName, sp.Key.Locations(), existing.Key.Locations())...)
+			continue
+		}
+		schemas.SetLoc(schemaName, sp.Key.Locations(), flatValue)
+	}
+	return diags
+}
+
+// liftNestedCatalogGrants injects securable={catalog, <name>} into nested
+// catalog grants and moves them into the flat grants map.
+func liftNestedCatalogGrants(catalogName string, nested dyn.Value, grants *dyn.Mapping) diag.Diagnostics {
+	return liftNestedGrants(nested, grants, "catalog", catalogName,
+		fmt.Sprintf("grant nested under catalog %q", catalogName))
+}
+
+// liftNestedSchemaGrants injects securable={schema, <name>} into nested
+// schema grants and moves them into the flat grants map.
+func liftNestedSchemaGrants(schemaName string, nested dyn.Value, grants *dyn.Mapping) diag.Diagnostics {
+	return liftNestedGrants(nested, grants, "schema", schemaName,
+		fmt.Sprintf("grant nested under schema %q", schemaName))
+}
+
+func liftNestedGrants(nested dyn.Value, grants *dyn.Mapping, kind, parentName, ctxDesc string) diag.Diagnostics {
+	var diags diag.Diagnostics
+	nestedMap, ok := nested.AsMap()
+	if !ok {
+		return diags
+	}
+	for _, gp := range nestedMap.Pairs() {
+		grantName := gp.Key.MustString()
+		grantValue, ok := gp.Value.AsMap()
+		if !ok {
+			continue
+		}
+		updated := grantValue.Clone()
+
+		if d := injectSecurable(&updated, kind, parentName, ctxDesc, gp.Key.Locations()); d != nil {
+			diags = append(diags, d...)
+		}
+
+		flatValue := dyn.NewValue(updated, gp.Value.Locations())
+		if existing, ok := grants.GetPairByString(grantName); ok {
+			diags = append(diags, collisionDiag("grant", grantName, gp.Key.Locations(), existing.Key.Locations())...)
+			continue
+		}
+		grants.SetLoc(grantName, gp.Key.Locations(), flatValue)
+	}
+	return diags
+}
+
+// injectStringField writes key=want into m. If m already has key with a
+// different value, emits an error diagnostic.
+func injectStringField(m *dyn.Mapping, key, want, ctxDesc string, locs []dyn.Location) diag.Diagnostics {
+	existing, ok := m.GetByString(key)
+	if ok {
+		if got, _ := existing.AsString(); got != "" && got != want {
+			return diag.Diagnostics{{
+				Severity:  diag.Error,
+				Summary:   fmt.Sprintf("%s: %s=%q conflicts with parent %q", ctxDesc, key, got, want),
+				Locations: locs,
+			}}
+		}
+	}
+	m.SetLoc(key, locs, dyn.V(want))
+	return nil
+}
+
+// injectSecurable writes securable={type: kind, name: parentName} into m. If
+// m already has a securable that differs, emits an error.
+func injectSecurable(m *dyn.Mapping, kind, parentName, ctxDesc string, locs []dyn.Location) diag.Diagnostics {
+	want := dyn.V(map[string]dyn.Value{
+		"type": dyn.V(kind),
+		"name": dyn.V(parentName),
+	})
+	existing, ok := m.GetByString("securable")
+	if ok {
+		existingMap, _ := existing.AsMap()
+		gotType, _ := existingMap.GetByString("type")
+		gotName, _ := existingMap.GetByString("name")
+		gt, _ := gotType.AsString()
+		gn, _ := gotName.AsString()
+		if (gt != "" && gt != kind) || (gn != "" && gn != parentName) {
+			return diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"%s: securable=%s/%s conflicts with parent %s/%s",
+					ctxDesc, gt, gn, kind, parentName,
+				),
+				Locations: locs,
+			}}
+		}
+	}
+	m.SetLoc("securable", locs, want)
+	return nil
+}
+
+func collisionDiag(kind, name string, nestedLocs, flatLocs []dyn.Location) diag.Diagnostics {
+	locs := append([]dyn.Location{}, nestedLocs...)
+	locs = append(locs, flatLocs...)
+	return diag.Diagnostics{{
+		Severity:  diag.Error,
+		Summary:   fmt.Sprintf("%s %q is declared both as a flat entry and nested under its parent", kind, name),
+		Locations: locs,
+	}}
+}
+
+func mapOrNew(v dyn.Value) dyn.Mapping {
+	m, ok := v.AsMap()
+	if !ok {
+		return dyn.NewMapping()
+	}
+	return m.Clone()
+}
+
+// removeKeys returns a new Mapping with the named keys dropped.
+func removeKeys(m dyn.Mapping, keys ...string) dyn.Mapping {
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+	out := dyn.NewMapping()
+	for _, p := range m.Pairs() {
+		if _, skip := drop[p.Key.MustString()]; skip {
+			continue
+		}
+		out.SetLoc(p.Key.MustString(), p.Key.Locations(), p.Value)
+	}
+	return out
+}

--- a/ucm/config/mutator/flatten_nested_resources_test.go
+++ b/ucm/config/mutator/flatten_nested_resources_test.go
@@ -1,0 +1,155 @@
+package mutator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenNestedResources(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		wantDiagSubs  []string
+		wantSchema    map[string]string // schemaName → expected catalog
+		wantGrantKind map[string]string // grantName → expected securable kind
+		wantGrantName map[string]string // grantName → expected securable name
+	}{
+		{
+			name: "bare nested schema injects catalog",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1: {name: s1}
+`,
+			wantSchema: map[string]string{"s1": "c1"},
+		},
+		{
+			name: "nested schema with matching catalog does not error",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1: {name: s1, catalog: c1}
+`,
+			wantSchema: map[string]string{"s1": "c1"},
+		},
+		{
+			name: "nested schema with conflicting catalog errors",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1: {name: s1, catalog: other}
+`,
+			wantDiagSubs: []string{"conflicts with parent"},
+			wantSchema:   map[string]string{"s1": "other"},
+		},
+		{
+			name: "nested grant at catalog level injects securable",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      grants:
+        g1: {principal: p, privileges: [USE_CATALOG]}
+`,
+			wantGrantKind: map[string]string{"g1": "catalog"},
+			wantGrantName: map[string]string{"g1": "c1"},
+		},
+		{
+			name: "nested grant at schema level injects securable",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1:
+          name: s1
+          grants:
+            g1: {principal: p, privileges: [SELECT]}
+`,
+			wantGrantKind: map[string]string{"g1": "schema"},
+			wantGrantName: map[string]string{"g1": "s1"},
+			wantSchema:    map[string]string{"s1": "c1"},
+		},
+		{
+			name: "flat-vs-nested schema collision errors",
+			yaml: `
+ucm: {name: t}
+resources:
+  schemas:
+    s1: {name: s1, catalog: c1}
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1: {name: s1}
+`,
+			wantDiagSubs: []string{"declared both as a flat entry and nested"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := loadUcm(t, tc.yaml)
+			diags := ucm.Apply(t.Context(), u, mutator.FlattenNestedResources())
+
+			for _, sub := range tc.wantDiagSubs {
+				found := false
+				for _, s := range summaries(diags) {
+					if strings.Contains(s, sub) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected diag containing %q, got %v", sub, summaries(diags))
+			}
+			if len(tc.wantDiagSubs) == 0 {
+				require.Empty(t, diags, "unexpected diags: %v", summaries(diags))
+			}
+
+			for name, want := range tc.wantSchema {
+				got := u.Config.Resources.Schemas[name]
+				require.NotNil(t, got, "schema %q missing", name)
+				assert.Equal(t, want, got.Catalog, "schema %q catalog", name)
+			}
+			for name, want := range tc.wantGrantKind {
+				got := u.Config.Resources.Grants[name]
+				require.NotNil(t, got, "grant %q missing", name)
+				assert.Equal(t, want, got.Securable.Type)
+			}
+			for name, want := range tc.wantGrantName {
+				got := u.Config.Resources.Grants[name]
+				require.NotNil(t, got, "grant %q missing", name)
+				assert.Equal(t, want, got.Securable.Name)
+			}
+
+			// Nested maps must be cleared after flatten.
+			for _, c := range u.Config.Resources.Catalogs {
+				assert.Nil(t, c.Schemas, "catalog.Schemas should be cleared")
+				assert.Nil(t, c.Grants, "catalog.Grants should be cleared")
+			}
+			for _, s := range u.Config.Resources.Schemas {
+				assert.Nil(t, s.Grants, "schema.Grants should be cleared")
+			}
+		})
+	}
+}

--- a/ucm/config/mutator/inherit_catalog_tags.go
+++ b/ucm/config/mutator/inherit_catalog_tags.go
@@ -1,0 +1,43 @@
+package mutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+)
+
+type inheritCatalogTags struct{}
+
+// InheritCatalogTags merges each catalog's tags into every schema under that
+// catalog unless the schema sets tag_inherit: false. Schema tags win on
+// conflict. Runs after FlattenNestedResources (so schemas are already flat
+// and carry a catalog reference) and before ValidateTags.
+func InheritCatalogTags() ucm.Mutator { return &inheritCatalogTags{} }
+
+func (m *inheritCatalogTags) Name() string { return "InheritCatalogTags" }
+
+func (m *inheritCatalogTags) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	catalogs := u.Config.Resources.Catalogs
+	for _, schema := range u.Config.Resources.Schemas {
+		if schema == nil || schema.Catalog == "" {
+			continue
+		}
+		if schema.TagInherit != nil && !*schema.TagInherit {
+			continue
+		}
+		parent := catalogs[schema.Catalog]
+		if parent == nil || len(parent.Tags) == 0 {
+			continue
+		}
+		if schema.Tags == nil {
+			schema.Tags = make(map[string]string, len(parent.Tags))
+		}
+		for k, v := range parent.Tags {
+			if _, exists := schema.Tags[k]; !exists {
+				schema.Tags[k] = v
+			}
+		}
+	}
+	return nil
+}

--- a/ucm/config/mutator/inherit_catalog_tags_test.go
+++ b/ucm/config/mutator/inherit_catalog_tags_test.go
@@ -1,0 +1,96 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInheritCatalogTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		schema   string
+		wantTags map[string]string
+	}{
+		{
+			name: "catalog tags inherited by default",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags: {cost_center: "1", data_owner: a}
+      schemas:
+        s1: {name: s1}
+`,
+			schema:   "s1",
+			wantTags: map[string]string{"cost_center": "1", "data_owner": "a"},
+		},
+		{
+			name: "schema tag overrides parent on conflict",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags: {cost_center: "1", data_owner: a}
+      schemas:
+        s1: {name: s1, tags: {data_owner: b}}
+`,
+			schema:   "s1",
+			wantTags: map[string]string{"cost_center": "1", "data_owner": "b"},
+		},
+		{
+			name: "tag_inherit false opts out",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags: {cost_center: "1"}
+      schemas:
+        s1: {name: s1, tag_inherit: false}
+`,
+			schema:   "s1",
+			wantTags: nil,
+		},
+		{
+			name: "flat schema inherits from its named catalog",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1, tags: {cost_center: "1"}}
+  schemas:
+    s1: {name: s1, catalog: c1}
+`,
+			schema:   "s1",
+			wantTags: map[string]string{"cost_center": "1"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := loadUcm(t, tc.yaml)
+			diags := ucm.ApplySeq(t.Context(), u,
+				mutator.FlattenNestedResources(),
+				mutator.InheritCatalogTags(),
+			)
+			require.NoError(t, diags.Error())
+
+			got := u.Config.Resources.Schemas[tc.schema]
+			require.NotNil(t, got)
+			if tc.wantTags == nil {
+				assert.Empty(t, got.Tags)
+			} else {
+				assert.Equal(t, tc.wantTags, got.Tags)
+			}
+		})
+	}
+}

--- a/ucm/config/resources/catalog.go
+++ b/ucm/config/resources/catalog.go
@@ -15,4 +15,10 @@ type Catalog struct {
 
 	// Tags is a key/value map evaluated by ucm's tag-validation mutators.
 	Tags map[string]string `json:"tags,omitempty"`
+
+	// Schemas and Grants are nested-form conveniences: the FlattenNestedResources
+	// mutator moves them to Root.Resources.{Schemas,Grants} (injecting parent
+	// references) before any other mutator runs. Always nil after load.
+	Schemas map[string]*Schema `json:"schemas,omitempty"`
+	Grants  map[string]*Grant  `json:"grants,omitempty"`
 }

--- a/ucm/config/resources/schema.go
+++ b/ucm/config/resources/schema.go
@@ -5,13 +5,24 @@ type Schema struct {
 	// Name of the schema. Required.
 	Name string `json:"name"`
 
-	// Catalog is the name of the parent catalog. Required.
+	// Catalog is the name of the parent catalog. Required in flat form;
+	// injected by FlattenNestedResources when declared nested under a catalog.
 	// In M1 this becomes interpolatable via ${resources.catalogs.X.name}.
-	Catalog string `json:"catalog"`
+	Catalog string `json:"catalog,omitempty"`
 
 	// Comment is a human-readable description.
 	Comment string `json:"comment,omitempty"`
 
 	// Tags is a key/value map evaluated by ucm's tag-validation mutators.
 	Tags map[string]string `json:"tags,omitempty"`
+
+	// TagInherit controls whether parent-catalog tags merge into this schema's
+	// tags (schema-key wins). nil means inherit (the default). Set false to
+	// opt out.
+	TagInherit *bool `json:"tag_inherit,omitempty"`
+
+	// Grants nested under this schema. FlattenNestedResources moves them to
+	// Root.Resources.Grants with securable={type:schema, name:<this>} injected.
+	// Always nil after load.
+	Grants map[string]*Grant `json:"grants,omitempty"`
 }

--- a/ucm/phases/load.go
+++ b/ucm/phases/load.go
@@ -13,6 +13,8 @@ import (
 // the user did not pass --target.
 func LoadDefaultTarget(ctx context.Context, u *ucm.Ucm) {
 	ucm.ApplySeqContext(ctx, u,
+		mutator.FlattenNestedResources(),
+		mutator.InheritCatalogTags(),
 		mutator.DefineDefaultTarget(),
 		mutator.SelectDefaultTarget(),
 	)
@@ -22,6 +24,8 @@ func LoadDefaultTarget(ctx context.Context, u *ucm.Ucm) {
 // --target <name>.
 func LoadNamedTarget(ctx context.Context, u *ucm.Ucm, name string) {
 	ucm.ApplySeqContext(ctx, u,
+		mutator.FlattenNestedResources(),
+		mutator.InheritCatalogTags(),
 		mutator.DefineDefaultTarget(),
 		mutator.SelectTarget(name),
 	)


### PR DESCRIPTION
Closes #5

## Summary
- `FlattenNestedResources` mutator lifts `resources.catalogs[C].{schemas,grants}` and `resources.schemas[S].grants` into the flat maps, injecting `catalog` on schemas and `securable={type,name}` on grants. Emits error diagnostics (with source locations on both sides) for flat-vs-nested duplicates and conflicting parent references.
- `InheritCatalogTags` merges parent-catalog tags into each schema under it; schema keys win. Opt-out via `tag_inherit: false` on the schema. Applies uniformly to flat and nested schemas so refactors don't change behavior.
- Both mutators run before target selection in `phases.Load*`, so the rest of the pipeline (including `ValidateTags`) continues to see a purely flat tree.
- Rewrites `.claude/agents/gitops.md` as a UCM-specific playbook keyed to `cmd/ucm/CLAUDE.md` — fork context, 9-step workflow, fork-scoped CI gate (`GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`), hard rules (no `bundle/**` imports, no identity resources, no `run`/`sync` verbs).

## Why
The flat form forces authors to repeat the parent catalog on every schema (`catalog: team_alpha`) and the securable identity on every grant. Since schemas and grants are children of a catalog in UC's actual hierarchy, nesting is the natural ergonomic — but the in-memory tree stays flat so tfdyn/state/interpolation stay identical to DAB and upstream-sync cost is unchanged.

Design decisions are captured in the issue; key locked choices:
- **Dual form**: flat and nested both valid
- **Tag inheritance default ON**, opt-out via `tag_inherit: false` (`*bool`)
- **Grants nestable at catalog AND schema level** symmetrically
- **Bindings deferred** to M1 (reserved slot in design, no `Binding` resource yet)

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/ucm/... ./ucm/...` — all passing
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] Table-driven unit tests for `FlattenNestedResources` (6 cases covering injection, matching-parent noop, conflicting parent, catalog-level grant, schema-level grant, flat/nested collision)
- [x] Table-driven unit tests for `InheritCatalogTags` (4 cases: default inheritance, schema-wins override, opt-out, flat-schema inheritance)
- [x] Acceptance-style fixture tests: `testdata/nested` (passes), `testdata/collision` (errors with location info), `testdata/inherit_opt_out` (errors on missing tags after opt-out)
- [x] Existing `testdata/valid` and `testdata/missing_tag` still pass — no regression on flat form

## Fork-divergence notes
- No edits to `bundle/**` or upstream files.
- No new edits to `cmd/cmd.go`.
- `.claude/agents/gitops.md` is a fork-only addition (not upstream-owned); this PR adapts it from the original DR Manager playbook to a UCM-specific one.

## Base branch
Targets `feat/3-validate-schema` (open as PR #4) because that branch hasn't merged to `main` yet — keeps this diff focused on issue #5. Rebase onto `main` once #4 merges.