### PR TITLE
Feat #10: tfdyn converter registry + Catalog/Schema/Grant converters

### DIFF
--- a/cmd/ucm/schema.go
+++ b/cmd/ucm/schema.go
@@ -1,0 +1,35 @@
+package ucm
+
+import (
+	"github.com/databricks/cli/cmd/root"
+	ucmschema "github.com/databricks/cli/ucm/schema"
+	"github.com/spf13/cobra"
+)
+
+func newSchemaCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "schema",
+		Short: "Print the JSON schema for ucm.yml.",
+		Long: `Print the JSON schema for ucm.yml.
+
+Pipe into a file and point your editor at it for autocomplete and validation:
+
+  databricks ucm schema > ucm.schema.json
+`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		out, err := ucmschema.Generate()
+		if err != nil {
+			return err
+		}
+		if _, err := cmd.OutOrStdout().Write(out); err != nil {
+			return err
+		}
+		_, err = cmd.OutOrStdout().Write([]byte{'\n'})
+		return err
+	}
+
+	return cmd
+}

--- a/cmd/ucm/stubs.go
+++ b/cmd/ucm/stubs.go
@@ -21,14 +21,6 @@ func stub(use, short string) *cobra.Command {
 	return cmd
 }
 
-func newValidateCommand() *cobra.Command {
-	return stub("validate", "Validate ucm.yml for errors, warnings, policy violations.")
-}
-
-func newSchemaCommand() *cobra.Command {
-	return stub("schema", "Print the JSON schema for ucm.yml.")
-}
-
 func newPlanCommand() *cobra.Command {
 	return stub("plan", "Preview the changes ucm deploy would make.")
 }

--- a/cmd/ucm/testdata/missing_tag/ucm.yml
+++ b/cmd/ucm/testdata/missing_tag/ucm.yml
@@ -1,0 +1,15 @@
+ucm:
+  name: fixture-missing-tag
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      tags:
+        cost_center: "1234"
+        # missing data_owner and classification
+
+  tag_validation_rules:
+    enforce_ownership:
+      securable_types: [catalog]
+      required: [cost_center, data_owner, classification]

--- a/cmd/ucm/testdata/valid/ucm.yml
+++ b/cmd/ucm/testdata/valid/ucm.yml
@@ -1,0 +1,37 @@
+ucm:
+  name: fixture-valid
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      comment: alpha catalog
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal
+
+  schemas:
+    bronze:
+      catalog: team_alpha
+      name: bronze
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal
+
+  grants:
+    alpha_read:
+      securable: { type: catalog, name: team_alpha }
+      principal: alpha-readers
+      privileges: [USE_CATALOG, SELECT]
+
+  tag_validation_rules:
+    enforce_ownership:
+      securable_types: [catalog, schema]
+      required: [cost_center, data_owner, classification]
+      allowed_values:
+        classification: [public, internal, confidential, restricted]

--- a/cmd/ucm/ucm.go
+++ b/cmd/ucm/ucm.go
@@ -35,6 +35,8 @@ Online documentation: https://docs.databricks.com/en/dev-tools/ucm/index.html`,
 		GroupID: "development",
 	}
 
+	cmd.PersistentFlags().StringP("target", "t", "", "ucm target to use (if applicable)")
+
 	cmd.AddCommand(newValidateCommand())
 	cmd.AddCommand(newSchemaCommand())
 	cmd.AddCommand(newPlanCommand())

--- a/cmd/ucm/utils/utils.go
+++ b/cmd/ucm/utils/utils.go
@@ -1,0 +1,59 @@
+// Package utils contains helpers shared by `databricks ucm` subcommand
+// implementations — primarily ProcessUcm, which mirrors the role of
+// cmd/bundle/utils.ProcessBundle for the ucm verbs.
+package utils
+
+import (
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+// ProcessOptions controls optional behavior in ProcessUcm. M0 only exposes
+// the `Validate` switch; more knobs will join as additional verbs land.
+type ProcessOptions struct {
+	// Validate runs phases.Validate after loading the target. Set this when
+	// implementing the `validate` or `policy-check` verbs.
+	Validate bool
+}
+
+// ProcessUcm loads the ucm.yml rooted at the working directory (or
+// DATABRICKS_UCM_ROOT), selects the target indicated by --target (or the
+// default target), and — if opts.Validate — runs the validation phase.
+//
+// Errors are reported via logdiag. The caller should check
+// logdiag.HasError(cmd.Context()) and render diagnostics before returning.
+func ProcessUcm(cmd *cobra.Command, opts ProcessOptions) *ucm.Ucm {
+	ctx := cmd.Context()
+	if !logdiag.IsSetup(ctx) {
+		ctx = logdiag.InitContext(ctx)
+		cmd.SetContext(ctx)
+	}
+
+	u := ucm.MustLoad(ctx)
+	if u == nil || logdiag.HasError(ctx) {
+		return u
+	}
+
+	if target := getTargetFromCmd(cmd); target == "" {
+		phases.LoadDefaultTarget(ctx, u)
+	} else {
+		phases.LoadNamedTarget(ctx, u, target)
+	}
+	if logdiag.HasError(ctx) {
+		return u
+	}
+
+	if opts.Validate {
+		phases.Validate(ctx, u)
+	}
+	return u
+}
+
+func getTargetFromCmd(cmd *cobra.Command) string {
+	if flag := cmd.Flag("target"); flag != nil {
+		return flag.Value.String()
+	}
+	return ""
+}

--- a/cmd/ucm/validate.go
+++ b/cmd/ucm/validate.go
@@ -1,0 +1,53 @@
+package ucm
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/spf13/cobra"
+)
+
+func newValidateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate ucm.yml for errors, warnings, policy violations.",
+		Long: `Validate ucm configuration for errors, warnings and policy violations.
+
+Runs the full ucm mutator chain, including tag-validation rules, against the
+selected target. Useful as a CI gate before ` + "`ucm deploy`" + `.
+
+Common invocations:
+  databricks ucm validate                  # Validate default target
+  databricks ucm validate --target prod    # Validate a specific target
+  databricks ucm validate --strict         # Fail on warnings too`,
+		Args: root.NoArgs,
+	}
+
+	var strict bool
+	cmd.Flags().BoolVar(&strict, "strict", false, "Treat warnings as errors")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		utils.ProcessUcm(cmd, utils.ProcessOptions{Validate: true})
+		ctx := cmd.Context()
+
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		numWarnings := logdiag.NumWarnings(ctx)
+		if strict && numWarnings > 0 {
+			noun := "warning"
+			if numWarnings != 1 {
+				noun = "warnings"
+			}
+			return fmt.Errorf("%d %s found. Warnings are not allowed in strict mode", numWarnings, noun)
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Validation OK!")
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/validate_test.go
+++ b/cmd/ucm/validate_test.go
@@ -1,0 +1,74 @@
+package ucm_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cmdUcm "github.com/databricks/cli/cmd/ucm"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runValidate invokes the cobra ucm-subtree in a temp cwd set to fixtureDir
+// and returns stdout, stderr, and whatever the Execute call returned.
+func runValidate(t *testing.T, fixtureDir string) (string, string, error) {
+	t.Helper()
+
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(fixtureDir))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	cmd := cmdUcm.New()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"validate"})
+
+	ctx, _ := cmdio.NewTestContextWithStderr(context.Background())
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetRoot(ctx, fixtureDir)
+	cmd.SetContext(ctx)
+
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func TestCmd_Validate_ValidFixturePasses(t *testing.T) {
+	stdout, stderr, err := runValidate(t, filepath.Join("testdata", "valid"))
+	t.Logf("stdout=%q", stdout)
+	t.Logf("stderr=%q", stderr)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Validation OK!")
+}
+
+func TestCmd_Validate_MissingTagFixtureFails(t *testing.T) {
+	_, _, err := runValidate(t, filepath.Join("testdata", "missing_tag"))
+	require.Error(t, err)
+}
+
+func TestCmd_Schema_ProducesValidJSON(t *testing.T) {
+	cmd := cmdUcm.New()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"schema"})
+
+	require.NoError(t, cmd.Execute())
+
+	// The output must parse as JSON and declare an object at the root.
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &schema))
+
+	// Should at minimum advertise the ucm root in the $defs tree.
+	raw := out.String()
+	assert.True(t, strings.Contains(raw, "resources.Catalog"), "schema should describe Catalog")
+	assert.True(t, strings.Contains(raw, "resources.TagValidationRule"), "schema should describe TagValidationRule")
+}

--- a/ucm/config/account.go
+++ b/ucm/config/account.go
@@ -1,0 +1,10 @@
+package config
+
+// Account describes the Databricks account that hosts the metastore.
+//
+// M0 captures just the identifying fields; account-scoped operations
+// (metastore CRUD, metastore assignment) land in M1+.
+type Account struct {
+	AccountId string `json:"account_id,omitempty"`
+	Host      string `json:"host,omitempty"`
+}

--- a/ucm/config/filename.go
+++ b/ucm/config/filename.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type ConfigFileNames []string
+
+// FileNames contains allowed names of the root ucm configuration file.
+var FileNames = ConfigFileNames{
+	"ucm.yml",
+	"ucm.yaml",
+}
+
+func (c ConfigFileNames) FindInPath(path string) (string, error) {
+	result := ""
+	var firstErr error
+
+	for _, file := range c {
+		filePath := filepath.Join(path, file)
+		_, err := os.Stat(filePath)
+		if err == nil {
+			if result != "" {
+				return "", fmt.Errorf("multiple ucm root configuration files found in %s", path)
+			}
+			result = filePath
+		} else if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	if result == "" {
+		return "", firstErr
+	}
+
+	return result, nil
+}

--- a/ucm/config/filename_test.go
+++ b/ucm/config/filename_test.go
@@ -1,0 +1,36 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileNames_FindSingle(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ucm.yml"), []byte("ucm:\n  name: x\n"), 0o644))
+
+	path, err := config.FileNames.FindInPath(dir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "ucm.yml"), path)
+}
+
+func TestFileNames_RejectAmbiguous(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ucm.yml"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ucm.yaml"), []byte(""), 0o644))
+
+	_, err := config.FileNames.FindInPath(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple")
+}
+
+func TestFileNames_Missing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := config.FileNames.FindInPath(dir)
+	require.Error(t, err)
+}

