### PR TITLE
Feat #16: State pull/push with lock + StateFiler

### DIFF
--- a/ucm/deploy/filer/workspace_filer.go
+++ b/ucm/deploy/filer/workspace_filer.go
@@ -40,6 +40,15 @@ func newWorkspaceFilerFromInner(inner libsfiler.Filer) *WorkspaceFiler {
 	return &WorkspaceFiler{inner: inner}
 }
 
+// NewStateFilerFromFiler adapts an arbitrary libs/filer.Filer into a
+// StateFiler. Mirrors lock.NewLockerWithFiler: callers that already hold a
+// libs/filer.Filer — tests backed by NewLocalClient, or future s3/adls/gcs
+// implementations — can reuse it as the state-storage backend without going
+// through a workspace client.
+func NewStateFilerFromFiler(inner libsfiler.Filer) StateFiler {
+	return &WorkspaceFiler{inner: inner}
+}
+
 // Read opens the file at path for reading.
 func (w *WorkspaceFiler) Read(ctx context.Context, path string) (io.ReadCloser, error) {
 	rc, err := w.inner.Read(ctx, path)

--- a/ucm/deploy/state.go
+++ b/ucm/deploy/state.go
@@ -1,0 +1,146 @@
+// Package deploy owns the remote-state lifecycle for ucm: the pull/push/ops
+// glue that sits between the pluggable StateFiler (U1) and the deploy Locker
+// (U2). It is forked from bundle/deploy; keeping the shapes close eases
+// future cross-checks without introducing a bundle/** import.
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/google/uuid"
+)
+
+// Remote and local filenames for the state artifacts. StateFileName lives
+// next to TfStateFileName in the remote state dir; Seq-based conflict
+// detection reads UcmStateFileName only.
+const (
+	// UcmStateFileName is the ucm-specific sidecar that tracks Seq/Version
+	// alongside the opaque terraform.tfstate blob.
+	UcmStateFileName = "ucm-state.json"
+
+	// TfStateFileName is the terraform-managed state blob that ucm mirrors
+	// locally so the terraform wrapper can drive plan/apply offline.
+	TfStateFileName = "terraform.tfstate"
+
+	// LocalCacheDir is the root under the ucm project directory used to
+	// mirror remote state. The per-target sub-directory is appended by
+	// LocalStateDir.
+	LocalCacheDir = ".databricks/ucm"
+
+	// StateVersion is bumped on incompatible changes to the on-wire State
+	// shape. Pull treats a remote Version greater than this as an error so
+	// older CLIs refuse to overwrite newer state blobs.
+	StateVersion = 1
+)
+
+// State is the ucm-side sidecar stored as ucm-state.json in the remote state
+// directory. It carries just enough metadata to detect stale overwrites and
+// identify the CLI that produced the blob. The opaque terraform.tfstate lives
+// separately so terraform tooling can read it without understanding Seq.
+type State struct {
+	// Version is bumped on incompatible changes to this struct. A remote
+	// Version greater than StateVersion fails the pull.
+	Version int `json:"version"`
+
+	// Seq is incremented on every successful Push. Push refuses to overwrite
+	// a remote whose Seq is greater than the Seq we saw at Pull time.
+	Seq int `json:"seq"`
+
+	// ID uniquely identifies the sequence of deployments for this target.
+	// Rotating it starts a fresh Seq chain (e.g. after --force).
+	ID uuid.UUID `json:"id"`
+
+	// CliVersion is the ucm/cli version that wrote the blob. Informational
+	// only — Seq is the source of truth for conflict detection.
+	CliVersion string `json:"cli_version,omitempty"`
+
+	// Timestamp is when the state was produced. Informational only.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// ErrStaleState is returned by Push when the remote Seq is greater than the
+// Seq we observed at Pull time. Callers can unwrap via errors.As to surface
+// the two Seq values to the user.
+type ErrStaleState struct {
+	// LocalSeq is the Seq we believe we are advancing from.
+	LocalSeq int
+	// RemoteSeq is the Seq currently on the remote, which is ahead of
+	// LocalSeq.
+	RemoteSeq int
+}
+
+// Error formats the conflict for human consumption.
+func (e *ErrStaleState) Error() string {
+	return fmt.Sprintf("ucm state: local state is stale (local seq %d < remote seq %d); pull before pushing", e.LocalSeq, e.RemoteSeq)
+}
+
+// Backend bundles the remote-IO dependencies needed by Pull and Push. It is
+// supplied by the caller so tests can inject local-disk filers without a live
+// workspace client. U6 will build the production Backend from
+// ucm.state.backend config; until then callers compose it directly.
+type Backend struct {
+	// StateFiler is where terraform.tfstate and ucm-state.json are read
+	// from and written to. Typically rooted at the per-target workspace
+	// state path.
+	StateFiler filer.StateFiler
+
+	// LockFiler is where the Locker writes deploy.lock. In the v1 workspace
+	// backend StateFiler and LockFiler point at the same remote dir; the
+	// split exists because the Locker API consumes libs/filer.Filer rather
+	// than the ucm StateFiler.
+	LockFiler libsfiler.Filer
+
+	// User is embedded into the lock record so contending clients can see
+	// who currently holds the lock. Empty strings are allowed for tests.
+	User string
+}
+
+// loadState reads a State from r.
+func loadState(r io.Reader) (*State, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("ucm state: parse: %w", err)
+	}
+	return &s, nil
+}
+
+// readRemoteUcmState loads ucm-state.json via the StateFiler, returning
+// (nil, nil) when the file is absent (first-run case).
+func readRemoteUcmState(ctx context.Context, f filer.StateFiler) (*State, error) {
+	rc, err := f.Read(ctx, UcmStateFileName)
+	if err != nil {
+		if errors.Is(err, filer.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer rc.Close()
+	return loadState(rc)
+}
+
+// validateCompatibility fails when the remote State was written by a newer
+// CLI with an incompatible schema version.
+func validateCompatibility(s *State) error {
+	if s.Version > StateVersion {
+		return fmt.Errorf("ucm state: remote version %d > supported %d; upgrade the CLI", s.Version, StateVersion)
+	}
+	return nil
+}
+
+// newLocker constructs a Locker bound to the backend's LockFiler. Kept
+// package-private because the only callers are Pull and Push.
+func newLocker(b Backend, targetDir string) *lock.Locker {
+	return lock.NewLockerWithFiler(b.User, targetDir, b.LockFiler)
+}

--- a/ucm/deploy/state_pull.go
+++ b/ucm/deploy/state_pull.go
@@ -1,0 +1,154 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/google/uuid"
+)
+
+// LocalStateDir returns the local directory where state artifacts are mirrored
+// for u. Always forward-slash on the wire; callers that write to disk should
+// pass the return value through filepath.FromSlash when interacting with the
+// OS filesystem.
+func LocalStateDir(u *ucm.Ucm) string {
+	target := u.Config.Ucm.Target
+	return filepath.Join(u.RootPath, filepath.FromSlash(LocalCacheDir), target)
+}
+
+// Pull copies terraform.tfstate and ucm-state.json from the remote StateFiler
+// into the per-target local cache directory. On a first run the remote files
+// are absent and a fresh local state with Seq=0 is written instead.
+//
+// The deploy lock is acquired for the duration of the pull so that a
+// concurrent Push cannot swap the remote blob out from under us mid-read.
+func Pull(ctx context.Context, u *ucm.Ucm, b Backend) error {
+	if u == nil {
+		return errors.New("ucm state: Pull called with nil Ucm")
+	}
+	if b.StateFiler == nil || b.LockFiler == nil {
+		return errors.New("ucm state: Pull requires StateFiler and LockFiler in Backend")
+	}
+
+	l := newLocker(b, ".")
+	if err := l.Acquire(ctx, false); err != nil {
+		return fmt.Errorf("ucm state: acquire lock: %w", err)
+	}
+	defer releaseBestEffort(ctx, l, lock.GoalDeploy)
+
+	localDir := LocalStateDir(u)
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		return fmt.Errorf("ucm state: create local cache dir: %w", err)
+	}
+
+	remoteUcm, err := readRemoteUcmState(ctx, b.StateFiler)
+	if err != nil {
+		return fmt.Errorf("ucm state: read remote %s: %w", UcmStateFileName, err)
+	}
+
+	if remoteUcm == nil {
+		log.Infof(ctx, "ucm state: remote is empty, initializing fresh local state at %s", filepath.ToSlash(localDir))
+		return writeFreshLocal(ctx, localDir)
+	}
+
+	if err := validateCompatibility(remoteUcm); err != nil {
+		return err
+	}
+
+	log.Infof(ctx, "ucm state: pulling remote state (seq %d) into %s", remoteUcm.Seq, filepath.ToSlash(localDir))
+	if err := writeLocalState(localDir, remoteUcm); err != nil {
+		return fmt.Errorf("ucm state: write local %s: %w", UcmStateFileName, err)
+	}
+
+	if err := copyRemoteToLocal(ctx, b.StateFiler, TfStateFileName, filepath.Join(localDir, TfStateFileName)); err != nil {
+		if errors.Is(err, filer.ErrNotFound) {
+			// A ucm-state.json without a sibling terraform.tfstate is a
+			// recoverable first-run shape (ucm pulled once but never
+			// applied terraform). Leave local tfstate absent.
+			log.Infof(ctx, "ucm state: no remote %s yet; skipping", TfStateFileName)
+			return nil
+		}
+		return fmt.Errorf("ucm state: copy remote %s: %w", TfStateFileName, err)
+	}
+	return nil
+}
+
+// writeFreshLocal writes a Seq=0 ucm-state.json to localDir and nothing else.
+// The absence of a local terraform.tfstate is the signal downstream phases
+// use to recognise first-run behaviour.
+func writeFreshLocal(ctx context.Context, localDir string) error {
+	fresh := newFreshState()
+	if err := writeLocalState(localDir, fresh); err != nil {
+		return fmt.Errorf("ucm state: write fresh local state: %w", err)
+	}
+	log.Infof(ctx, "ucm state: wrote fresh local state (seq 0) to %s", filepath.ToSlash(localDir))
+	return nil
+}
+
+// newFreshState builds a Seq=0 State with a newly-generated ID, used on
+// first-run and after destroy.
+func newFreshState() *State {
+	return &State{
+		Version: StateVersion,
+		Seq:     0,
+		ID:      uuid.New(),
+	}
+}
+
+// writeLocalState writes s to <localDir>/ucm-state.json with 0600 perms so
+// that workspace-side credentials embedded in terraform.tfstate (if any later
+// land there) aren't world-readable on shared dev machines.
+func writeLocalState(localDir string, s *State) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(localDir, UcmStateFileName), data, 0o600)
+}
+
+// copyRemoteToLocal streams a single remote file into a local file,
+// truncating any existing local copy. The buffered ReadAll keeps the
+// implementation simple; state files are small.
+func copyRemoteToLocal(ctx context.Context, f filer.StateFiler, remote, localPath string) error {
+	rc, err := f.Read(ctx, remote)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	buf, err := io.ReadAll(rc)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(localPath, buf, 0o600)
+}
+
+// releaseBestEffort is deferred by Pull/Push so the lock is released on every
+// exit path including errors. Release failures are logged rather than
+// surfaced because the primary error already communicates the deploy outcome
+// and a stuck lock is more operator-visible than a swallowed one.
+func releaseBestEffort(ctx context.Context, l *lock.Locker, goal lock.Goal) {
+	if err := l.Release(ctx, goal); err != nil {
+		log.Warnf(ctx, "ucm state: release lock (goal %s): %v", goal, err)
+	}
+}
+
+// readLocalState is used by Push to learn the Seq we think we're advancing.
+// Shared here so state_pull_test.go can exercise the same file format.
+func readLocalState(localDir string) (*State, error) {
+	data, err := os.ReadFile(filepath.Join(localDir, UcmStateFileName))
+	if err != nil {
+		return nil, err
+	}
+	return loadState(bytes.NewReader(data))
+}

