### PR TITLE
Feat #8: StateFiler interface + workspace files impl

### DIFF
--- a/ucm/deploy/filer/iface.go
+++ b/ucm/deploy/filer/iface.go
@@ -1,0 +1,77 @@
+// Package filer defines the pluggable state-storage backend used by UCM.
+//
+// StateFiler abstracts the small set of file operations needed by the state
+// manager (U4) and the terraform wrapper (U5): read, write, delete, stat,
+// and listing. The v1 implementation is backed by workspace files
+// (see workspace_filer.go); v2 adds S3/ADLS/GCS backends.
+//
+// Paths are always forward-slash-separated and relative to the root configured
+// on the concrete implementation.
+package filer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+// ErrNotFound is returned by Read and Stat when the target path does not exist.
+// Concrete implementations may return wrapped errors; callers must use
+// errors.Is to compare.
+var ErrNotFound = errors.New("ucm filer: path not found")
+
+// WriteMode is a bit-mask controlling the behavior of StateFiler.Write.
+type WriteMode int
+
+const (
+	// WriteModeOverwrite overwrites the target path if it already exists.
+	WriteModeOverwrite WriteMode = 1 << iota
+
+	// WriteModeCreateParents creates any missing parent directories.
+	WriteModeCreateParents
+)
+
+// Has reports whether m includes every flag in other.
+func (m WriteMode) Has(other WriteMode) bool {
+	return m&other == other
+}
+
+// FileInfo describes a single entry returned by StateFiler.Stat or
+// StateFiler.ReadDir. It deliberately does not embed os.FileInfo or fs.FileInfo
+// so the interface is not tied to local-filesystem semantics.
+type FileInfo interface {
+	// Name returns the base name of the entry.
+	Name() string
+
+	// Size returns the size in bytes (0 for directories).
+	Size() int64
+
+	// ModTime returns the last-modified time.
+	ModTime() time.Time
+
+	// IsDir reports whether the entry is a directory.
+	IsDir() bool
+}
+
+// StateFiler is the minimal file-system surface UCM state operations need.
+// It is deliberately smaller than libs/filer.Filer — no Mkdir, no recursive
+// delete — because the state manager and terraform wrapper never use them.
+type StateFiler interface {
+	// Read opens the file at path for reading.
+	// Returns an error wrapping ErrNotFound when the path does not exist.
+	Read(ctx context.Context, path string) (io.ReadCloser, error)
+
+	// Write writes r to path. Behavior is controlled by mode.
+	Write(ctx context.Context, path string, r io.Reader, mode WriteMode) error
+
+	// Delete removes the file at path. Deleting a non-existent path is not an error.
+	Delete(ctx context.Context, path string) error
+
+	// Stat returns metadata for the file at path.
+	// Returns an error wrapping ErrNotFound when the path does not exist.
+	Stat(ctx context.Context, path string) (FileInfo, error)
+
+	// ReadDir lists the entries of the directory at path.
+	ReadDir(ctx context.Context, path string) ([]FileInfo, error)
+}