--- a/ucm/config/mutator/define_default_target.go
+++ b/ucm/config/mutator/define_default_target.go
@@ -1,0 +1,33 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+)
+
+type defineDefaultTarget struct {
+	name string
+}
+
+// DefineDefaultTarget adds a target named "default" to the configuration if
+// none have been defined. Keeps verb wiring uniform (SelectTarget always has
+// something to pick) even when ucm.yml omits `targets:` entirely.
+func DefineDefaultTarget() ucm.Mutator {
+	return &defineDefaultTarget{name: "default"}
+}
+
+func (m *defineDefaultTarget) Name() string {
+	return fmt.Sprintf("DefineDefaultTarget(%s)", m.name)
+}
+
+func (m *defineDefaultTarget) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	if len(u.Config.Targets) > 0 {
+		return nil
+	}
+	u.Config.Targets = map[string]*config.Target{m.name: {}}
+	return nil
+}

--- a/ucm/config/mutator/define_default_target_test.go
+++ b/ucm/config/mutator/define_default_target_test.go
@@ -1,0 +1,34 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefineDefaultTarget_AddsDefaultWhenNoneDefined(t *testing.T) {
+	u := &ucm.Ucm{}
+	diags := ucm.Apply(t.Context(), u, mutator.DefineDefaultTarget())
+	require.NoError(t, diags.Error())
+
+	got, ok := u.Config.Targets["default"]
+	assert.True(t, ok)
+	assert.Equal(t, &config.Target{}, got)
+}
+
+func TestDefineDefaultTarget_NoopWhenTargetExists(t *testing.T) {
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Targets: map[string]*config.Target{"dev": {}},
+		},
+	}
+	diags := ucm.Apply(t.Context(), u, mutator.DefineDefaultTarget())
+	require.NoError(t, diags.Error())
+
+	_, ok := u.Config.Targets["default"]
+	assert.False(t, ok)
+}

--- a/ucm/config/mutator/select_default_target.go
+++ b/ucm/config/mutator/select_default_target.go
@@ -1,0 +1,51 @@
+package mutator
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+)
+
+type selectDefaultTarget struct{}
+
+// SelectDefaultTarget picks the default target and merges it in. One target
+// means that target is the default; multiple targets requires exactly one to
+// carry `default: true`.
+func SelectDefaultTarget() ucm.Mutator {
+	return &selectDefaultTarget{}
+}
+
+func (m *selectDefaultTarget) Name() string { return "SelectDefaultTarget" }
+
+func (m *selectDefaultTarget) Apply(ctx context.Context, u *ucm.Ucm) diag.Diagnostics {
+	if len(u.Config.Targets) == 0 {
+		return diag.Errorf("no targets defined")
+	}
+
+	names := slices.Collect(maps.Keys(u.Config.Targets))
+	if len(names) == 1 {
+		ucm.ApplyContext(ctx, u, SelectTarget(names[0]))
+		return nil
+	}
+
+	var defaults []string
+	for name, t := range u.Config.Targets {
+		if t != nil && t.Default {
+			defaults = append(defaults, name)
+		}
+	}
+
+	if len(defaults) > 1 {
+		return diag.Errorf("multiple targets are marked as default (%s)", strings.Join(defaults, ", "))
+	}
+	if len(defaults) == 0 {
+		return diag.Errorf("please specify target")
+	}
+
+	ucm.ApplyContext(ctx, u, SelectTarget(defaults[0]))
+	return nil
+}

--- a/ucm/config/mutator/select_default_target_test.go
+++ b/ucm/config/mutator/select_default_target_test.go
@@ -1,0 +1,87 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectDefaultTarget_SingleTargetIsDefault(t *testing.T) {
+	u := &ucm.Ucm{}
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+targets:
+  dev: {}
+`))
+	require.NoError(t, diags.Error())
+	u.Config = *cfg
+
+	diags = ucm.Apply(t.Context(), u, mutator.SelectDefaultTarget())
+	require.NoError(t, diags.Error())
+	assert.Equal(t, "dev", u.Config.Ucm.Target)
+}
+
+func TestSelectDefaultTarget_PicksMarkedDefault(t *testing.T) {
+	u := &ucm.Ucm{}
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+targets:
+  dev:
+    default: true
+  prod: {}
+`))
+	require.NoError(t, diags.Error())
+	u.Config = *cfg
+
+	diags = ucm.Apply(t.Context(), u, mutator.SelectDefaultTarget())
+	require.NoError(t, diags.Error())
+	assert.Equal(t, "dev", u.Config.Ucm.Target)
+}
+
+func TestSelectDefaultTarget_MultipleDefaultsFails(t *testing.T) {
+	u := &ucm.Ucm{}
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+targets:
+  dev:
+    default: true
+  prod:
+    default: true
+`))
+	require.NoError(t, diags.Error())
+	u.Config = *cfg
+
+	diags = ucm.Apply(t.Context(), u, mutator.SelectDefaultTarget())
+	require.Error(t, diags.Error())
+	assert.Contains(t, diags.Error().Error(), "multiple targets are marked as default")
+}
+
+func TestSelectDefaultTarget_NoDefaultErrors(t *testing.T) {
+	u := &ucm.Ucm{}
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+targets:
+  dev: {}
+  prod: {}
+`))
+	require.NoError(t, diags.Error())
+	u.Config = *cfg
+
+	diags = ucm.Apply(t.Context(), u, mutator.SelectDefaultTarget())
+	require.Error(t, diags.Error())
+	assert.Contains(t, diags.Error().Error(), "please specify target")
+}
+
+func TestSelectDefaultTarget_NoTargetsFails(t *testing.T) {
+	u := &ucm.Ucm{}
+	diags := ucm.Apply(t.Context(), u, mutator.SelectDefaultTarget())
+	require.Error(t, diags.Error())
+}

--- a/ucm/config/mutator/select_target.go
+++ b/ucm/config/mutator/select_target.go
@@ -1,0 +1,50 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+)
+
+type selectTarget struct {
+	name string
+}
+
+// SelectTarget merges the named target into the root configuration and
+// records the selection under u.Target + u.Config.Ucm.Target.
+func SelectTarget(name string) ucm.Mutator {
+	return &selectTarget{name: name}
+}
+
+func (m *selectTarget) Name() string {
+	return fmt.Sprintf("SelectTarget(%s)", m.name)
+}
+
+func (m *selectTarget) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	if u.Config.Targets == nil {
+		return diag.Errorf("no targets defined")
+	}
+
+	target, ok := u.Config.Targets[m.name]
+	if !ok {
+		available := slices.Collect(maps.Keys(u.Config.Targets))
+		return diag.Errorf("%s: no such target. Available targets: %s", m.name, strings.Join(available, ", "))
+	}
+
+	if err := u.Config.MergeTargetOverrides(m.name); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to perform target override for target=%s: %w", m.name, err))
+	}
+
+	u.Target = target
+	u.Config.Ucm.Target = m.name
+
+	// Drop the raw targets block from the merged tree so it doesn't appear
+	// twice in validate/summary output.
+	u.Config.Targets = nil
+	return nil
+}

--- a/ucm/config/mutator/select_target_test.go
+++ b/ucm/config/mutator/select_target_test.go
@@ -1,0 +1,102 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectTarget_MergesOverrides(t *testing.T) {
+	_, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+workspace:
+  host: https://default.example.com
+resources:
+  catalogs:
+    base:
+      name: base
+targets:
+  dev:
+    workspace:
+      host: https://dev.example.com
+    resources:
+      catalogs:
+        dev_only:
+          name: dev_only
+`))
+	require.NoError(t, diags.Error())
+
+	u := &ucm.Ucm{}
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+workspace:
+  host: https://default.example.com
+resources:
+  catalogs:
+    base:
+      name: base
+targets:
+  dev:
+    workspace:
+      host: https://dev.example.com
+    resources:
+      catalogs:
+        dev_only:
+          name: dev_only
+`))
+	require.NoError(t, diags.Error())
+	u.Config = *cfg
+
+	diags = ucm.Apply(t.Context(), u, mutator.SelectTarget("dev"))
+	require.NoError(t, diags.Error())
+
+	assert.Equal(t, "dev", u.Config.Ucm.Target)
+	assert.Equal(t, "https://dev.example.com", u.Config.Workspace.Host)
+	assert.Contains(t, u.Config.Resources.Catalogs, "base")
+	assert.Contains(t, u.Config.Resources.Catalogs, "dev_only")
+	assert.Nil(t, u.Config.Targets) // cleared post-merge
+}
+
+func TestSelectTarget_MissingTargetFails(t *testing.T) {
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Targets: map[string]*config.Target{"dev": {}},
+		},
+	}
+	diags := ucm.Apply(t.Context(), u, mutator.SelectTarget("prod"))
+	require.Error(t, diags.Error())
+	assert.Contains(t, diags.Error().Error(), "no such target")
+}
+
+func TestSelectTarget_NoTargetsFails(t *testing.T) {
+	u := &ucm.Ucm{}
+	diags := ucm.Apply(t.Context(), u, mutator.SelectTarget("dev"))
+	require.Error(t, diags.Error())
+}
+
+// Guard that u.Target is populated after the merge (value equality — pointer
+// identity is lost because the dyn/typed round-trip during MarkMutatorEntry
+// rebuilds the map).
+func TestSelectTarget_RecordsTargetSnapshot(t *testing.T) {
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Ucm: config.Ucm{Name: "acme"},
+			Resources: config.Resources{
+				Catalogs: map[string]*resources.Catalog{"base": {Name: "base"}},
+			},
+			Targets: map[string]*config.Target{"dev": {Default: true}},
+		},
+	}
+	diags := ucm.Apply(t.Context(), u, mutator.SelectTarget("dev"))
+	require.NoError(t, diags.Error())
+
+	require.NotNil(t, u.Target)
+	assert.True(t, u.Target.Default)
+}

