### PR TITLE
Feat #9: Fork bundle/deploy/lock into ucm/deploy/lock

### DIFF
--- a/ucm/deploy/lock/acquire.go
+++ b/ucm/deploy/lock/acquire.go
@@ -1,0 +1,116 @@
+package lock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"time"
+
+	"github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/libs/log"
+)
+
+// ErrLockHeld is returned by Acquire when another client already holds the
+// lock. It carries the contending lock state so callers (or the human) can
+// decide whether --force is warranted.
+type ErrLockHeld struct {
+	Holder          string
+	AcquisitionTime time.Time
+	IsForced        bool
+}
+
+// Error implements error. The message format is deliberately close to the
+// bundle/libs/locker message so CI logs and user muscle memory carry over.
+func (e *ErrLockHeld) Error() string {
+	if e.IsForced {
+		return fmt.Sprintf("deploy lock force acquired by %s at %v. Use --force-lock to override", e.Holder, e.AcquisitionTime)
+	}
+	return fmt.Sprintf("deploy lock acquired by %s at %v. Use --force-lock to override", e.Holder, e.AcquisitionTime)
+}
+
+// GetActiveLockState returns the lock record currently written at TargetDir,
+// irrespective of whether this locker holds it. Returns fs.ErrNotExist if no
+// lock is currently held.
+func (l *Locker) GetActiveLockState(ctx context.Context) (*State, error) {
+	reader, err := l.filer.Read(ctx, LockFileName)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	remote := State{}
+	if err := json.Unmarshal(data, &remote); err != nil {
+		return nil, err
+	}
+	return &remote, nil
+}
+
+// assertLockHeld verifies that the lock file under TargetDir matches this
+// locker's ID. Returns ErrLockHeld if another client is the current holder.
+func (l *Locker) assertLockHeld(ctx context.Context) error {
+	active, err := l.GetActiveLockState(ctx)
+	if errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("no active lock on target dir: %w", err)
+	}
+	if err != nil {
+		return err
+	}
+	if active.ID != l.LocalState.ID {
+		return &ErrLockHeld{
+			Holder:          active.User,
+			AcquisitionTime: active.AcquisitionTime,
+			IsForced:        active.IsForced,
+		}
+	}
+	return nil
+}
+
+// Acquire writes a lock record under TargetDir. If force is true it
+// overwrites any existing record; otherwise it races via an atomic create
+// and returns *ErrLockHeld on contention.
+func (l *Locker) Acquire(ctx context.Context, force bool) error {
+	log.Infof(ctx, "Acquiring deployment lock (force: %v)", force)
+
+	newState := State{
+		ID:              l.LocalState.ID,
+		AcquisitionTime: time.Now(),
+		IsForced:        force,
+		User:            l.LocalState.User,
+	}
+	buf, err := json.Marshal(newState)
+	if err != nil {
+		return err
+	}
+
+	modes := []filer.WriteMode{filer.CreateParentDirectories}
+	if force {
+		modes = append(modes, filer.OverwriteIfExists)
+	}
+
+	err = l.filer.Write(ctx, LockFileName, bytes.NewReader(buf), modes...)
+	if err != nil {
+		// If the write failed because the lock file already exists, fall
+		// through to assertLockHeld so the caller gets the ErrLockHeld with
+		// the contending holder's identity rather than a bare fs.ErrExist.
+		if !errors.Is(err, fs.ErrExist) {
+			return err
+		}
+	}
+
+	if err := l.assertLockHeld(ctx); err != nil {
+		return err
+	}
+
+	l.LocalState = &newState
+	l.Active = true
+	return nil
+}