--- a/ucm/deploy/filer/workspace_filer.go
+++ b/ucm/deploy/filer/workspace_filer.go
@@ -1,0 +1,124 @@
+package filer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"time"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/databricks-sdk-go"
+)
+
+// WorkspaceFiler is the v1 StateFiler backed by the Databricks workspace-files
+// API. It wraps libs/filer.Filer and translates between ucm-native types
+// (WriteMode, FileInfo, ErrNotFound) and the libs/filer + io/fs equivalents.
+//
+// Wrapping libs/filer rather than re-implementing the workspace-files
+// protocol keeps auth, retry, and SPOG-header handling in a single upstream
+// place — on the next upstream sync we inherit fixes for free.
+type WorkspaceFiler struct {
+	inner libsfiler.Filer
+}
+
+// NewWorkspaceFiler constructs a StateFiler that stores files under root
+// in the given workspace. root is a workspace path such as
+// "/Users/alice@example.com/.ucm/state/dev".
+func NewWorkspaceFiler(w *databricks.WorkspaceClient, root string) (StateFiler, error) {
+	inner, err := libsfiler.NewWorkspaceFilesClient(w, root)
+	if err != nil {
+		return nil, fmt.Errorf("ucm filer: init workspace client: %w", err)
+	}
+	return &WorkspaceFiler{inner: inner}, nil
+}
+
+// newWorkspaceFilerFromInner wraps an existing libs/filer.Filer. Exposed at
+// package scope so tests can inject a fake.
+func newWorkspaceFilerFromInner(inner libsfiler.Filer) *WorkspaceFiler {
+	return &WorkspaceFiler{inner: inner}
+}
+
+// Read opens the file at path for reading.
+func (w *WorkspaceFiler) Read(ctx context.Context, path string) (io.ReadCloser, error) {
+	rc, err := w.inner.Read(ctx, path)
+	if err != nil {
+		return nil, mapErr(path, err)
+	}
+	return rc, nil
+}
+
+// Write writes r to path, translating mode into libs/filer write flags.
+func (w *WorkspaceFiler) Write(ctx context.Context, path string, r io.Reader, mode WriteMode) error {
+	var flags []libsfiler.WriteMode
+	if mode.Has(WriteModeOverwrite) {
+		flags = append(flags, libsfiler.OverwriteIfExists)
+	}
+	if mode.Has(WriteModeCreateParents) {
+		flags = append(flags, libsfiler.CreateParentDirectories)
+	}
+	if err := w.inner.Write(ctx, path, r, flags...); err != nil {
+		return mapErr(path, err)
+	}
+	return nil
+}
+
+// Delete removes the file at path. A missing path is treated as success so
+// callers don't need to special-case idempotent cleanup.
+func (w *WorkspaceFiler) Delete(ctx context.Context, path string) error {
+	err := w.inner.Delete(ctx, path)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return mapErr(path, err)
+}
+
+// Stat returns metadata for the file at path.
+func (w *WorkspaceFiler) Stat(ctx context.Context, path string) (FileInfo, error) {
+	info, err := w.inner.Stat(ctx, path)
+	if err != nil {
+		return nil, mapErr(path, err)
+	}
+	return fsFileInfo{info}, nil
+}
+
+// ReadDir lists the entries of the directory at path.
+func (w *WorkspaceFiler) ReadDir(ctx context.Context, path string) ([]FileInfo, error) {
+	entries, err := w.inner.ReadDir(ctx, path)
+	if err != nil {
+		return nil, mapErr(path, err)
+	}
+	out := make([]FileInfo, 0, len(entries))
+	for _, e := range entries {
+		info, infoErr := e.Info()
+		if infoErr != nil {
+			return nil, fmt.Errorf("ucm filer: stat %s: %w", e.Name(), infoErr)
+		}
+		out = append(out, fsFileInfo{info})
+	}
+	return out, nil
+}
+
+// mapErr translates libs/filer errors into ucm-native sentinel errors.
+// fs.ErrNotExist covers both "file does not exist" and "no such directory"
+// from libs/filer because both define Is(fs.ErrNotExist) == true.
+func mapErr(path string, err error) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("%w: %s: %w", ErrNotFound, path, err)
+	}
+	return err
+}
+
+// fsFileInfo adapts an io/fs.FileInfo to the ucm-native FileInfo interface.
+type fsFileInfo struct {
+	inner fs.FileInfo
+}
+
+func (f fsFileInfo) Name() string       { return f.inner.Name() }
+func (f fsFileInfo) Size() int64        { return f.inner.Size() }
+func (f fsFileInfo) ModTime() time.Time { return f.inner.ModTime() }
+func (f fsFileInfo) IsDir() bool        { return f.inner.IsDir() }