--- a/ucm/deploy/state_pull_test.go
+++ b/ucm/deploy/state_pull_test.go
@@ -1,0 +1,187 @@
+package deploy_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/deploy"
+	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixture bundles the inputs every pull/push test needs: a local project dir
+// for the Ucm, and two filers for the remote (state + lock) sharing a single
+// temp dir so a second client can contend the same logical state root.
+type fixture struct {
+	t        *testing.T
+	projDir  string
+	remote   libsfiler.Filer
+	backend  deploy.Backend
+	u        *ucm.Ucm
+	localDir string
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	projDir := t.TempDir()
+	remoteDir := t.TempDir()
+
+	local, err := libsfiler.NewLocalClient(remoteDir)
+	require.NoError(t, err)
+
+	u := &ucm.Ucm{RootPath: projDir}
+	u.Config.Ucm = config.Ucm{Name: "test", Target: "dev"}
+
+	return &fixture{
+		t:       t,
+		projDir: projDir,
+		remote:  local,
+		backend: deploy.Backend{
+			StateFiler: ucmfiler.NewStateFilerFromFiler(local),
+			LockFiler:  local,
+			User:       "alice@example.com",
+		},
+		u:        u,
+		localDir: filepath.Join(projDir, filepath.FromSlash(deploy.LocalCacheDir), "dev"),
+	}
+}
+
+// readLocalUcmStateBytes reads the on-disk ucm-state.json from the local
+// cache directory. Tests use this instead of exposing readLocalState from
+// the production package.
+func readLocalUcmStateBytes(t *testing.T, localDir string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(localDir, deploy.UcmStateFileName))
+	require.NoError(t, err)
+	return data
+}
+
+func decodeState(t *testing.T, data []byte) deploy.State {
+	t.Helper()
+	var s deploy.State
+	require.NoError(t, json.NewDecoder(bytes.NewReader(data)).Decode(&s))
+	return s
+}
+
+// seedRemoteUcmState writes a ucm-state.json at the remote root. Used to
+// simulate a remote produced by a peer client (e.g. a contending Push).
+func seedRemoteUcmState(t *testing.T, ctx context.Context, remote libsfiler.Filer, s deploy.State) {
+	t.Helper()
+	blob, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(ctx, deploy.UcmStateFileName, bytes.NewReader(blob), libsfiler.OverwriteIfExists, libsfiler.CreateParentDirectories))
+}
+
+func TestPullFirstRunInitializesFreshLocal(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	got := decodeState(t, readLocalUcmStateBytes(t, f.localDir))
+	assert.Equal(t, 0, got.Seq)
+	assert.Equal(t, deploy.StateVersion, got.Version)
+
+	// tfstate must NOT be mirrored locally: the signal to downstream
+	// phases that this is a first-run.
+	_, err := os.Stat(filepath.Join(f.localDir, deploy.TfStateFileName))
+	assert.True(t, os.IsNotExist(err), "unexpected local tfstate on first-run: %v", err)
+}
+
+func TestPullMirrorsRemoteStateAndTfstate(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	remoteState := deploy.State{Version: deploy.StateVersion, Seq: 4}
+	seedRemoteUcmState(t, ctx, f.remote, remoteState)
+	require.NoError(t, f.remote.Write(ctx, deploy.TfStateFileName, bytes.NewReader([]byte(`{"terraform":"blob"}`)), libsfiler.OverwriteIfExists, libsfiler.CreateParentDirectories))
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	got := decodeState(t, readLocalUcmStateBytes(t, f.localDir))
+	assert.Equal(t, 4, got.Seq)
+
+	tfData, err := os.ReadFile(filepath.Join(f.localDir, deploy.TfStateFileName))
+	require.NoError(t, err)
+	assert.Equal(t, `{"terraform":"blob"}`, string(tfData))
+}
+
+func TestPullRejectsFutureVersion(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion + 1, Seq: 1})
+
+	err := deploy.Pull(ctx, f.u, f.backend)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote version")
+}
+
+func TestPullReleasesLockOnSuccess(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	// A contending client must be able to acquire the lock immediately
+	// after Pull returns — i.e. the defer ran.
+	contender := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, contender.Acquire(ctx, false))
+	require.NoError(t, contender.Release(ctx, lock.GoalDeploy))
+}
+
+func TestPullReleasesLockOnError(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// Future-version remote causes Pull to fail; the lock must still be
+	// released for the next caller.
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion + 99})
+
+	err := deploy.Pull(ctx, f.u, f.backend)
+	require.Error(t, err)
+
+	contender := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, contender.Acquire(ctx, false))
+	require.NoError(t, contender.Release(ctx, lock.GoalDeploy))
+}
+
+func TestPullFailsWhenLockAlreadyHeld(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// Peer grabs the lock first.
+	peer := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, peer.Acquire(ctx, false))
+	defer peer.Release(ctx, lock.GoalDeploy)
+
+	err := deploy.Pull(ctx, f.u, f.backend)
+	require.Error(t, err)
+
+	var held *lock.ErrLockHeld
+	require.ErrorAs(t, err, &held)
+	assert.Equal(t, "bob@example.com", held.Holder)
+}
+
+func TestPullRequiresBackend(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	err := deploy.Pull(ctx, f.u, deploy.Backend{})
+	require.Error(t, err)
+}
+
+func TestPullNilUcm(t *testing.T) {
+	ctx := t.Context()
+	err := deploy.Pull(ctx, nil, deploy.Backend{})
+	require.Error(t, err)
+}