--- a/ucm/deploy/lock/acquire_test.go
+++ b/ucm/deploy/lock/acquire_test.go
@@ -1,0 +1,111 @@
+package lock_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLocker(t *testing.T, user string) *lock.Locker {
+	t.Helper()
+	f, err := filer.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+	return lock.NewLockerWithFiler(user, "/test", f)
+}
+
+func newTestLockerOnFiler(user string, f filer.Filer) *lock.Locker {
+	return lock.NewLockerWithFiler(user, "/test", f)
+}
+
+func TestAcquireSucceedsOnEmptyDir(t *testing.T) {
+	ctx := t.Context()
+	l := newTestLocker(t, "alice@example.com")
+
+	err := l.Acquire(ctx, false)
+	require.NoError(t, err)
+	assert.True(t, l.Active)
+	assert.Equal(t, "alice@example.com", l.LocalState.User)
+	assert.False(t, l.LocalState.IsForced)
+	assert.False(t, l.LocalState.AcquisitionTime.IsZero())
+}
+
+func TestAcquireWritesRecordReadableByGetActiveLockState(t *testing.T) {
+	ctx := t.Context()
+	l := newTestLocker(t, "alice@example.com")
+
+	require.NoError(t, l.Acquire(ctx, false))
+
+	active, err := l.GetActiveLockState(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, l.LocalState.ID, active.ID)
+	assert.Equal(t, "alice@example.com", active.User)
+}
+
+func TestAcquireContentionReturnsErrLockHeld(t *testing.T) {
+	ctx := t.Context()
+
+	// Two lockers share the same underlying filer — i.e. same remote
+	// state dir. The second Acquire must observe the first's record.
+	shared, err := filer.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+
+	first := newTestLockerOnFiler("alice@example.com", shared)
+	second := newTestLockerOnFiler("bob@example.com", shared)
+
+	require.NoError(t, first.Acquire(ctx, false))
+
+	err = second.Acquire(ctx, false)
+	require.Error(t, err)
+
+	var held *lock.ErrLockHeld
+	require.ErrorAs(t, err, &held)
+	assert.Equal(t, "alice@example.com", held.Holder)
+	assert.False(t, held.IsForced)
+	assert.False(t, second.Active)
+}
+
+func TestAcquireForceOverridesExistingLock(t *testing.T) {
+	ctx := t.Context()
+	shared, err := filer.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+
+	first := newTestLockerOnFiler("alice@example.com", shared)
+	second := newTestLockerOnFiler("bob@example.com", shared)
+
+	require.NoError(t, first.Acquire(ctx, false))
+
+	// Non-forced contention fails.
+	err = second.Acquire(ctx, false)
+	require.Error(t, err)
+	var held *lock.ErrLockHeld
+	require.ErrorAs(t, err, &held)
+
+	// Forced contention wins and flips the active record over to second.
+	require.NoError(t, second.Acquire(ctx, true))
+	assert.True(t, second.Active)
+	assert.True(t, second.LocalState.IsForced)
+
+	active, err := second.GetActiveLockState(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, second.LocalState.ID, active.ID)
+	assert.Equal(t, "bob@example.com", active.User)
+}
+
+func TestErrLockHeldMessageFormat(t *testing.T) {
+	err := &lock.ErrLockHeld{Holder: "alice@example.com"}
+	assert.Contains(t, err.Error(), "deploy lock acquired by alice@example.com")
+	assert.Contains(t, err.Error(), "Use --force-lock to override")
+
+	forcedErr := &lock.ErrLockHeld{Holder: "alice@example.com", IsForced: true}
+	assert.Contains(t, forcedErr.Error(), "deploy lock force acquired by alice@example.com")
+}
+
+func TestErrLockHeldIsErrorAsTargetable(t *testing.T) {
+	var zero *lock.ErrLockHeld
+	err := error(&lock.ErrLockHeld{Holder: "alice@example.com"})
+	assert.True(t, errors.As(err, &zero))
+}