--- a/ucm/deploy/filer/workspace_filer_test.go
+++ b/ucm/deploy/filer/workspace_filer_test.go
@@ -1,0 +1,279 @@
+package filer
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"path"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memFiler is a minimal in-memory implementation of libsfiler.Filer used to
+// drive round-trip tests without a real workspace client. It models only the
+// semantics the wrapper exercises (overwrite, create-parents, not-found).
+type memFiler struct {
+	files map[string][]byte // path -> content; directories tracked by prefix
+	dirs  map[string]bool
+}
+
+func newMemFiler() *memFiler {
+	return &memFiler{
+		files: map[string][]byte{},
+		dirs:  map[string]bool{"/": true, "": true},
+	}
+}
+
+func (m *memFiler) Write(ctx context.Context, p string, r io.Reader, mode ...libsfiler.WriteMode) error {
+	overwrite := slices.Contains(mode, libsfiler.OverwriteIfExists)
+	createParents := slices.Contains(mode, libsfiler.CreateParentDirectories)
+
+	if _, exists := m.files[p]; exists && !overwrite {
+		return fs.ErrExist
+	}
+	parent := path.Dir(p)
+	if !m.dirs[parent] {
+		if !createParents {
+			return fs.ErrNotExist
+		}
+		for d := parent; d != "/" && d != "." && d != ""; d = path.Dir(d) {
+			m.dirs[d] = true
+		}
+	}
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.files[p] = body
+	return nil
+}
+
+func (m *memFiler) Read(ctx context.Context, p string) (io.ReadCloser, error) {
+	body, ok := m.files[p]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return io.NopCloser(bytes.NewReader(body)), nil
+}
+
+func (m *memFiler) Delete(ctx context.Context, p string, mode ...libsfiler.DeleteMode) error {
+	if _, ok := m.files[p]; !ok {
+		return fs.ErrNotExist
+	}
+	delete(m.files, p)
+	return nil
+}
+
+func (m *memFiler) ReadDir(ctx context.Context, p string) ([]fs.DirEntry, error) {
+	if !m.dirs[p] && p != "" {
+		return nil, fs.ErrNotExist
+	}
+	var out []fs.DirEntry
+	for filePath, body := range m.files {
+		if path.Dir(filePath) != p {
+			continue
+		}
+		out = append(out, memDirEntry{name: path.Base(filePath), size: int64(len(body))})
+	}
+	slices.SortFunc(out, func(a, b fs.DirEntry) int { return cmp.Compare(a.Name(), b.Name()) })
+	return out, nil
+}
+
+func (m *memFiler) Mkdir(ctx context.Context, p string) error {
+	m.dirs[p] = true
+	return nil
+}
+
+func (m *memFiler) Stat(ctx context.Context, p string) (fs.FileInfo, error) {
+	if body, ok := m.files[p]; ok {
+		return memFileInfo{name: path.Base(p), size: int64(len(body))}, nil
+	}
+	if m.dirs[p] {
+		return memFileInfo{name: path.Base(p), isDir: true}, nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+type memFileInfo struct {
+	name  string
+	size  int64
+	isDir bool
+}
+
+func (f memFileInfo) Name() string       { return f.name }
+func (f memFileInfo) Size() int64        { return f.size }
+func (f memFileInfo) Mode() fs.FileMode  { return 0 }
+func (f memFileInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (f memFileInfo) IsDir() bool        { return f.isDir }
+func (f memFileInfo) Sys() any           { return nil }
+
+type memDirEntry struct {
+	name string
+	size int64
+}
+
+func (e memDirEntry) Name() string               { return e.name }
+func (e memDirEntry) IsDir() bool                { return false }
+func (e memDirEntry) Type() fs.FileMode          { return 0 }
+func (e memDirEntry) Info() (fs.FileInfo, error) { return memFileInfo{name: e.name, size: e.size}, nil }
+
+func newTestFiler(t *testing.T) (*WorkspaceFiler, *memFiler) {
+	t.Helper()
+	mem := newMemFiler()
+	return newWorkspaceFilerFromInner(mem), mem
+}
+
+func TestWorkspaceFilerRoundTrip(t *testing.T) {
+	ctx := t.Context()
+	f, mem := newTestFiler(t)
+	mem.dirs["/state"] = true
+
+	require.NoError(t, f.Write(ctx, "/state/terraform.tfstate", strings.NewReader("hello"), 0))
+
+	rc, err := f.Read(ctx, "/state/terraform.tfstate")
+	require.NoError(t, err)
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(body))
+}
+
+func TestWorkspaceFilerWriteRejectsExistingWithoutOverwrite(t *testing.T) {
+	ctx := t.Context()
+	f, mem := newTestFiler(t)
+	mem.dirs["/state"] = true
+
+	require.NoError(t, f.Write(ctx, "/state/a", strings.NewReader("v1"), 0))
+
+	err := f.Write(ctx, "/state/a", strings.NewReader("v2"), 0)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fs.ErrExist), "expected fs.ErrExist, got %v", err)
+}
+
+func TestWorkspaceFilerWriteOverwriteMode(t *testing.T) {
+	ctx := t.Context()
+	f, mem := newTestFiler(t)
+	mem.dirs["/state"] = true
+
+	require.NoError(t, f.Write(ctx, "/state/a", strings.NewReader("v1"), 0))
+	require.NoError(t, f.Write(ctx, "/state/a", strings.NewReader("v2"), WriteModeOverwrite))
+
+	rc, err := f.Read(ctx, "/state/a")
+	require.NoError(t, err)
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "v2", string(body))
+}
+
+func TestWorkspaceFilerWriteCreateParents(t *testing.T) {
+	ctx := t.Context()
+	f, _ := newTestFiler(t)
+
+	err := f.Write(ctx, "/state/nested/deep/a", strings.NewReader("x"), 0)
+	require.Error(t, err, "write without CreateParents should fail for missing parent")
+	assert.True(t, errors.Is(err, ErrNotFound))
+
+	require.NoError(t, f.Write(ctx, "/state/nested/deep/a", strings.NewReader("x"), WriteModeCreateParents))
+
+	rc, err := f.Read(ctx, "/state/nested/deep/a")
+	require.NoError(t, err)
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "x", string(body))
+}
+
+func TestWorkspaceFilerReadMissingReturnsErrNotFound(t *testing.T) {
+	ctx := t.Context()
+	f, _ := newTestFiler(t)
+
+	_, err := f.Read(ctx, "/state/missing")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound), "expected ErrNotFound, got %v", err)
+}
+
+func TestWorkspaceFilerStatMissingReturnsErrNotFound(t *testing.T) {
+	ctx := t.Context()
+	f, _ := newTestFiler(t)
+
+	_, err := f.Stat(ctx, "/state/missing")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestWorkspaceFilerStatExistingFile(t *testing.T) {
+	ctx := t.Context()
+	f, mem := newTestFiler(t)
+	mem.dirs["/state"] = true
+	require.NoError(t, f.Write(ctx, "/state/a", strings.NewReader("abcdef"), 0))
+
+	info, err := f.Stat(ctx, "/state/a")
+	require.NoError(t, err)
+	assert.Equal(t, "a", info.Name())
+	assert.Equal(t, int64(6), info.Size())
+	assert.False(t, info.IsDir())
+}
+
+func TestWorkspaceFilerReadDir(t *testing.T) {
+	ctx := t.Context()
+	f, mem := newTestFiler(t)
+	mem.dirs["/state"] = true
+	require.NoError(t, f.Write(ctx, "/state/a", strings.NewReader("1"), 0))
+	require.NoError(t, f.Write(ctx, "/state/b", strings.NewReader("22"), 0))
+
+	entries, err := f.ReadDir(ctx, "/state")
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "a", entries[0].Name())
+	assert.Equal(t, int64(1), entries[0].Size())
+	assert.Equal(t, "b", entries[1].Name())
+	assert.Equal(t, int64(2), entries[1].Size())
+}
+
+func TestWorkspaceFilerDeleteMissingIsNoop(t *testing.T) {
+	ctx := t.Context()
+	f, _ := newTestFiler(t)
+
+	require.NoError(t, f.Delete(ctx, "/state/missing"))
+}
+
+func TestWorkspaceFilerDeleteExisting(t *testing.T) {
+	ctx := t.Context()
+	f, mem := newTestFiler(t)
+	mem.dirs["/state"] = true
+	require.NoError(t, f.Write(ctx, "/state/a", strings.NewReader("x"), 0))
+
+	require.NoError(t, f.Delete(ctx, "/state/a"))
+	_, err := f.Read(ctx, "/state/a")
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestWriteModeHas(t *testing.T) {
+	cases := []struct {
+		name  string
+		m     WriteMode
+		probe WriteMode
+		want  bool
+	}{
+		{"zero has zero", 0, 0, true},
+		{"overwrite has overwrite", WriteModeOverwrite, WriteModeOverwrite, true},
+		{"overwrite lacks create-parents", WriteModeOverwrite, WriteModeCreateParents, false},
+		{"combined has overwrite", WriteModeOverwrite | WriteModeCreateParents, WriteModeOverwrite, true},
+		{"combined has create-parents", WriteModeOverwrite | WriteModeCreateParents, WriteModeCreateParents, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.m.Has(tc.probe))
+		})
+	}
+}