--- a/ucm/deploy/state_push.go
+++ b/ucm/deploy/state_push.go
@@ -1,0 +1,116 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/google/uuid"
+)
+
+// Push mirrors the local state cache into the remote StateFiler. It bumps
+// Seq, refuses to overwrite a remote that has advanced past the Seq we
+// observed locally, and writes atomically-ish by writing ucm-state.json last
+// so a partial push leaves the remote tfstate readable but clearly un-acked.
+//
+// On a fresh local (no ucm-state.json under LocalStateDir), Push returns an
+// error — the expected shape is Pull → mutate → Push, and pushing without a
+// pull means the caller has no baseline Seq to reason about.
+func Push(ctx context.Context, u *ucm.Ucm, b Backend) error {
+	if u == nil {
+		return errors.New("ucm state: Push called with nil Ucm")
+	}
+	if b.StateFiler == nil || b.LockFiler == nil {
+		return errors.New("ucm state: Push requires StateFiler and LockFiler in Backend")
+	}
+
+	l := newLocker(b, ".")
+	if err := l.Acquire(ctx, false); err != nil {
+		return fmt.Errorf("ucm state: acquire lock: %w", err)
+	}
+	defer releaseBestEffort(ctx, l, lock.GoalDeploy)
+
+	localDir := LocalStateDir(u)
+	local, err := readLocalState(localDir)
+	if err != nil {
+		return fmt.Errorf("ucm state: read local %s: %w", UcmStateFileName, err)
+	}
+
+	if err := assertRemoteNotAhead(ctx, b.StateFiler, local); err != nil {
+		return err
+	}
+
+	// Bump Seq before serialising so the on-remote record matches the
+	// intent of this Push. A crash after writeRemote but before the
+	// bookkeeping below leaves the remote ahead of local; the next Pull
+	// catches up.
+	next := *local
+	next.Version = StateVersion
+	next.Seq = local.Seq + 1
+	if next.ID == uuid.Nil {
+		next.ID = uuid.New()
+	}
+	next.Timestamp = time.Now().UTC()
+
+	if err := writeRemote(ctx, b.StateFiler, localDir, &next); err != nil {
+		return err
+	}
+
+	// Mirror the bumped Seq into the local cache so the next Push starts
+	// from an accurate baseline without requiring an intervening Pull.
+	if err := writeLocalState(localDir, &next); err != nil {
+		return fmt.Errorf("ucm state: refresh local %s: %w", UcmStateFileName, err)
+	}
+	log.Infof(ctx, "ucm state: pushed state (seq %d -> %d) for target %s", local.Seq, next.Seq, u.Config.Ucm.Target)
+	return nil
+}
+
+// assertRemoteNotAhead fails with ErrStaleState when the remote Seq exceeds
+// the local Seq. Missing remote state counts as Seq=-1 for comparison so a
+// first Push always succeeds.
+func assertRemoteNotAhead(ctx context.Context, f filer.StateFiler, local *State) error {
+	remote, err := readRemoteUcmState(ctx, f)
+	if err != nil {
+		return fmt.Errorf("ucm state: inspect remote: %w", err)
+	}
+	if remote == nil {
+		return nil
+	}
+	if remote.Seq > local.Seq {
+		return &ErrStaleState{LocalSeq: local.Seq, RemoteSeq: remote.Seq}
+	}
+	return nil
+}
+
+// writeRemote uploads the local terraform.tfstate (if any) first, then
+// ucm-state.json. ucm-state.json is written last so a crash between the two
+// leaves the remote in a shape the next Pull can still interpret as
+// "remote ahead of us, need to advance" rather than "blank slate".
+func writeRemote(ctx context.Context, f filer.StateFiler, localDir string, next *State) error {
+	tfPath := filepath.Join(localDir, TfStateFileName)
+	if data, err := os.ReadFile(tfPath); err == nil {
+		if err := f.Write(ctx, TfStateFileName, bytes.NewReader(data), filer.WriteModeOverwrite|filer.WriteModeCreateParents); err != nil {
+			return fmt.Errorf("ucm state: write remote %s: %w", TfStateFileName, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("ucm state: read local %s: %w", TfStateFileName, err)
+	}
+
+	blob, err := json.MarshalIndent(next, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := f.Write(ctx, UcmStateFileName, bytes.NewReader(blob), filer.WriteModeOverwrite|filer.WriteModeCreateParents); err != nil {
+		return fmt.Errorf("ucm state: write remote %s: %w", UcmStateFileName, err)
+	}
+	return nil
+}

--- a/ucm/deploy/state_push_test.go
+++ b/ucm/deploy/state_push_test.go
@@ -1,0 +1,210 @@
+package deploy_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readRemoteState round-trips the remote ucm-state.json for assertion
+// purposes. Returns nil if the remote hasn't been written yet.
+func readRemoteState(t *testing.T, f libsfiler.Filer) *deploy.State {
+	t.Helper()
+	rc, err := f.Read(t.Context(), deploy.UcmStateFileName)
+	if err != nil {
+		return nil
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	var s deploy.State
+	require.NoError(t, json.Unmarshal(data, &s))
+	return &s
+}
+
+func TestPushFirstWriteAfterPull(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// First Pull on an empty remote establishes a Seq=0 local.
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	// Drop a tfstate blob locally so Push has something to upload.
+	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), []byte(`{"tf":"v1"}`), 0o600))
+
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	remote := readRemoteState(t, f.remote)
+	require.NotNil(t, remote)
+	assert.Equal(t, 1, remote.Seq)
+
+	// Local should have been refreshed to match the new Seq.
+	localData, err := os.ReadFile(filepath.Join(f.localDir, deploy.UcmStateFileName))
+	require.NoError(t, err)
+	var local deploy.State
+	require.NoError(t, json.Unmarshal(localData, &local))
+	assert.Equal(t, 1, local.Seq)
+}
+
+func TestPushPullRoundTripIsIdentical(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+	tfBlob := []byte(`{"tf":"roundtrip"}`)
+	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), tfBlob, 0o600))
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	// Simulate a second clone of the project: wipe the local cache and
+	// re-Pull. The pulled tfstate must byte-for-byte match what was Pushed.
+	require.NoError(t, os.RemoveAll(f.localDir))
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	got, err := os.ReadFile(filepath.Join(f.localDir, deploy.TfStateFileName))
+	require.NoError(t, err)
+	assert.Equal(t, tfBlob, got)
+
+	// Seq must round-trip too.
+	state, err := os.ReadFile(filepath.Join(f.localDir, deploy.UcmStateFileName))
+	require.NoError(t, err)
+	var s deploy.State
+	require.NoError(t, json.Unmarshal(state, &s))
+	assert.Equal(t, 1, s.Seq)
+}
+
+func TestPushDetectsStaleState(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// Client A pulls and prepares to push.
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	// Meanwhile, client B advances the remote Seq out from under A.
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion, Seq: 5})
+
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+
+	var stale *deploy.ErrStaleState
+	require.ErrorAs(t, err, &stale)
+	assert.Equal(t, 0, stale.LocalSeq)
+	assert.Equal(t, 5, stale.RemoteSeq)
+}
+
+func TestPushSecondPushAfterRemoteBumpFails(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	// Peer bumps remote Seq.
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion, Seq: 99})
+
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+	var stale *deploy.ErrStaleState
+	require.ErrorAs(t, err, &stale)
+	assert.Equal(t, 99, stale.RemoteSeq)
+}
+
+func TestPushWithoutPriorPullFails(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// No Pull before Push → no local ucm-state.json → read error.
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read local")
+}
+
+func TestPushReleasesLockOnStaleError(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	// Force a stale-state failure.
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion, Seq: 5})
+
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+
+	// Lock must be released after the failure.
+	contender := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, contender.Acquire(ctx, false))
+	require.NoError(t, contender.Release(ctx, lock.GoalDeploy))
+}
+
+func TestPushReleasesLockOnSuccess(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	contender := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, contender.Acquire(ctx, false))
+	require.NoError(t, contender.Release(ctx, lock.GoalDeploy))
+}
+
+func TestPushFailsWhenLockHeldByPeer(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	peer := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, peer.Acquire(ctx, false))
+	defer peer.Release(ctx, lock.GoalDeploy)
+
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+	var held *lock.ErrLockHeld
+	require.ErrorAs(t, err, &held)
+}
+
+func TestPushMirrorsTfstateBytesExactly(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+	tfBlob := bytes.Repeat([]byte{0xAB}, 2048)
+	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), tfBlob, 0o600))
+
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	rc, err := f.remote.Read(ctx, deploy.TfStateFileName)
+	require.NoError(t, err)
+	defer rc.Close()
+	remoteTf, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, tfBlob, remoteTf)
+}
+
+func TestPushNilUcmRequiresBackend(t *testing.T) {
+	ctx := t.Context()
+	err := deploy.Push(ctx, nil, deploy.Backend{})
+	require.Error(t, err)
+
+	f := newFixture(t)
+	err = deploy.Push(ctx, f.u, deploy.Backend{})
+	require.Error(t, err)
+}
+
+func TestPushErrStaleStateIsAssignableToPointer(t *testing.T) {
+	// Guards against regressions in ErrStaleState pointer receiver.
+	var stale *deploy.ErrStaleState
+	var e error = &deploy.ErrStaleState{LocalSeq: 1, RemoteSeq: 2}
+	require.True(t, errors.As(e, &stale))
+}