--- a/ucm/config/mutator/validate_tags.go
+++ b/ucm/config/mutator/validate_tags.go
@@ -1,0 +1,167 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/resources"
+)
+
+type validateTags struct{}
+
+// ValidateTags enforces every resources.tag_validation_rules.* entry against
+// every matching securable in the resources tree.
+//
+// For each rule + matching securable:
+//   - every key in Required must be present on the securable's `tags` map
+//   - if the rule sets AllowedValues for a key, the tag value (when present)
+//     must be a member
+//
+// Emits error-level diagnostics with source-location info pointing at the
+// offending securable, so editor integrations can jump to the right spot.
+//
+// No dependency on UC's server-side tag policy — this is ucm's own gate,
+// run during `validate`, `plan`, and `policy-check`.
+func ValidateTags() ucm.Mutator { return &validateTags{} }
+
+func (m *validateTags) Name() string { return "ValidateTags" }
+
+// securableFieldsToKind maps the Resources struct field (as it appears under
+// `resources:` in ucm.yml) to the rule's `securable_types` token.
+var securableFieldsToKind = map[string]string{
+	"catalogs": "catalog",
+	"schemas":  "schema",
+}
+
+func (m *validateTags) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	rules := u.Config.Resources.TagValidationRules
+	if len(rules) == 0 {
+		return nil
+	}
+
+	ruleNames := sortedKeys(rules)
+
+	var diags diag.Diagnostics
+	for _, field := range []string{"catalogs", "schemas"} {
+		kind := securableFieldsToKind[field]
+		for _, resourceName := range securableNames(u, field) {
+			tags := securableTags(u, field, resourceName)
+			for _, ruleName := range ruleNames {
+				rule := rules[ruleName]
+				if rule == nil || !slices.Contains(rule.SecurableTypes, kind) {
+					continue
+				}
+				diags = append(diags, evaluateRule(u, field, resourceName, tags, ruleName, rule)...)
+			}
+		}
+	}
+	return diags
+}
+
+func evaluateRule(
+	u *ucm.Ucm,
+	field, resourceName string,
+	tags map[string]string,
+	ruleName string,
+	rule *resources.TagValidationRule,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	tagsPath := dyn.NewPath(
+		dyn.Key("resources"),
+		dyn.Key(field),
+		dyn.Key(resourceName),
+		dyn.Key("tags"),
+	)
+
+	for _, key := range sortedStrings(rule.Required) {
+		if _, ok := tags[key]; !ok {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"tag-validation-rule %q requires tag %q on %s %q",
+					ruleName, key, securableFieldsToKind[field], resourceName,
+				),
+				Paths:     []dyn.Path{tagsPath},
+				Locations: locations(u, tagsPath),
+			})
+		}
+	}
+
+	for _, key := range sortedKeys(rule.AllowedValues) {
+		allowed := rule.AllowedValues[key]
+		value, ok := tags[key]
+		if !ok {
+			continue
+		}
+		if !slices.Contains(allowed, value) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"tag-validation-rule %q: %s %q tag %q=%q is not in allowed values %v",
+					ruleName, securableFieldsToKind[field], resourceName, key, value, allowed,
+				),
+				Paths:     []dyn.Path{tagsPath.Append(dyn.Key(key))},
+				Locations: locations(u, tagsPath.Append(dyn.Key(key))),
+			})
+		}
+	}
+
+	return diags
+}
+
+func securableNames(u *ucm.Ucm, field string) []string {
+	switch field {
+	case "catalogs":
+		return sortedKeys(u.Config.Resources.Catalogs)
+	case "schemas":
+		return sortedKeys(u.Config.Resources.Schemas)
+	}
+	return nil
+}
+
+func securableTags(u *ucm.Ucm, field, name string) map[string]string {
+	switch field {
+	case "catalogs":
+		if c := u.Config.Resources.Catalogs[name]; c != nil {
+			return c.Tags
+		}
+	case "schemas":
+		if s := u.Config.Resources.Schemas[name]; s != nil {
+			return s.Tags
+		}
+	}
+	return nil
+}
+
+func locations(u *ucm.Ucm, p dyn.Path) []dyn.Location {
+	v, err := dyn.GetByPath(u.Config.Value(), p)
+	if err != nil {
+		return nil
+	}
+	loc := v.Location()
+	if loc.File == "" && loc.Line == 0 {
+		return nil
+	}
+	return []dyn.Location{loc}
+}
+
+func sortedStrings(in []string) []string {
+	out := slices.Clone(in)
+	sort.Strings(out)
+	return out
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/ucm/config/mutator/validate_tags_test.go
+++ b/ucm/config/mutator/validate_tags_test.go
@@ -1,0 +1,177 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadUcm parses raw YAML and returns a fresh Ucm backed by it.
+func loadUcm(t *testing.T, yaml string) *ucm.Ucm {
+	t.Helper()
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(yaml))
+	require.NoError(t, diags.Error())
+	return &ucm.Ucm{Config: *cfg}
+}
+
+func summaries(ds diag.Diagnostics) []string {
+	out := make([]string, 0, len(ds))
+	for _, d := range ds {
+		out = append(out, d.Summary)
+	}
+	return out
+}
+
+func TestValidateTags_AllTagsPresent(t *testing.T) {
+	u := loadUcm(t, `
+ucm:
+  name: acme
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal
+  tag_validation_rules:
+    r:
+      securable_types: [catalog]
+      required: [cost_center, data_owner, classification]
+      allowed_values:
+        classification: [public, internal, confidential]
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ValidateTags())
+	require.NoError(t, diags.Error())
+	assert.Empty(t, diags)
+}
+
+func TestValidateTags_MissingRequired(t *testing.T) {
+	u := loadUcm(t, `
+ucm:
+  name: acme
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags:
+        cost_center: "1234"
+  tag_validation_rules:
+    r:
+      securable_types: [catalog]
+      required: [cost_center, data_owner, classification]
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ValidateTags())
+	require.Error(t, diags.Error())
+	assert.Len(t, diags, 2) // data_owner + classification
+	for _, d := range diags {
+		assert.Equal(t, diag.Error, d.Severity)
+	}
+	assert.Contains(t, summaries(diags)[0], "classification")
+	assert.Contains(t, summaries(diags)[1], "data_owner")
+}
+
+func TestValidateTags_DisallowedValue(t *testing.T) {
+	u := loadUcm(t, `
+ucm:
+  name: acme
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: bogus
+  tag_validation_rules:
+    r:
+      securable_types: [catalog]
+      required: [cost_center, data_owner, classification]
+      allowed_values:
+        classification: [public, internal, confidential]
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ValidateTags())
+	require.Error(t, diags.Error())
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, "not in allowed values")
+}
+
+func TestValidateTags_SchemaSecurable(t *testing.T) {
+	u := loadUcm(t, `
+ucm:
+  name: acme
+resources:
+  schemas:
+    s1:
+      name: s1
+      catalog: c1
+      # missing all required tags
+  tag_validation_rules:
+    r:
+      securable_types: [schema]
+      required: [data_owner]
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ValidateTags())
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, `schema "s1"`)
+}
+
+// Catalogs of a type excluded from the rule must not be flagged.
+func TestValidateTags_SecurableTypeFilter(t *testing.T) {
+	u := loadUcm(t, `
+ucm:
+  name: acme
+resources:
+  catalogs:
+    c1:
+      name: c1
+      # no tags, but rule only applies to schemas
+  tag_validation_rules:
+    r:
+      securable_types: [schema]
+      required: [data_owner]
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ValidateTags())
+	assert.Empty(t, diags)
+}
+
+func TestValidateTags_NoRulesIsNoop(t *testing.T) {
+	u := loadUcm(t, `
+ucm:
+  name: acme
+resources:
+  catalogs:
+    c1:
+      name: c1
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ValidateTags())
+	assert.Empty(t, diags)
+}
+
+// Diagnostics must carry source locations pointing at the securable's tags
+// map — this is what makes the errors jump-to-definition in editors.
+func TestValidateTags_DiagnosticLocations(t *testing.T) {
+	u := loadUcm(t, `
+ucm:
+  name: acme
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags:
+        cost_center: "1234"
+  tag_validation_rules:
+    r:
+      securable_types: [catalog]
+      required: [data_owner]
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ValidateTags())
+	require.Len(t, diags, 1)
+	require.NotEmpty(t, diags[0].Locations)
+	assert.Equal(t, "/test/ucm.yml", diags[0].Locations[0].File)
+}

--- a/ucm/config/resources.go
+++ b/ucm/config/resources.go
@@ -1,0 +1,13 @@
+package config
+
+import "github.com/databricks/cli/ucm/config/resources"
+
+// Resources is the top-level container for every UC and cloud-underlay
+// resource declared in ucm.yml. For M0 only a minimal UC-native subset is
+// supported; cloud resources (S3/ADLS/GCS, IAM/MI/SA, KMS) land in M2.
+type Resources struct {
+	Catalogs            map[string]*resources.Catalog           `json:"catalogs,omitempty"`
+	Schemas             map[string]*resources.Schema            `json:"schemas,omitempty"`
+	Grants              map[string]*resources.Grant             `json:"grants,omitempty"`
+	TagValidationRules  map[string]*resources.TagValidationRule `json:"tag_validation_rules,omitempty"`
+}

--- a/ucm/config/resources/catalog.go
+++ b/ucm/config/resources/catalog.go
@@ -1,0 +1,18 @@
+package resources
+
+// Catalog is a UC catalog. M0 scope: name, comment, storage_root, tags.
+// Additional fields (owner, properties, isolation_mode, etc.) will land in M1.
+type Catalog struct {
+	// Name of the catalog in Unity Catalog. Required.
+	Name string `json:"name"`
+
+	// Comment is a human-readable description.
+	Comment string `json:"comment,omitempty"`
+
+	// StorageRoot is the cloud storage URL backing the catalog (optional for
+	// managed catalogs without an explicit storage root).
+	StorageRoot string `json:"storage_root,omitempty"`
+
+	// Tags is a key/value map evaluated by ucm's tag-validation mutators.
+	Tags map[string]string `json:"tags,omitempty"`
+}

--- a/ucm/config/resources/grant.go
+++ b/ucm/config/resources/grant.go
@@ -1,0 +1,23 @@
+package resources
+
+// Securable identifies a UC object that a grant applies to.
+type Securable struct {
+	// Type of the securable (catalog, schema, table, volume, external_location, ...).
+	Type string `json:"type"`
+
+	// Name of the securable.
+	Name string `json:"name"`
+}
+
+// Grant assigns privileges on a securable to a principal.
+type Grant struct {
+	// Securable is the object receiving the grant.
+	Securable Securable `json:"securable"`
+
+	// Principal is the UC/account-level principal (user, group, SP) name.
+	Principal string `json:"principal"`
+
+	// Privileges is the list of UC privileges being granted
+	// (e.g., USE_CATALOG, USE_SCHEMA, SELECT, MODIFY).
+	Privileges []string `json:"privileges"`
+}

--- a/ucm/config/resources/schema.go
+++ b/ucm/config/resources/schema.go
@@ -1,0 +1,17 @@
+package resources
+
+// Schema is a UC schema (a.k.a. database) nested inside a catalog.
+type Schema struct {
+	// Name of the schema. Required.
+	Name string `json:"name"`
+
+	// Catalog is the name of the parent catalog. Required.
+	// In M1 this becomes interpolatable via ${resources.catalogs.X.name}.
+	Catalog string `json:"catalog"`
+
+	// Comment is a human-readable description.
+	Comment string `json:"comment,omitempty"`
+
+	// Tags is a key/value map evaluated by ucm's tag-validation mutators.
+	Tags map[string]string `json:"tags,omitempty"`
+}

--- a/ucm/config/resources/tag_validation_rule.go
+++ b/ucm/config/resources/tag_validation_rule.go
@@ -1,0 +1,21 @@
+package resources
+
+// TagValidationRule declares required tag keys (and optionally allowed values)
+// for a set of securable types. Enforced by ucm/config/mutator.ValidateTags
+// during `validate`, `plan`, and `policy-check`.
+//
+// Note: this is ucm's own policy engine, independent of any server-side UC
+// tag-policy feature.
+type TagValidationRule struct {
+	// SecurableTypes selects which resource kinds this rule applies to
+	// (e.g., ["catalog", "schema"]). M0 supports "catalog" and "schema".
+	SecurableTypes []string `json:"securable_types"`
+
+	// Required is the list of tag keys that must be present on every matching
+	// securable.
+	Required []string `json:"required,omitempty"`
+
+	// AllowedValues restricts the values a given tag key may take. If a key is
+	// not present here, any value is allowed.
+	AllowedValues map[string][]string `json:"allowed_values,omitempty"`
+}

--- a/ucm/config/root.go
+++ b/ucm/config/root.go
@@ -1,0 +1,201 @@
+// Package config holds the typed and dynamic configuration tree for a ucm
+// deployment. Mirrors the shape of bundle/config but targets Unity Catalog.
+package config
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/libs/dyn/merge"
+	"github.com/databricks/cli/libs/dyn/yamlloader"
+	"github.com/databricks/cli/libs/log"
+)
+
+// Root is the root of the ucm.yml configuration tree.
+//
+// The shape intentionally mirrors bundle.config.Root: a private dyn.Value
+// holds the normalized dynamic tree, and the typed fields are re-derived from
+// it across every mutator apply via MarkMutatorEntry/Exit. This keeps location
+// information and interpolation (landing in M1) cheap.
+type Root struct {
+	value dyn.Value
+	depth int
+
+	Ucm Ucm `json:"ucm"`
+
+	Workspace Workspace `json:"workspace,omitempty"`
+	Account   Account   `json:"account,omitempty"`
+
+	Resources Resources `json:"resources,omitempty"`
+
+	// Targets is set to nil by SelectTarget once a target has been merged.
+	Targets map[string]*Target `json:"targets,omitempty"`
+}
+
+// Load reads a ucm.yml file from disk.
+func Load(path string) (*Root, diag.Diagnostics) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+	return LoadFromBytes(path, raw)
+}
+
+// LoadFromBytes parses raw YAML bytes into a Root. `path` is only used for
+// diagnostic source locations.
+func LoadFromBytes(path string, raw []byte) (*Root, diag.Diagnostics) {
+	r := Root{}
+
+	v, err := yamlloader.LoadYAML(path, bytes.NewBuffer(raw))
+	if err != nil {
+		return nil, diag.Errorf("failed to load %s: %v", path, err)
+	}
+
+	v, diags := convert.Normalize(r, v)
+
+	if err := r.updateWithDynamicValue(v); err != nil {
+		diags = diags.Extend(diag.Errorf("failed to load %s: %v", path, err))
+		return nil, diags
+	}
+	return &r, diags
+}
+
+// Value returns the current dynamic configuration tree.
+func (r *Root) Value() dyn.Value {
+	return r.value
+}
+
+func (r *Root) initializeDynamicValue() error {
+	if r.value.IsValid() {
+		return nil
+	}
+	nv, err := convert.FromTyped(r, dyn.NilValue)
+	if err != nil {
+		return err
+	}
+	r.value = nv
+	return nil
+}
+
+func (r *Root) updateWithDynamicValue(nv dyn.Value) error {
+	depth := r.depth
+	defer func() { r.depth = depth }()
+
+	if err := convert.ToTyped(r, nv); err != nil {
+		return err
+	}
+	r.value = nv
+	return nil
+}
+
+// Mutate applies fn to the dynamic configuration tree and re-syncs typed
+// fields.
+func (r *Root) Mutate(fn func(dyn.Value) (dyn.Value, error)) error {
+	if err := r.initializeDynamicValue(); err != nil {
+		return err
+	}
+	nv, err := fn(r.value)
+	if err != nil {
+		return err
+	}
+	return r.updateWithDynamicValue(nv)
+}
+
+// Merge folds another Root's dynamic tree into this one (used to load included
+// files in M1).
+func (r *Root) Merge(other *Root) error {
+	return r.Mutate(func(root dyn.Value) (dyn.Value, error) {
+		return merge.Merge(root, other.value)
+	})
+}
+
+// MarkMutatorEntry is invoked by ApplyContext before each mutator runs.
+// It keeps the dynamic and typed trees consistent across mutator boundaries.
+func (r *Root) MarkMutatorEntry(ctx context.Context) error {
+	if err := r.initializeDynamicValue(); err != nil {
+		return err
+	}
+	r.depth++
+
+	if r.depth == 1 {
+		if err := r.updateWithDynamicValue(r.value); err != nil {
+			log.Warnf(ctx, "unable to convert dynamic configuration to typed configuration: %v", err)
+			return err
+		}
+	} else {
+		nv, err := convert.FromTyped(r, r.value)
+		if err != nil {
+			log.Warnf(ctx, "unable to convert typed configuration to dynamic configuration: %v", err)
+			return err
+		}
+		if err := r.updateWithDynamicValue(nv); err != nil {
+			log.Warnf(ctx, "unable to convert dynamic configuration to typed configuration: %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// MarkMutatorExit is invoked by ApplyContext after each mutator runs.
+func (r *Root) MarkMutatorExit(ctx context.Context) error {
+	r.depth--
+	if r.depth == 0 {
+		nv, err := convert.FromTyped(r, r.value)
+		if err != nil {
+			log.Warnf(ctx, "unable to convert typed configuration to dynamic configuration: %v", err)
+			return err
+		}
+		if err := r.updateWithDynamicValue(nv); err != nil {
+			log.Warnf(ctx, "unable to convert dynamic configuration to typed configuration: %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func mergeField(rv, ov dyn.Value, name string) (dyn.Value, error) {
+	path := dyn.NewPath(dyn.Key(name))
+	reference, _ := dyn.GetByPath(rv, path)
+	override, _ := dyn.GetByPath(ov, path)
+
+	var out dyn.Value
+	var err error
+	switch {
+	case reference.IsValid() && override.IsValid():
+		out, err = merge.Merge(reference, override)
+		if err != nil {
+			return dyn.InvalidValue, err
+		}
+	case reference.IsValid():
+		out = reference
+	case override.IsValid():
+		out = override
+	default:
+		return rv, nil
+	}
+	return dyn.SetByPath(rv, path, out)
+}
+
+// MergeTargetOverrides merges the named target's overrides into the root
+// configuration. Fields that should be overwritten (not deep-merged) are
+// handled explicitly.
+func (r *Root) MergeTargetOverrides(name string) error {
+	root := r.value
+	target, err := dyn.GetByPath(root, dyn.NewPath(dyn.Key("targets"), dyn.Key(name)))
+	if err != nil {
+		return err
+	}
+
+	for _, f := range []string{"workspace", "account", "resources"} {
+		if root, err = mergeField(root, target, f); err != nil {
+			return fmt.Errorf("failed to merge target=%s field=%s: %w", name, f, err)
+		}
+	}
+
+	return r.updateWithDynamicValue(root)
+}

--- a/ucm/config/root_test.go
+++ b/ucm/config/root_test.go
@@ -1,0 +1,102 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFromBytes_MinimalUcm(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+`))
+	require.NoError(t, diags.Error())
+	assert.Equal(t, "acme", cfg.Ucm.Name)
+}
+
+func TestLoadFromBytes_FullM0Surface(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+account:
+  account_id: 0000-0000
+  host: https://accounts.cloud.databricks.com
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      comment: alpha catalog
+      tags:
+        cost_center: "1234"
+  schemas:
+    bronze:
+      catalog: team_alpha
+      name: bronze
+  grants:
+    reads:
+      securable: { type: catalog, name: team_alpha }
+      principal: alpha-readers
+      privileges: [USE_CATALOG, SELECT]
+  tag_validation_rules:
+    r:
+      securable_types: [catalog]
+      required: [cost_center]
+
+targets:
+  dev:
+    default: true
+  prod:
+    workspace:
+      host: https://prod.example.com
+`))
+	require.NoError(t, diags.Error())
+
+	assert.Equal(t, "https://example.cloud.databricks.com", cfg.Workspace.Host)
+	assert.Equal(t, "0000-0000", cfg.Account.AccountId)
+
+	require.Contains(t, cfg.Resources.Catalogs, "team_alpha")
+	assert.Equal(t, "team_alpha", cfg.Resources.Catalogs["team_alpha"].Name)
+	assert.Equal(t, "1234", cfg.Resources.Catalogs["team_alpha"].Tags["cost_center"])
+
+	require.Contains(t, cfg.Resources.Schemas, "bronze")
+	assert.Equal(t, "team_alpha", cfg.Resources.Schemas["bronze"].Catalog)
+
+	require.Contains(t, cfg.Resources.Grants, "reads")
+	assert.Equal(t, "catalog", cfg.Resources.Grants["reads"].Securable.Type)
+	assert.Equal(t, []string{"USE_CATALOG", "SELECT"}, cfg.Resources.Grants["reads"].Privileges)
+
+	require.Contains(t, cfg.Resources.TagValidationRules, "r")
+
+	require.Contains(t, cfg.Targets, "dev")
+	assert.True(t, cfg.Targets["dev"].Default)
+}
+
+func TestLoadFromBytes_InvalidYAML(t *testing.T) {
+	_, diags := config.LoadFromBytes("/test/ucm.yml", []byte("this:\n  is: [unterminated"))
+	require.Error(t, diags.Error())
+}
+
+func TestMergeTargetOverrides_WorkspaceHost(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+workspace:
+  host: https://base.example.com
+targets:
+  prod:
+    workspace:
+      host: https://prod.example.com
+`))
+	require.NoError(t, diags.Error())
+
+	require.NoError(t, cfg.MergeTargetOverrides("prod"))
+	assert.Equal(t, "https://prod.example.com", cfg.Workspace.Host)
+}

