### PR TITLE
Feat #7: Mirror bundle.engine as ucm.engine + DATABRICKS_UCM_ENGINE (stacked on #4)

### DIFF
--- a/cmd/ucm/utils/utils.go
+++ b/cmd/ucm/utils/utils.go
@@ -1,13 +1,24 @@
 // Package utils contains helpers shared by `databricks ucm` subcommand
 // implementations — primarily ProcessUcm, which mirrors the role of
-// cmd/bundle/utils.ProcessBundle for the ucm verbs.
+// cmd/bundle/utils.ProcessBundle for the ucm verbs, and ResolveEngineSetting,
+// which picks the effective deployment engine.
 package utils
 
 import (
+	"context"
+
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/engine"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/spf13/cobra"
+)
+
+const (
+	sourceConfig  = "config"
+	sourceEnv     = "env"
+	sourceDefault = "default"
 )
 
 // ProcessOptions controls optional behavior in ProcessUcm. M0 only exposes
@@ -49,6 +60,42 @@ func ProcessUcm(cmd *cobra.Command, opts ProcessOptions) *ucm.Ucm {
 		phases.Validate(ctx, u)
 	}
 	return u
+}
+
+// ResolveEngineSetting determines the effective engine for a ucm project.
+//
+// Priority is: ucm.engine in config > DATABRICKS_UCM_ENGINE env var > Default.
+// The returned EngineSetting always has a concrete Type (never EngineNotSet):
+// callers get a ready-to-dispatch value without having to handle the unset case.
+func ResolveEngineSetting(ctx context.Context, u *config.Ucm) (engine.EngineSetting, error) {
+	var configEngine engine.EngineType
+	if u != nil {
+		configEngine = u.Engine
+	}
+
+	if configEngine != engine.EngineNotSet {
+		return engine.EngineSetting{
+			Type:       configEngine,
+			Source:     sourceConfig,
+			ConfigType: configEngine,
+		}, nil
+	}
+
+	envEngine, err := engine.FromEnv(ctx)
+	if err != nil {
+		return engine.EngineSetting{}, err
+	}
+	if envEngine != engine.EngineNotSet {
+		return engine.EngineSetting{
+			Type:   envEngine,
+			Source: sourceEnv,
+		}, nil
+	}
+
+	return engine.EngineSetting{
+		Type:   engine.Default,
+		Source: sourceDefault,
+	}, nil
 }
 
 func getTargetFromCmd(cmd *cobra.Command) string {

--- a/cmd/ucm/utils/utils_test.go
+++ b/cmd/ucm/utils/utils_test.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEngineSettingConfigTakesPriority(t *testing.T) {
+	ctx := env.Set(t.Context(), engine.EnvVar, "terraform")
+	u := &config.Ucm{Engine: engine.EngineDirect}
+	got, err := ResolveEngineSetting(ctx, u)
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineDirect, got.Type)
+	assert.Equal(t, engine.EngineDirect, got.ConfigType)
+	assert.Equal(t, "config", got.Source)
+}
+
+func TestResolveEngineSettingConfigOverridesInvalidEnv(t *testing.T) {
+	// An invalid env var is ignored when the config already selects an engine.
+	ctx := env.Set(t.Context(), engine.EnvVar, "bogus")
+	u := &config.Ucm{Engine: engine.EngineTerraform}
+	got, err := ResolveEngineSetting(ctx, u)
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineTerraform, got.Type)
+	assert.Equal(t, "config", got.Source)
+}
+
+func TestResolveEngineSettingFallsBackToEnv(t *testing.T) {
+	ctx := env.Set(t.Context(), engine.EnvVar, "direct")
+	got, err := ResolveEngineSetting(ctx, &config.Ucm{})
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineDirect, got.Type)
+	assert.Equal(t, engine.EngineNotSet, got.ConfigType)
+	assert.Equal(t, "env", got.Source)
+}
+
+func TestResolveEngineSettingDefault(t *testing.T) {
+	got, err := ResolveEngineSetting(t.Context(), &config.Ucm{})
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineTerraform, got.Type)
+	assert.Equal(t, engine.EngineNotSet, got.ConfigType)
+	assert.Equal(t, "default", got.Source)
+}
+
+func TestResolveEngineSettingNilUcm(t *testing.T) {
+	got, err := ResolveEngineSetting(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineTerraform, got.Type)
+	assert.Equal(t, "default", got.Source)
+}
+
+func TestResolveEngineSettingInvalidEnv(t *testing.T) {
+	ctx := env.Set(t.Context(), engine.EnvVar, "bogus")
+	_, err := ResolveEngineSetting(ctx, &config.Ucm{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), engine.EnvVar)
+}