--- a/ucm/deploy/lock/lock.go
+++ b/ucm/deploy/lock/lock.go
@@ -1,0 +1,89 @@
+// Package lock provides deployment lock primitives for ucm. It is forked
+// from bundle/deploy/lock to avoid importing bundle internals; the underlying
+// wire protocol (a JSON lock file at <stateDir>/deploy.lock) is deliberately
+// identical to libs/locker so ucm and bundle can later share the same state
+// root if needed. Forking rather than wrapping libs/locker lets tests inject
+// an arbitrary filer.Filer without requiring a live workspace client.
+package lock
+
+import (
+	"time"
+
+	"github.com/databricks/cli/libs/filer"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/google/uuid"
+)
+
+// LockFileName is the on-the-wire name of the deploy lock file under the
+// state directory. Kept identical to libs/locker.LockFileName so ucm and
+// bundle lockers are mutually exclusive on a shared state root.
+const LockFileName = "deploy.lock"
+
+// Goal identifies the operation that holds the lock. Release uses it to
+// decide how strict to be about missing lock files — a destroy that already
+// deleted the state dir is expected to find no lock.
+type Goal string
+
+const (
+	GoalDeploy  = Goal("deploy")
+	GoalDestroy = Goal("destroy")
+	GoalBind    = Goal("bind")
+	GoalUnbind  = Goal("unbind")
+)
+
+// State is the on-the-wire lock record: who holds the lock, when they took
+// it, and whether it was forcefully acquired. Field names match
+// libs/locker.LockState so ucm and bundle can deserialize each other's locks.
+type State struct {
+	ID              uuid.UUID `json:"ID"`
+	AcquisitionTime time.Time `json:"AcquisitionTime"`
+	IsForced        bool      `json:"IsForced"`
+	User            string    `json:"User"`
+}
+
+// Locker enables exclusive access to a remote state directory for one client.
+// Multiple clients race to create LockFileName under targetDir; the first
+// write wins. Lock holders may force-release a stale lock with the force
+// flag, at the cost of the exclusivity guarantee.
+type Locker struct {
+	filer filer.Filer
+
+	// TargetDir is the scope of the lock (state directory root).
+	TargetDir string
+	// Active is true when this locker holds the lock. Forced acquisitions
+	// may break exclusivity for other holders.
+	Active bool
+	// LocalState is this client's record of the lock; uploaded to TargetDir
+	// on Acquire.
+	LocalState *State
+}
+
+// NewLocker creates a Locker backed by a workspace-files filer rooted at
+// targetDir. user is embedded into the lock record so contending clients can
+// see who currently holds it.
+func NewLocker(user, targetDir string, w *databricks.WorkspaceClient) (*Locker, error) {
+	f, err := filer.NewWorkspaceFilesClient(w, targetDir)
+	if err != nil {
+		return nil, err
+	}
+	return newLocker(user, targetDir, f), nil
+}
+
+// NewLockerWithFiler lets callers inject an arbitrary filer.Filer (e.g. a
+// local-disk filer in tests, or a future s3/adls/gcs state filer).
+// Production workspace-files callers should use NewLocker.
+func NewLockerWithFiler(user, targetDir string, f filer.Filer) *Locker {
+	return newLocker(user, targetDir, f)
+}
+
+func newLocker(user, targetDir string, f filer.Filer) *Locker {
+	return &Locker{
+		filer:     f,
+		TargetDir: targetDir,
+		Active:    false,
+		LocalState: &State{
+			ID:   uuid.New(),
+			User: user,
+		},
+	}
+}

--- a/ucm/deploy/lock/release.go
+++ b/ucm/deploy/lock/release.go
@@ -1,0 +1,50 @@
+package lock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"slices"
+
+	"github.com/databricks/cli/libs/log"
+)
+
+// ReleaseOption tweaks Release behavior.
+type ReleaseOption int
+
+const (
+	// AllowLockFileNotExist makes Release succeed if the lock file is
+	// already gone. Used by destroy, which may delete the state dir before
+	// Release gets a chance to run.
+	AllowLockFileNotExist ReleaseOption = iota
+)
+
+// Release deletes the lock file under TargetDir if this locker owns it.
+// The goal argument mirrors bundle/deploy/lock.Release: destroy implies
+// AllowLockFileNotExist is tolerated even without an explicit option.
+func (l *Locker) Release(ctx context.Context, goal Goal, opts ...ReleaseOption) error {
+	log.Infof(ctx, "Releasing deployment lock (goal: %s)", goal)
+
+	if !l.Active {
+		return errors.New("unlock called when lock is not held")
+	}
+
+	// Destroy tolerates a missing lock file by default.
+	allowNotExist := slices.Contains(opts, AllowLockFileNotExist) || goal == GoalDestroy
+
+	if _, err := l.filer.Stat(ctx, LockFileName); errors.Is(err, fs.ErrNotExist) && allowNotExist {
+		l.Active = false
+		return nil
+	}
+
+	if err := l.assertLockHeld(ctx); err != nil {
+		return fmt.Errorf("unlock called when lock is not held: %w", err)
+	}
+
+	if err := l.filer.Delete(ctx, LockFileName); err != nil {
+		return err
+	}
+	l.Active = false
+	return nil
+}