--- a/ucm/config/target.go
+++ b/ucm/config/target.go
@@ -1,0 +1,13 @@
+package config
+
+// Target defines overrides for a single deployment target (dev/staging/prod
+// or any user-chosen name). Merged into Root when SelectTarget runs.
+type Target struct {
+	// Default marks this target as the one to select when the user does not
+	// pass --target.
+	Default bool `json:"default,omitempty"`
+
+	Workspace *Workspace `json:"workspace,omitempty"`
+	Account   *Account   `json:"account,omitempty"`
+	Resources *Resources `json:"resources,omitempty"`
+}

--- a/ucm/config/ucm.go
+++ b/ucm/config/ucm.go
@@ -1,0 +1,12 @@
+package config
+
+// Ucm holds top-level metadata about a ucm deployment (parallel to
+// bundle.Bundle in DAB).
+type Ucm struct {
+	// Name uniquely identifies this ucm deployment.
+	Name string `json:"name"`
+
+	// Target records which target is currently selected. It is populated
+	// by the SelectTarget mutator; users do not set it in ucm.yml.
+	Target string `json:"target,omitempty" bundle:"readonly"`
+}

--- a/ucm/config/workspace.go
+++ b/ucm/config/workspace.go
@@ -1,0 +1,10 @@
+package config
+
+// Workspace describes a Databricks workspace that ucm targets.
+//
+// M0 holds only the host URL. Auth wiring (OAuth M2M client id/secret,
+// account id, profile resolution) lands in M1 along with the real deploy
+// path.
+type Workspace struct {
+	Host string `json:"host,omitempty"`
+}