### PR DESCRIPTION
Closes #8

## Summary
- Adds `ucm/deploy/filer/iface.go` with a minimal UCM-native `StateFiler` interface (Read/Write/Delete/Stat/ReadDir), a typed `WriteMode` bit-mask, and a sentinel `ErrNotFound`.
- Adds `ucm/deploy/filer/workspace_filer.go` — v1 implementation backed by workspace files, wrapping `libs/filer.NewWorkspaceFilesClient` and translating `fs.ErrNotExist` into the UCM-native `ErrNotFound`.
- Adds `ucm/deploy/filer/workspace_filer_test.go` — round-trip, overwrite, create-parents, missing-read, missing-stat, delete-missing-is-noop, and `ReadDir` coverage driven by a small in-memory libs/filer stub.

## Why
U4 (state pull/push) and U5 (terraform wrapper) both need a stable surface to read/write `terraform.tfstate` and UCM-native snapshots. Defining the interface in its own PR keeps subsequent state + terraform work unblocked without dragging in bundle-specific assumptions. Wrapping `libs/filer` rather than re-implementing the workspace-files protocol keeps auth, retry, and the SPOG `X-Databricks-Org-Id` header handling in a single upstream place — fixes flow through on the weekly upstream sync.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`
- [x] Round-trip write/read against an in-memory libs/filer stub; `errors.Is(err, ErrNotFound)` verified on missing-path reads and stats.

## Fork-divergence notes
- Edits to upstream files: none.
- New touchpoints outside `cmd/ucm/**`, `ucm/**`, `.claude/**`, `.github/workflows/upstream-sync.yml`: none.
- No imports from `bundle/**`. Imports from `libs/filer` and `databricks-sdk-go` only.

## Base branch
`main` — not stacked on any open PR.