--- a/ucm/deploy/state_test.go
+++ b/ucm/deploy/state_test.go
@@ -1,0 +1,75 @@
+package deploy_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateJSONRoundTrip(t *testing.T) {
+	src := deploy.State{
+		Version:   deploy.StateVersion,
+		Seq:       7,
+		ID:        uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+		Timestamp: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+	}
+	buf, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	var got deploy.State
+	require.NoError(t, json.Unmarshal(buf, &got))
+	assert.Equal(t, src, got)
+}
+
+func TestErrStaleStateMessage(t *testing.T) {
+	err := &deploy.ErrStaleState{LocalSeq: 3, RemoteSeq: 5}
+	msg := err.Error()
+	assert.Contains(t, msg, "local seq 3")
+	assert.Contains(t, msg, "remote seq 5")
+	assert.Contains(t, msg, "pull before pushing")
+}
+
+func TestErrStaleStateErrorsAs(t *testing.T) {
+	err := error(&deploy.ErrStaleState{LocalSeq: 1, RemoteSeq: 2})
+	var target *deploy.ErrStaleState
+	require.True(t, errors.As(err, &target))
+	assert.Equal(t, 1, target.LocalSeq)
+	assert.Equal(t, 2, target.RemoteSeq)
+}
+
+func TestErrStaleStateIsReflexive(t *testing.T) {
+	// errors.Is on a typed error falls back to == identity via the pointer;
+	// this guards against anyone adding a custom Is that breaks that.
+	err := &deploy.ErrStaleState{LocalSeq: 1, RemoteSeq: 2}
+	assert.True(t, errors.Is(err, err))
+}
+
+func TestStateUnmarshalEmptyTimestamp(t *testing.T) {
+	// Tolerate blobs written by tests or future CLIs that omit Timestamp.
+	var s deploy.State
+	require.NoError(t, json.Unmarshal([]byte(`{"version":1,"seq":0,"id":"00000000-0000-0000-0000-000000000000","timestamp":"0001-01-01T00:00:00Z"}`), &s))
+	assert.Equal(t, 1, s.Version)
+	assert.Equal(t, 0, s.Seq)
+	assert.True(t, s.Timestamp.IsZero())
+}
+
+func TestStateMarshalIndented(t *testing.T) {
+	// Sanity-check that an indented marshal reads back identical. This is
+	// the exact shape writeLocalState persists.
+	src := deploy.State{Version: 1, Seq: 2, ID: uuid.New(), Timestamp: time.Now().UTC()}
+	buf, err := json.MarshalIndent(src, "", "  ")
+	require.NoError(t, err)
+
+	var got deploy.State
+	require.NoError(t, json.NewDecoder(bytes.NewReader(buf)).Decode(&got))
+	assert.Equal(t, src.Seq, got.Seq)
+	assert.Equal(t, src.Version, got.Version)
+	assert.Equal(t, src.ID, got.ID)
+}