--- a/ucm/deploy/terraform/tfdyn/convert_catalog.go
+++ b/ucm/deploy/terraform/tfdyn/convert_catalog.go
@@ -1,0 +1,49 @@
+package tfdyn
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+// convertCatalogResource transforms a ucm catalog entry into a dyn.Value
+// shaped like the databricks_catalog Terraform resource.
+//
+// The mapping is intentionally narrow (M0 fields only): name, comment,
+// storage_root, and tags-as-properties. force_destroy is always set so ucm
+// can manage the catalog's lifecycle through terraform.
+func convertCatalogResource(_ context.Context, key string, vin dyn.Value) (dyn.Value, error) {
+	pairs := []dyn.Pair{}
+	appendString(&pairs, vin, "name", key)
+	appendStringIfSet(&pairs, vin, "comment")
+	appendStringIfSet(&pairs, vin, "storage_root")
+
+	if tags, ok := mapFromValue(vin.Get("tags")); ok {
+		pairs = append(pairs, dyn.Pair{
+			Key:   dyn.NewValue("properties", vin.Get("tags").Locations()),
+			Value: tags,
+		})
+	}
+
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.V("force_destroy"),
+		Value: dyn.V(true),
+	})
+
+	return dyn.NewValue(dyn.NewMappingFromPairs(pairs), vin.Locations()), nil
+}
+
+type catalogConverter struct{}
+
+func (catalogConverter) Convert(ctx context.Context, key string, vin dyn.Value, out *Resources) error {
+	v, err := convertCatalogResource(ctx, key, vin)
+	if err != nil {
+		return err
+	}
+	out.Catalog[key] = v
+	return nil
+}
+
+func init() {
+	registerConverter("catalogs", catalogConverter{})
+}

--- a/ucm/deploy/terraform/tfdyn/convert_catalog_test.go
+++ b/ucm/deploy/terraform/tfdyn/convert_catalog_test.go
@@ -1,0 +1,85 @@
+package tfdyn
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertCatalog(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		src  resources.Catalog
+		want map[string]any
+	}{
+		{
+			name: "minimal",
+			key:  "sales",
+			src:  resources.Catalog{Name: "sales_prod"},
+			want: map[string]any{
+				"name":          "sales_prod",
+				"force_destroy": true,
+			},
+		},
+		{
+			name: "with comment and storage root",
+			key:  "sales",
+			src: resources.Catalog{
+				Name:        "sales_prod",
+				Comment:     "Sales team catalog",
+				StorageRoot: "s3://bucket/root",
+			},
+			want: map[string]any{
+				"name":          "sales_prod",
+				"comment":       "Sales team catalog",
+				"storage_root":  "s3://bucket/root",
+				"force_destroy": true,
+			},
+		},
+		{
+			name: "with tags -> properties",
+			key:  "sales",
+			src: resources.Catalog{
+				Name: "sales_prod",
+				Tags: map[string]string{"team": "sales", "env": "prod"},
+			},
+			want: map[string]any{
+				"name": "sales_prod",
+				"properties": map[string]any{
+					"team": "sales",
+					"env":  "prod",
+				},
+				"force_destroy": true,
+			},
+		},
+		{
+			name: "defaults name from key when missing",
+			key:  "analytics",
+			src:  resources.Catalog{},
+			want: map[string]any{
+				"name":          "analytics",
+				"force_destroy": true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+
+			out := NewResources()
+			err = catalogConverter{}.Convert(t.Context(), tc.key, vin, out)
+			require.NoError(t, err)
+
+			got, ok := out.Catalog[tc.key]
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got.AsAny())
+		})
+	}
+}

--- a/ucm/deploy/terraform/tfdyn/convert_grant.go
+++ b/ucm/deploy/terraform/tfdyn/convert_grant.go
@@ -1,0 +1,99 @@
+package tfdyn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+// securableField maps a ucm securable type token to the field name on the
+// databricks_grants Terraform resource. Only catalog and schema are in M0;
+// volumes/external_locations/storage_credentials land in M2.
+var securableField = map[string]string{
+	"catalog": "catalog",
+	"schema":  "schema",
+}
+
+// convertGrantResource emits a databricks_grants block for a single ucm
+// grant entry. When the securable name matches a ucm-managed catalog or
+// schema the grant references it through a TF interpolation
+// (`${databricks_catalog.<key>.id}`) so terraform plans the dependency
+// edge; otherwise the literal name is emitted.
+func convertGrantResource(_ context.Context, vin dyn.Value, out *Resources) (dyn.Value, error) {
+	secVal := vin.Get("securable")
+	kindVal := secVal.Get("type")
+	nameVal := secVal.Get("name")
+
+	kind, _ := kindVal.AsString()
+	name, _ := nameVal.AsString()
+
+	field, ok := securableField[kind]
+	if !ok {
+		return dyn.InvalidValue, fmt.Errorf("unsupported securable type %q (M0 supports catalog, schema)", kind)
+	}
+
+	reference := name
+	dependsOn := []dyn.Value{}
+	switch field {
+	case "catalog":
+		if _, managed := out.Catalog[name]; managed {
+			reference = fmt.Sprintf("${databricks_catalog.%s.name}", name)
+			dependsOn = append(dependsOn, dyn.V("databricks_catalog."+name))
+		}
+	case "schema":
+		if _, managed := out.Schema[name]; managed {
+			reference = fmt.Sprintf("${databricks_schema.%s.id}", name)
+			dependsOn = append(dependsOn, dyn.V("databricks_schema."+name))
+		}
+	}
+
+	principalVal := vin.Get("principal")
+	privilegesVal := vin.Get("privileges")
+
+	grantEntry := dyn.NewValue(dyn.NewMappingFromPairs([]dyn.Pair{
+		{
+			Key:   dyn.NewValue("principal", principalVal.Locations()),
+			Value: principalVal,
+		},
+		{
+			Key:   dyn.NewValue("privileges", privilegesVal.Locations()),
+			Value: privilegesVal,
+		},
+	}), vin.Locations())
+
+	pairs := []dyn.Pair{
+		{
+			Key:   dyn.NewValue(field, nameVal.Locations()),
+			Value: dyn.NewValue(reference, nameVal.Locations()),
+		},
+		{
+			Key:   dyn.V("grant"),
+			Value: dyn.V([]dyn.Value{grantEntry}),
+		},
+	}
+
+	if len(dependsOn) > 0 {
+		pairs = append(pairs, dyn.Pair{
+			Key:   dyn.V("depends_on"),
+			Value: dyn.V(dependsOn),
+		})
+	}
+
+	return dyn.NewValue(dyn.NewMappingFromPairs(pairs), vin.Locations()), nil
+}
+
+type grantConverter struct{}
+
+func (grantConverter) Convert(ctx context.Context, key string, vin dyn.Value, out *Resources) error {
+	v, err := convertGrantResource(ctx, vin, out)
+	if err != nil {
+		return fmt.Errorf("grant %q: %w", key, err)
+	}
+	out.Grants[key] = v
+	return nil
+}
+
+func init() {
+	registerConverter("grants", grantConverter{})
+}