--- a/ucm/config/engine/engine.go
+++ b/ucm/config/engine/engine.go
@@ -1,0 +1,74 @@
+// Package engine describes the ucm deployment engine selection.
+//
+// Mirrors bundle/config/engine so ucm can resolve its own engine independently
+// of bundle. The fork-and-adapt approach keeps ucm free of bundle imports as
+// required by cmd/ucm/CLAUDE.md.
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/env"
+)
+
+// EnvVar is the name of the environment variable that overrides the ucm engine.
+const EnvVar = "DATABRICKS_UCM_ENGINE"
+
+// EngineType identifies the deployment engine that ucm should use.
+type EngineType string
+
+const (
+	EngineDirect    EngineType = "direct"
+	EngineTerraform EngineType = "terraform"
+	EngineNotSet    EngineType = ""
+)
+
+// Default is used when neither ucm.engine nor DATABRICKS_UCM_ENGINE is set.
+const Default = EngineTerraform
+
+// Parse returns the EngineType for a string value.
+// The second return value is false if the string is not a recognized engine.
+func Parse(engine string) (EngineType, bool) {
+	switch engine {
+	case "":
+		return EngineNotSet, true
+	case "terraform":
+		return EngineTerraform, true
+	case "direct":
+		return EngineDirect, true
+	default:
+		return EngineNotSet, false
+	}
+}
+
+// FromEnv returns the engine configured via DATABRICKS_UCM_ENGINE.
+// Returns EngineNotSet (without error) when the variable is empty or unset.
+func FromEnv(ctx context.Context) (EngineType, error) {
+	value := env.Get(ctx, EnvVar)
+	engine, ok := Parse(value)
+	if !ok {
+		return EngineNotSet, fmt.Errorf("unexpected setting for %s=%#v (expected 'terraform' or 'direct')", EnvVar, value)
+	}
+	return engine, nil
+}
+
+// EngineSetting represents a resolved engine choice along with where it came from.
+type EngineSetting struct {
+	Type       EngineType // effective resolved engine
+	Source     string     // human-readable source of Type
+	ConfigType EngineType // value from ucm config (EngineNotSet if not configured)
+}
+
+// ThisOrDefault returns the receiver, or Default when the receiver is EngineNotSet.
+func (e EngineType) ThisOrDefault() EngineType {
+	if e == EngineNotSet {
+		return Default
+	}
+	return e
+}
+
+// IsDirect reports whether the effective engine (after defaulting) is EngineDirect.
+func (e EngineType) IsDirect() bool {
+	return e.ThisOrDefault() == EngineDirect
+}