--- a/ucm/deploy/lock/release_test.go
+++ b/ucm/deploy/lock/release_test.go
@@ -1,0 +1,102 @@
+package lock_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseRoundTrip(t *testing.T) {
+	ctx := t.Context()
+	l := newTestLocker(t, "alice@example.com")
+
+	require.NoError(t, l.Acquire(ctx, false))
+	require.NoError(t, l.Release(ctx, lock.GoalDeploy))
+	assert.False(t, l.Active)
+
+	// Second Release errors since state is no longer Active.
+	err := l.Release(ctx, lock.GoalDeploy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unlock called when lock is not held")
+}
+
+func TestReleaseFailsWhenLockNotHeld(t *testing.T) {
+	ctx := t.Context()
+	l := newTestLocker(t, "alice@example.com")
+
+	err := l.Release(ctx, lock.GoalDeploy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unlock called when lock is not held")
+}
+
+func TestReleaseAfterContentionDoesNotClearOthersLock(t *testing.T) {
+	ctx := t.Context()
+	shared, err := filer.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+
+	first := newTestLockerOnFiler("alice@example.com", shared)
+	second := newTestLockerOnFiler("bob@example.com", shared)
+
+	require.NoError(t, first.Acquire(ctx, false))
+
+	// second never acquired; its internal Active flag is false, so Release
+	// must refuse to touch the on-disk lock.
+	err = second.Release(ctx, lock.GoalDeploy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unlock called when lock is not held")
+
+	// first's lock is still on disk.
+	active, err := first.GetActiveLockState(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, first.LocalState.ID, active.ID)
+}
+
+func TestReleaseGoalDestroyToleratesMissingLockFile(t *testing.T) {
+	ctx := t.Context()
+	shared, err := filer.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+
+	l := newTestLockerOnFiler("alice@example.com", shared)
+	require.NoError(t, l.Acquire(ctx, false))
+
+	// Simulate the destroy race: some other component wiped the state dir
+	// before we got a chance to Release.
+	require.NoError(t, shared.Delete(ctx, lock.LockFileName))
+
+	// Destroy must not fail.
+	require.NoError(t, l.Release(ctx, lock.GoalDestroy))
+	assert.False(t, l.Active)
+}
+
+func TestReleaseGoalDeployFailsOnMissingLockFile(t *testing.T) {
+	ctx := t.Context()
+	shared, err := filer.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+
+	l := newTestLockerOnFiler("alice@example.com", shared)
+	require.NoError(t, l.Acquire(ctx, false))
+
+	require.NoError(t, shared.Delete(ctx, lock.LockFileName))
+
+	// GoalDeploy is strict: a missing lock file is an error state.
+	err = l.Release(ctx, lock.GoalDeploy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unlock called when lock is not held")
+}
+
+func TestReleaseWithAllowLockFileNotExistOption(t *testing.T) {
+	ctx := t.Context()
+	shared, err := filer.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+
+	l := newTestLockerOnFiler("alice@example.com", shared)
+	require.NoError(t, l.Acquire(ctx, false))
+
+	require.NoError(t, shared.Delete(ctx, lock.LockFileName))
+
+	require.NoError(t, l.Release(ctx, lock.GoalDeploy, lock.AllowLockFileNotExist))
+	assert.False(t, l.Active)
+}


### PR DESCRIPTION
Closes #9

## Summary
- Forks `bundle/deploy/lock` into `ucm/deploy/lock` (direct `Acquire`/`Release` methods, no `bundle.Mutator` wrapper).
- Introduces a typed `*ErrLockHeld` sentinel so callers can drive `--force-lock` messaging via `errors.As` instead of string matching.
- Preserves the `deploy.lock` wire format from `libs/locker` so ucm and bundle lockers are mutually exclusive on a shared state root.

## Why
Fork rules forbid importing `bundle/**` from `ucm/**`, and the bundle locker is tightly coupled to `bundle.Bundle` via the mutator Apply harness that ucm doesn't have yet. Forking the primitives now — before ucm's deploy/destroy phases land (#10+) — gives those PRs a stable, UC-specific locker to wire up. The copy is intentionally thin: it wraps a `filer.Filer` exactly as `libs/locker` does, so future upstream drift shows up as a narrow diff rather than an engine-wide rebase.

Key deviations from the `bundle/deploy/lock` origin, called out so reviewers can decide whether to also push them upstream later:
- Direct `Acquire(ctx, force)` / `Release(ctx, goal, opts...)` methods on `*Locker`, not `bundle.Mutator` Apply wrappers.
- `*ErrLockHeld` typed error replacing the `fmt.Errorf` string in `libs/locker.assertLockHeld`.
- `NewLockerWithFiler(user, targetDir, filer.Filer)` constructor so unit tests can inject a `filer.NewLocalClient` and exercise contention without a workspace — production code paths still go through `NewLocker(user, targetDir, *databricks.WorkspaceClient)`.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...` (12 new tests pass)
- [x] Grep check: no `github.com/databricks/cli/bundle` imports under `ucm/`.
- [x] Tests cover: successful acquire/release round-trip, contested lock returning `*ErrLockHeld`, force-lock override path, and `GoalDestroy` tolerating a missing lock file.
- [ ] No upstream file edits — `cmd/cmd.go` and all `bundle/**`, `libs/**`, `acceptance/**`, `integration/**` are untouched.