--- a/ucm/deploy/terraform/tfdyn/convert_grant_test.go
+++ b/ucm/deploy/terraform/tfdyn/convert_grant_test.go
@@ -1,0 +1,116 @@
+package tfdyn
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertGrant(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		src     resources.Grant
+		managed func(*Resources)
+		want    map[string]any
+	}{
+		{
+			name: "grant on external catalog",
+			key:  "sales_admins",
+			src: resources.Grant{
+				Securable:  resources.Securable{Type: "catalog", Name: "external_cat"},
+				Principal:  "sales-admins",
+				Privileges: []string{"USE_CATALOG"},
+			},
+			want: map[string]any{
+				"catalog": "external_cat",
+				"grant": []any{
+					map[string]any{
+						"principal":  "sales-admins",
+						"privileges": []any{"USE_CATALOG"},
+					},
+				},
+			},
+		},
+		{
+			name: "grant on managed catalog emits depends_on and interpolation",
+			key:  "sales_admins",
+			src: resources.Grant{
+				Securable:  resources.Securable{Type: "catalog", Name: "sales"},
+				Principal:  "sales-admins",
+				Privileges: []string{"USE_CATALOG", "SELECT"},
+			},
+			managed: func(r *Resources) {
+				r.Catalog["sales"] = dyn.V("placeholder")
+			},
+			want: map[string]any{
+				"catalog": "${databricks_catalog.sales.name}",
+				"grant": []any{
+					map[string]any{
+						"principal":  "sales-admins",
+						"privileges": []any{"USE_CATALOG", "SELECT"},
+					},
+				},
+				"depends_on": []any{"databricks_catalog.sales"},
+			},
+		},
+		{
+			name: "grant on managed schema",
+			key:  "analytics_readers",
+			src: resources.Grant{
+				Securable:  resources.Securable{Type: "schema", Name: "raw"},
+				Principal:  "analysts",
+				Privileges: []string{"USE_SCHEMA"},
+			},
+			managed: func(r *Resources) {
+				r.Schema["raw"] = dyn.V("placeholder")
+			},
+			want: map[string]any{
+				"schema": "${databricks_schema.raw.id}",
+				"grant": []any{
+					map[string]any{
+						"principal":  "analysts",
+						"privileges": []any{"USE_SCHEMA"},
+					},
+				},
+				"depends_on": []any{"databricks_schema.raw"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+
+			out := NewResources()
+			if tc.managed != nil {
+				tc.managed(out)
+			}
+			err = grantConverter{}.Convert(t.Context(), tc.key, vin, out)
+			require.NoError(t, err)
+
+			got, ok := out.Grants[tc.key]
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got.AsAny())
+		})
+	}
+}
+
+func TestConvertGrantUnsupportedSecurable(t *testing.T) {
+	src := resources.Grant{
+		Securable:  resources.Securable{Type: "volume", Name: "v1"},
+		Principal:  "x",
+		Privileges: []string{"READ_VOLUME"},
+	}
+	vin, err := convert.FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
+
+	out := NewResources()
+	err = grantConverter{}.Convert(t.Context(), "vol_grant", vin, out)
+	require.ErrorContains(t, err, `unsupported securable type "volume"`)
+}

--- a/ucm/deploy/terraform/tfdyn/convert_schema.go
+++ b/ucm/deploy/terraform/tfdyn/convert_schema.go
@@ -1,0 +1,65 @@
+package tfdyn
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+// convertSchemaResource shapes a ucm schema entry like a databricks_schema
+// Terraform resource. When the parent catalog is a ucm-managed resource
+// (i.e. a key present on out.Catalog) the emitted block carries a
+// depends_on entry pointing at the catalog so terraform orders the graph
+// correctly; free-form catalog names bypass the depends_on because no
+// ucm-managed dependency exists.
+func convertSchemaResource(_ context.Context, key string, vin dyn.Value, out *Resources) (dyn.Value, error) {
+	pairs := []dyn.Pair{}
+	appendString(&pairs, vin, "name", key)
+
+	catalogField := vin.Get("catalog")
+	catalogName, _ := catalogField.AsString()
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.NewValue("catalog_name", catalogField.Locations()),
+		Value: dyn.NewValue(catalogName, catalogField.Locations()),
+	})
+
+	appendStringIfSet(&pairs, vin, "comment")
+
+	if tags, ok := mapFromValue(vin.Get("tags")); ok {
+		pairs = append(pairs, dyn.Pair{
+			Key:   dyn.NewValue("properties", vin.Get("tags").Locations()),
+			Value: tags,
+		})
+	}
+
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.V("force_destroy"),
+		Value: dyn.V(true),
+	})
+
+	if _, managed := out.Catalog[catalogName]; managed {
+		pairs = append(pairs, dyn.Pair{
+			Key: dyn.V("depends_on"),
+			Value: dyn.V([]dyn.Value{
+				dyn.V("databricks_catalog." + catalogName),
+			}),
+		})
+	}
+
+	return dyn.NewValue(dyn.NewMappingFromPairs(pairs), vin.Locations()), nil
+}
+
+type schemaConverter struct{}
+
+func (schemaConverter) Convert(ctx context.Context, key string, vin dyn.Value, out *Resources) error {
+	v, err := convertSchemaResource(ctx, key, vin, out)
+	if err != nil {
+		return err
+	}
+	out.Schema[key] = v
+	return nil
+}
+
+func init() {
+	registerConverter("schemas", schemaConverter{})
+}

--- a/ucm/deploy/terraform/tfdyn/convert_schema_test.go
+++ b/ucm/deploy/terraform/tfdyn/convert_schema_test.go
@@ -1,0 +1,80 @@
+package tfdyn
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertSchema(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		src     resources.Schema
+		managed map[string]struct{}
+		want    map[string]any
+	}{
+		{
+			name: "minimal external catalog",
+			key:  "raw",
+			src:  resources.Schema{Name: "raw", Catalog: "external_catalog"},
+			want: map[string]any{
+				"name":          "raw",
+				"catalog_name":  "external_catalog",
+				"force_destroy": true,
+			},
+		},
+		{
+			name:    "managed catalog emits depends_on",
+			key:     "raw",
+			src:     resources.Schema{Name: "raw_data", Catalog: "sales"},
+			managed: map[string]struct{}{"sales": {}},
+			want: map[string]any{
+				"name":          "raw_data",
+				"catalog_name":  "sales",
+				"force_destroy": true,
+				"depends_on":    []any{"databricks_catalog.sales"},
+			},
+		},
+		{
+			name: "with comment and tags",
+			key:  "analytics",
+			src: resources.Schema{
+				Name:    "analytics",
+				Catalog: "ext",
+				Comment: "analytics schema",
+				Tags:    map[string]string{"owner": "data"},
+			},
+			want: map[string]any{
+				"name":          "analytics",
+				"catalog_name":  "ext",
+				"comment":       "analytics schema",
+				"properties":    map[string]any{"owner": "data"},
+				"force_destroy": true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+
+			out := NewResources()
+			for k := range tc.managed {
+				out.Catalog[k] = dyn.V("placeholder")
+			}
+
+			err = schemaConverter{}.Convert(t.Context(), tc.key, vin, out)
+			require.NoError(t, err)
+
+			got, ok := out.Schema[tc.key]
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got.AsAny())
+		})
+	}
+}

--- a/ucm/deploy/terraform/tfdyn/helpers.go
+++ b/ucm/deploy/terraform/tfdyn/helpers.go
@@ -1,0 +1,47 @@
+package tfdyn
+
+import "github.com/databricks/cli/libs/dyn"
+
+// appendString adds key=fallback to pairs when vin does not already define
+// the field. If vin sets the field, the caller's value wins and its
+// location is preserved.
+func appendString(pairs *[]dyn.Pair, vin dyn.Value, key, fallback string) {
+	v := vin.Get(key)
+	if s, ok := v.AsString(); ok && s != "" {
+		*pairs = append(*pairs, dyn.Pair{
+			Key:   dyn.NewValue(key, v.Locations()),
+			Value: v,
+		})
+		return
+	}
+	*pairs = append(*pairs, dyn.Pair{
+		Key:   dyn.V(key),
+		Value: dyn.V(fallback),
+	})
+}
+
+// appendStringIfSet appends key=vin[key] when the field is a non-empty
+// string. Missing or empty fields are skipped so the Terraform JSON does
+// not carry empty `"comment": ""` noise.
+func appendStringIfSet(pairs *[]dyn.Pair, vin dyn.Value, key string) {
+	v := vin.Get(key)
+	s, ok := v.AsString()
+	if !ok || s == "" {
+		return
+	}
+	*pairs = append(*pairs, dyn.Pair{
+		Key:   dyn.NewValue(key, v.Locations()),
+		Value: v,
+	})
+}
+
+// mapFromValue returns v as a map-typed dyn.Value when it holds at least
+// one key; otherwise the second return is false so callers can skip
+// emitting an empty map.
+func mapFromValue(v dyn.Value) (dyn.Value, bool) {
+	m, ok := v.AsMap()
+	if !ok || m.Len() == 0 {
+		return dyn.InvalidValue, false
+	}
+	return v, true
+}

--- a/ucm/deploy/terraform/tfdyn/registry.go
+++ b/ucm/deploy/terraform/tfdyn/registry.go
@@ -1,0 +1,52 @@
+// Package tfdyn converts a ucm configuration tree into the Terraform JSON
+// resource map consumed by the terraform wrapper in ucm/deploy/terraform.
+//
+// Each converter mirrors the shape of bundle/deploy/terraform/tfdyn but
+// emits dyn.Value trees directly rather than typed TF schema structs. This
+// keeps source-location metadata intact so downstream diagnostics can point
+// back to the originating ucm.yml span.
+package tfdyn
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+// Resources is the accumulated Terraform resource payload produced while
+// walking a ucm configuration. Each map is keyed by the resource key used in
+// ucm.yml. The wrapper in U5 combines these into a top-level `resource`
+// block.
+type Resources struct {
+	Catalog map[string]dyn.Value
+	Schema  map[string]dyn.Value
+	Grants  map[string]dyn.Value
+}
+
+// NewResources returns an empty Resources ready for converters to fill.
+func NewResources() *Resources {
+	return &Resources{
+		Catalog: map[string]dyn.Value{},
+		Schema:  map[string]dyn.Value{},
+		Grants:  map[string]dyn.Value{},
+	}
+}
+
+// Converter converts a single resource entry from the ucm tree into one or
+// more Terraform resource blocks on out.
+type Converter interface {
+	Convert(ctx context.Context, key string, vin dyn.Value, out *Resources) error
+}
+
+var converters = map[string]Converter{}
+
+// GetConverter returns the converter registered for the given ucm resource
+// kind ("catalogs", "schemas", "grants").
+func GetConverter(name string) (Converter, bool) {
+	c, ok := converters[name]
+	return c, ok
+}
+
+func registerConverter(name string, c Converter) {
+	converters[name] = c
+}