--- a/ucm/config/engine/engine_test.go
+++ b/ucm/config/engine/engine_test.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		input string
+		want  EngineType
+		ok    bool
+	}{
+		{"", EngineNotSet, true},
+		{"terraform", EngineTerraform, true},
+		{"direct", EngineDirect, true},
+		{"TERRAFORM", EngineNotSet, false},
+		{"tf", EngineNotSet, false},
+		{"unknown", EngineNotSet, false},
+	}
+	for _, c := range cases {
+		got, ok := Parse(c.input)
+		assert.Equal(t, c.want, got, "Parse(%q) value", c.input)
+		assert.Equal(t, c.ok, ok, "Parse(%q) ok", c.input)
+	}
+}
+
+func TestFromEnv(t *testing.T) {
+	ctx := env.Set(t.Context(), EnvVar, "direct")
+	e, err := FromEnv(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, EngineDirect, e)
+}
+
+func TestFromEnvTerraform(t *testing.T) {
+	ctx := env.Set(t.Context(), EnvVar, "terraform")
+	e, err := FromEnv(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, EngineTerraform, e)
+}
+
+func TestFromEnvNotSet(t *testing.T) {
+	e, err := FromEnv(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, EngineNotSet, e)
+}
+
+func TestFromEnvInvalid(t *testing.T) {
+	ctx := env.Set(t.Context(), EnvVar, "bogus")
+	_, err := FromEnv(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), EnvVar)
+}
+
+func TestThisOrDefault(t *testing.T) {
+	assert.Equal(t, EngineTerraform, EngineNotSet.ThisOrDefault())
+	assert.Equal(t, EngineTerraform, EngineTerraform.ThisOrDefault())
+	assert.Equal(t, EngineDirect, EngineDirect.ThisOrDefault())
+}
+
+func TestIsDirect(t *testing.T) {
+	assert.False(t, EngineNotSet.IsDirect())
+	assert.False(t, EngineTerraform.IsDirect())
+	assert.True(t, EngineDirect.IsDirect())
+}

--- a/ucm/config/ucm.go
+++ b/ucm/config/ucm.go
@@ -1,10 +1,16 @@
 package config
 
+import "github.com/databricks/cli/ucm/config/engine"
+
 // Ucm holds top-level metadata about a ucm deployment (parallel to
 // bundle.Bundle in DAB).
 type Ucm struct {
 	// Name uniquely identifies this ucm deployment.
 	Name string `json:"name"`
+
+	// Engine selects the deployment engine ("terraform" or "direct").
+	// Can be overridden with the DATABRICKS_UCM_ENGINE environment variable.
+	Engine engine.EngineType `json:"engine,omitempty"`
 
 	// Target records which target is currently selected. It is populated
 	// by the SelectTarget mutator; users do not set it in ucm.yml.


### PR DESCRIPTION
Closes #7

Supersedes #12 — that PR was branched off `main`, but this work depends on the `cmd/ucm/utils/utils.go` and `ucm/config/ucm.go` introduced by #4 (feat/3-validate-schema). Rebased onto `feat/3-validate-schema` so the diff is a clean extension of that trunk.

## Summary
- New package `ucm/config/engine` — 1:1 port of `bundle/config/engine`. Env var constant is `DATABRICKS_UCM_ENGINE` (matches the `DATABRICKS_UCM_ROOT` precedent). Exposes `EngineType`, `Parse`, `FromEnv`, `EngineSetting`, `ThisOrDefault`, `IsDirect`.
- `ucm/config/ucm.go` — adds `Engine engine.EngineType` alongside existing `Name` and `Target`.
- `cmd/ucm/utils/utils.go` — extends the existing file with `ResolveEngineSetting(ctx, u) (engine.EngineSetting, error)`. Priority: config > env > default. Always returns a concrete `Type` (never `EngineNotSet`) so callers don't need to handle the unset case.
- Unit tests for `engine` (parse, FromEnv, ThisOrDefault, IsDirect) and for `ResolveEngineSetting` (config-wins, env-fallback, default, invalid-env, nil-Ucm).

## Why
M1 adds a dispatch point between a future terraform engine and a future direct-API engine, mirroring DAB. Threading the field + resolver now unblocks U6/U7 without retrofitting. Locked decision: **no per-target engine override** in this PR — matches DAB parity; keeps fork-divergence minimal.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`

## Fork-divergence notes
- No edits to `bundle/**`, `cmd/bundle/**`, `libs/**`.
- No new edits to `cmd/cmd.go`.
- No imports from `bundle/**` in `ucm/**` or `cmd/ucm/**`.

## Base branch
Stacked on `feat/3-validate-schema` (PR #4) because that branch introduces the `ucm/config/ucm.go` and `cmd/ucm/utils/utils.go` files this PR extends. Retarget to `main` once #4 merges.