### PR DESCRIPTION
Closes #16

## Summary
- Add `ucm/deploy/state.go` with `State` (Version/Seq/ID/Timestamp) and a typed `*ErrStaleState` that surfaces via `errors.Is`/`errors.As`.
- Add `ucm/deploy/state_pull.go` and `state_push.go` that wrap the U1 `StateFiler` and U2 `Locker`: acquire deploy lock, read/write `terraform.tfstate` + `ucm-state.json` at the remote root, release on defer.
- Push bumps Seq; a remote whose Seq is ahead of local returns `*ErrStaleState` with both sides populated so callers can prompt the user to pull.
- Expose `filer.NewStateFilerFromFiler(libsfiler.Filer)` so tests (and future non-workspace backends) can supply any `libs/filer.Filer` where a `StateFiler` is expected.

## Why
U6 (phase wiring) and any future `ucm deploy` / `ucm destroy` need a remote-state lifecycle that is safe under concurrency. Mirroring the bundle Seq protocol keeps the mental model cheap for anyone who has read `bundle/deploy/state*` while keeping the fork free of `bundle/**` imports. Failing fast on stale state is strictly better than silently clobbering a peer's deploy.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`
- [x] Table-driven coverage under `ucm/deploy/state_{,pull_,push_}test.go`: round-trip (Push → Pull byte-identical), first-run (empty remote → Seq=0 local, tfstate absent), stale-state (peer bumped Seq → typed error), lock released on success and on every error path, peer contention surfaces `*lock.ErrLockHeld`.

## Dependency on Wave 1
- Builds directly on U1 (`filer.StateFiler` + `ErrNotFound`) and U2 (`lock.Locker`, `NewLockerWithFiler`, `*ErrLockHeld`).
- Touches a single U1 file — `ucm/deploy/filer/workspace_filer.go` — to add the exported `NewStateFilerFromFiler` adapter. No behavior change to existing code.

## Fork-divergence notes
- Edits to upstream files: none. All changes live under `ucm/deploy/**`.
- New touchpoints outside `ucm/**`: none.

## Base branch
Targets `ci/wave1-integration` (not `main`) because this is Wave 2 work that stacks on the U0/U1/U2/U3 synthesis branch. Re-target to `main` after Wave 1 lands.