--- a/ucm/deploy/terraform/tfdyn/tfdyn.go
+++ b/ucm/deploy/terraform/tfdyn/tfdyn.go
@@ -1,0 +1,113 @@
+package tfdyn
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/ucm"
+)
+
+// convertOrder controls the order in which resource kinds are walked. The
+// ordering matters because downstream converters inspect earlier ones
+// (schemas look at Resources.Catalog to decide whether to emit depends_on;
+// grants look at Resources.Catalog and Resources.Schema).
+var convertOrder = []string{"catalogs", "schemas", "grants"}
+
+// Convert walks a ucm configuration and produces the Terraform JSON
+// resource tree suitable for writing as a .tf.json file. The returned
+// dyn.Value is shaped as:
+//
+//	{
+//	  "resource": {
+//	    "databricks_catalog": { "<key>": { ... } },
+//	    "databricks_schema":  { "<key>": { ... } },
+//	    "databricks_grants":  { "<key>": { ... } }
+//	  }
+//	}
+//
+// Empty resource kinds are omitted.
+func Convert(ctx context.Context, u *ucm.Ucm) (dyn.Value, error) {
+	out := NewResources()
+
+	resourcesVal, err := dyn.GetByPath(u.Config.Value(), dyn.NewPath(dyn.Key("resources")))
+	if err != nil {
+		// No resources: emit an empty terraform file rather than failing.
+		resourcesVal = dyn.V(map[string]dyn.Value{})
+	}
+
+	for _, kind := range convertOrder {
+		conv, ok := GetConverter(kind)
+		if !ok {
+			continue
+		}
+		bucket := resourcesVal.Get(kind)
+		if !bucket.IsValid() {
+			continue
+		}
+		m, ok := bucket.AsMap()
+		if !ok {
+			continue
+		}
+
+		keys := make([]string, 0, m.Len())
+		for _, p := range m.Pairs() {
+			keys = append(keys, p.Key.MustString())
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			vin, _ := m.GetByString(key)
+			if err := conv.Convert(ctx, key, vin, out); err != nil {
+				return dyn.InvalidValue, fmt.Errorf("convert %s.%s: %w", kind, key, err)
+			}
+		}
+	}
+
+	return buildResourceTree(out), nil
+}
+
+// buildResourceTree assembles the `{resource: {<tf_type>: {<key>: ...}}}`
+// dyn.Value from the per-kind maps produced by the converters.
+func buildResourceTree(out *Resources) dyn.Value {
+	blocks := []struct {
+		tfType string
+		values map[string]dyn.Value
+	}{
+		{"databricks_catalog", out.Catalog},
+		{"databricks_schema", out.Schema},
+		{"databricks_grants", out.Grants},
+	}
+
+	var resourcePairs []dyn.Pair
+	for _, b := range blocks {
+		if len(b.values) == 0 {
+			continue
+		}
+		keys := make([]string, 0, len(b.values))
+		for k := range b.values {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		pairs := make([]dyn.Pair, 0, len(keys))
+		for _, k := range keys {
+			pairs = append(pairs, dyn.Pair{
+				Key:   dyn.V(k),
+				Value: b.values[k],
+			})
+		}
+		resourcePairs = append(resourcePairs, dyn.Pair{
+			Key:   dyn.V(b.tfType),
+			Value: dyn.V(dyn.NewMappingFromPairs(pairs)),
+		})
+	}
+
+	return dyn.V(dyn.NewMappingFromPairs([]dyn.Pair{
+		{
+			Key:   dyn.V("resource"),
+			Value: dyn.V(dyn.NewMappingFromPairs(resourcePairs)),
+		},
+	}))
+}

--- a/ucm/deploy/terraform/tfdyn/tfdyn_test.go
+++ b/ucm/deploy/terraform/tfdyn/tfdyn_test.go
@@ -1,0 +1,112 @@
+package tfdyn
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvert_HappyPath(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+      comment: sales data
+  schemas:
+    raw:
+      name: raw
+      catalog: sales
+  grants:
+    sales_admins:
+      securable:
+        type: catalog
+        name: sales
+      principal: sales-admins
+      privileges: [USE_CATALOG]
+`))
+	require.False(t, diags.HasError(), "load diagnostics: %v", diags)
+
+	u := &ucm.Ucm{Config: *cfg}
+
+	got, err := Convert(t.Context(), u)
+	require.NoError(t, err)
+
+	want := map[string]any{
+		"resource": map[string]any{
+			"databricks_catalog": map[string]any{
+				"sales": map[string]any{
+					"name":          "sales_prod",
+					"comment":       "sales data",
+					"force_destroy": true,
+				},
+			},
+			"databricks_schema": map[string]any{
+				"raw": map[string]any{
+					"name":          "raw",
+					"catalog_name":  "sales",
+					"force_destroy": true,
+					"depends_on":    []any{"databricks_catalog.sales"},
+				},
+			},
+			"databricks_grants": map[string]any{
+				"sales_admins": map[string]any{
+					"catalog": "${databricks_catalog.sales.name}",
+					"grant": []any{
+						map[string]any{
+							"principal":  "sales-admins",
+							"privileges": []any{"USE_CATALOG"},
+						},
+					},
+					"depends_on": []any{"databricks_catalog.sales"},
+				},
+			},
+		},
+	}
+	assert.Equal(t, want, got.AsAny())
+}
+
+func TestConvert_EmptyResources(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: empty
+`))
+	require.False(t, diags.HasError(), "load diagnostics: %v", diags)
+
+	u := &ucm.Ucm{Config: *cfg}
+
+	got, err := Convert(t.Context(), u)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"resource": map[string]any{}}, got.AsAny())
+}
+
+func TestConvert_PreservesLocations(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+      comment: sales data
+`))
+	require.False(t, diags.HasError(), "load diagnostics: %v", diags)
+
+	u := &ucm.Ucm{Config: *cfg}
+
+	got, err := Convert(t.Context(), u)
+	require.NoError(t, err)
+
+	catalog := got.Get("resource").Get("databricks_catalog").Get("sales")
+	require.True(t, catalog.IsValid())
+	// The catalog block inherits its source location from the input node
+	// so diagnostics can point back to the offending span in ucm.yml.
+	loc := catalog.Location()
+	assert.Equal(t, "/test/ucm.yml", loc.File)
+	assert.NotZero(t, loc.Line)
+
+	nameField := catalog.Get("name")
+	require.True(t, nameField.IsValid())
+	assert.Equal(t, "/test/ucm.yml", nameField.Location().File)
+}

--- a/ucm/mutator.go
+++ b/ucm/mutator.go
@@ -1,0 +1,98 @@
+package ucm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+)
+
+// Mutator is a function-object that transforms a Ucm's configuration tree or
+// runtime state. Mirrors bundle.Mutator so converting code between the two
+// stays mechanical.
+type Mutator interface {
+	// Name returns the mutator's display name.
+	Name() string
+
+	// Apply runs the mutation against u.
+	Apply(context.Context, *Ucm) diag.Diagnostics
+}
+
+// ApplyContext runs a single mutator, keeping the dynamic/typed trees in sync
+// and forwarding diagnostics to logdiag.
+func ApplyContext(ctx context.Context, u *Ucm, m Mutator) {
+	ctx = log.NewContext(ctx, log.GetLogger(ctx).With("mutator", m.Name()))
+	log.Debugf(ctx, "Apply")
+
+	if err := u.Config.MarkMutatorEntry(ctx); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("entry error: %w", err))
+		return
+	}
+	defer func() {
+		if err := u.Config.MarkMutatorExit(ctx); err != nil {
+			logdiag.LogError(ctx, fmt.Errorf("exit error: %w", err))
+		}
+	}()
+
+	for _, d := range m.Apply(ctx, u) {
+		logdiag.LogDiag(ctx, d)
+	}
+}
+
+// ApplySeqContext runs mutators in order, stopping at the first one that logs
+// an error.
+func ApplySeqContext(ctx context.Context, u *Ucm, mutators ...Mutator) {
+	for _, m := range mutators {
+		ApplyContext(ctx, u, m)
+		if logdiag.HasError(ctx) {
+			break
+		}
+	}
+}
+
+type funcMutator struct {
+	fn func(context.Context, *Ucm)
+}
+
+func (m funcMutator) Name() string { return "<func>" }
+
+func (m funcMutator) Apply(ctx context.Context, u *Ucm) diag.Diagnostics {
+	m.fn(ctx, u)
+	return nil
+}
+
+// ApplyFuncContext applies an inline-specified function mutator.
+func ApplyFuncContext(ctx context.Context, u *Ucm, fn func(context.Context, *Ucm)) {
+	ApplyContext(ctx, u, funcMutator{fn})
+}
+
+// Apply runs a single mutator in a test-friendly way: it ensures logdiag is
+// set up, collects diagnostics into a slice, and returns them.
+func Apply(ctx context.Context, u *Ucm, m Mutator) diag.Diagnostics {
+	if !logdiag.IsSetup(ctx) {
+		ctx = logdiag.InitContext(ctx)
+	}
+	previous := logdiag.FlushCollected(ctx)
+	if len(previous) > 0 {
+		panic(fmt.Sprintf("Already have %d diags collected: %v", len(previous), previous))
+	}
+	logdiag.SetCollect(ctx, true)
+	ApplyContext(ctx, u, m)
+	return logdiag.FlushCollected(ctx)
+}
+
+// ApplySeq is the test-helper equivalent of ApplySeqContext.
+func ApplySeq(ctx context.Context, u *Ucm, mutators ...Mutator) diag.Diagnostics {
+	if !logdiag.IsSetup(ctx) {
+		ctx = logdiag.InitContext(ctx)
+	}
+	previous := logdiag.FlushCollected(ctx)
+	if len(previous) > 0 {
+		panic(fmt.Sprintf("Already have %d diags collected: %v", len(previous), previous))
+	}
+	logdiag.SetCollect(ctx, true)
+	ApplySeqContext(ctx, u, mutators...)
+	return logdiag.FlushCollected(ctx)
+}

--- a/ucm/phases/load.go
+++ b/ucm/phases/load.go
@@ -1,0 +1,28 @@
+// Package phases groups the mutator sequences that make up each ucm verb.
+// Each phase is a small composition helper around ucm.ApplySeqContext.
+package phases
+
+import (
+	"context"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+)
+
+// LoadDefaultTarget prepares a freshly-loaded Ucm for downstream phases when
+// the user did not pass --target.
+func LoadDefaultTarget(ctx context.Context, u *ucm.Ucm) {
+	ucm.ApplySeqContext(ctx, u,
+		mutator.DefineDefaultTarget(),
+		mutator.SelectDefaultTarget(),
+	)
+}
+
+// LoadNamedTarget prepares a freshly-loaded Ucm when the user passed
+// --target <name>.
+func LoadNamedTarget(ctx context.Context, u *ucm.Ucm, name string) {
+	ucm.ApplySeqContext(ctx, u,
+		mutator.DefineDefaultTarget(),
+		mutator.SelectTarget(name),
+	)
+}

--- a/ucm/phases/validate.go
+++ b/ucm/phases/validate.go
@@ -1,0 +1,26 @@
+package phases
+
+import (
+	"context"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+)
+
+// Validate runs every validation mutator against the loaded + target-merged
+// Ucm. M0 only has tag validation; more rules (naming, required fields,
+// metastore contention) land in subsequent milestones.
+func Validate(ctx context.Context, u *ucm.Ucm) {
+	ucm.ApplySeqContext(ctx, u,
+		mutator.ValidateTags(),
+	)
+}
+
+// PolicyCheck is the subset of Validate exposed as the `policy-check` verb:
+// cheap enough to run from a pre-commit hook. Currently identical to
+// Validate; will diverge once non-validation mutators join the chain.
+func PolicyCheck(ctx context.Context, u *ucm.Ucm) {
+	ucm.ApplySeqContext(ctx, u,
+		mutator.ValidateTags(),
+	)
+}

--- a/ucm/schema/schema.go
+++ b/ucm/schema/schema.go
@@ -1,0 +1,29 @@
+// Package schema produces the JSON schema for ucm.yml.
+//
+// M0 generates the schema at runtime via libs/jsonschema.FromType. Once the
+// shape stabilizes we will pre-compute it into a checked-in jsonschema.json
+// (as bundle/schema does) and embed via //go:embed — the Generate function
+// will stay as the generator entry point.
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/databricks/cli/libs/jsonschema"
+	"github.com/databricks/cli/ucm/config"
+)
+
+// Generate returns the JSON schema for ucm.yml as indented JSON bytes.
+func Generate() ([]byte, error) {
+	s, err := jsonschema.FromType(reflect.TypeOf(config.Root{}), nil)
+	if err != nil {
+		return nil, fmt.Errorf("generate ucm schema: %w", err)
+	}
+	out, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal ucm schema: %w", err)
+	}
+	return out, nil
+}

--- a/ucm/ucm.go
+++ b/ucm/ucm.go
@@ -1,0 +1,110 @@
+// Package ucm is the engine layer for the `databricks ucm` subcommand. It
+// parallels the `bundle` package and reuses shared primitives from libs/*.
+//
+// M0 includes just enough of the engine to support `validate` and `schema`:
+// a typed/dynamic config tree, a mutator plumbing layer, a filesystem loader,
+// and a tag-validation mutator. Terraform/state/deploy wiring lands in M1.
+package ucm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/databricks/cli/libs/folders"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config"
+)
+
+// RootEnv is the environment variable that pins a ucm root directory,
+// overriding filesystem traversal. Mirrors DATABRICKS_BUNDLE_ROOT.
+const RootEnv = "DATABRICKS_UCM_ROOT"
+
+// Ucm is the in-memory representation of a ucm deployment.
+type Ucm struct {
+	// RootPath is the local path to the directory containing ucm.yml.
+	RootPath string
+
+	// Config is the loaded configuration tree.
+	Config config.Root
+
+	// Target is the snapshot of the selected target after SelectTarget runs.
+	// nil until a target has been selected.
+	Target *config.Target
+}
+
+// Load builds a Ucm for the given root path, reading the ucm.yml file
+// underneath it.
+func Load(ctx context.Context, path string) (*Ucm, error) {
+	configFile, err := config.FileNames.FindInPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, diags := config.Load(configFile)
+	if diags.HasError() {
+		return nil, diags.Error()
+	}
+
+	log.Debugf(ctx, "Found ucm root at %s (file %s)", path, configFile)
+
+	u := &Ucm{
+		RootPath: filepath.Clean(path),
+		Config:   *cfg,
+	}
+	return u, nil
+}
+
+// MustLoad finds the ucm root, loads the config, and logs any error through
+// logdiag. Callers should check logdiag.HasError(ctx) afterwards.
+func MustLoad(ctx context.Context) *Ucm {
+	root, err := mustGetRoot(ctx)
+	if err != nil {
+		logdiag.LogError(ctx, err)
+		return nil
+	}
+	u, err := Load(ctx, root)
+	if err != nil {
+		logdiag.LogError(ctx, err)
+		return nil
+	}
+	return u
+}
+
+func getRootEnv() (string, error) {
+	path := os.Getenv(RootEnv)
+	if path == "" {
+		return "", nil
+	}
+	stat, err := os.Stat(path)
+	if err == nil && !stat.IsDir() {
+		err = errors.New("not a directory")
+	}
+	if err != nil {
+		return "", fmt.Errorf(`invalid ucm root %s=%q: %w`, RootEnv, path, err)
+	}
+	return path, nil
+}
+
+func getRootWithTraversal() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for _, name := range config.FileNames {
+		if path, err := folders.FindDirWithLeaf(wd, name); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("unable to locate ucm root: %s not found", config.FileNames[0])
+}
+
+func mustGetRoot(_ context.Context) (string, error) {
+	if path, err := getRootEnv(); path != "" || err != nil {
+		return path, err
+	}
+	return getRootWithTraversal()
+}

--- a/ucm/ucm_test.go
+++ b/ucm/ucm_test.go
@@ -1,0 +1,31 @@
+package ucm_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_FindsUcmYmlUnderPath(t *testing.T) {
+	dir := t.TempDir()
+	yaml := []byte(`
+ucm:
+  name: tree-loaded
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ucm.yml"), yaml, 0o644))
+
+	u, err := ucm.Load(t.Context(), dir)
+	require.NoError(t, err)
+	assert.Equal(t, "tree-loaded", u.Config.Ucm.Name)
+	assert.Equal(t, filepath.Clean(dir), u.RootPath)
+}
+
+func TestLoad_MissingUcmYml(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ucm.Load(t.Context(), dir)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Introduces `ucm/deploy/terraform/tfdyn`, a fork-and-adapt of `bundle/deploy/terraform/tfdyn` that converts a ucm configuration tree into the Terraform JSON resource payload. The U5 TF wrapper will consume this directly.

Top-level: `Convert(ctx, u *ucm.Ucm) (dyn.Value, error)` walks `u.Config.Resources` in a fixed order (catalogs, schemas, grants) and dispatches through a string-keyed registry. Output shape:

```
{
  "resource": {
    "databricks_catalog": { "<key>": { ... } },
    "databricks_schema":  { "<key>": { ... } },
    "databricks_grants":  { "<key>": { ... } }
  }
}
```

### Converters

- **Catalog** (`databricks_catalog`): name, comment, storage_root, `tags` -> `properties`, `force_destroy=true`.
- **Schema** (`databricks_schema`): `catalog` -> `catalog_name`. When the referenced catalog is a ucm-managed resource, emits `depends_on = ["databricks_catalog.<key>"]`; external catalog names skip depends_on.
- **Grant** (`databricks_grants`, plural): emits one `grant { principal, privileges }` entry per ucm grant. Catalog securables pointing at a managed catalog interpolate to `${databricks_catalog.<key>.name}`; schema securables pointing at a managed schema interpolate to `${databricks_schema.<key>.id}`. External securable names pass through verbatim. Only `catalog` and `schema` securables supported in M0; volumes/ELs/SCs land in M2 and return an explicit error.

### Design notes

- Unlike bundle's tfdyn, which round-trips through typed TF schema structs in `bundle/internal/tf/schema/`, ucm builds `dyn.Value` trees directly. This was dictated by the fork rule (no `bundle/**` imports) and by the desire to keep source locations attached to every emitted node so downstream diagnostics can cite `ucm.yml` spans.
- Converter ordering matters: `schemas` and `grants` inspect `Resources.Catalog` / `Resources.Schema` (populated by prior converters) to decide whether to emit `depends_on` and TF interpolations.

### Scope

- Included: Catalog, Schema, Grant converters; registry; top-level `Convert`.
- Out of scope (follow-ups): TF binary invocation (U5), state file I/O (U4), volumes/EL/SC converters (M2).

## Test plan

- [x] Table-driven unit tests per converter (golden-comparison via `AsAny()`).
  - Catalog: minimal, comment+storage_root, tags->properties, default-name-from-key.
  - Schema: external catalog, managed-catalog depends_on, comment+tags.
  - Grant: external catalog, managed-catalog interpolation, managed-schema interpolation, unsupported securable error.
- [x] Top-level happy path: 1 catalog + 1 schema + 1 grant, asserting the full `{resource: ...}` tree.
- [x] Empty-resources path returns `{resource: {}}`.
- [x] Location preservation verified: catalog block's `Location().File` and string leaves point back to `/test/ucm.yml`.
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...` clean.
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...` clean.
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...` green.
- [x] No `bundle/**` imports under `ucm/deploy/...`.

Closes #10

This pull request and its description were written by Isaac.