### PR TITLE
Feat #17: Terraform binary wrapper

### DIFF
--- a/ucm/deploy/terraform/apply.go
+++ b/ucm/deploy/terraform/apply.go
@@ -1,0 +1,58 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// Apply acquires the U2 deployment lock and runs `terraform apply`.
+// If a plan artefact from a previous Plan call is available, Apply consumes
+// it via tfexec.DirOrPlan; otherwise it falls back to an auto-approved
+// `terraform apply` that computes its own plan inline.
+//
+// The lock is released on defer with the GoalDeploy value regardless of
+// whether Apply succeeded. Contention on the lock surfaces as a
+// *lock.ErrLockHeld so callers can errors.As on it and present a helpful
+// "--force-lock to override" message to the user.
+func (t *Terraform) Apply(ctx context.Context, u *ucm.Ucm) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Init(ctx, u); err != nil {
+		return err
+	}
+
+	factory := t.lockerFactory
+	if factory == nil {
+		factory = defaultLockerFactory
+	}
+	locker, err := factory(ctx, u, t.user)
+	if err != nil {
+		return fmt.Errorf("create deployment locker: %w", err)
+	}
+	if err := locker.Acquire(ctx, false); err != nil {
+		return err
+	}
+	defer func() {
+		if relErr := locker.Release(ctx, lock.GoalDeploy); relErr != nil {
+			log.Warnf(ctx, "terraform apply: release lock: %v", relErr)
+		}
+	}()
+
+	opts := []tfexec.ApplyOption{}
+	if t.lastPlanExists && t.lastPlanPath != "" {
+		opts = append(opts, tfexec.DirOrPlan(t.lastPlanPath))
+	}
+	if err := t.runner.Apply(ctx, opts...); err != nil {
+		return fmt.Errorf("terraform apply: %w", err)
+	}
+
+	log.Infof(ctx, "terraform apply completed")
+	return nil
+}

--- a/ucm/deploy/terraform/apply_test.go
+++ b/ucm/deploy/terraform/apply_test.go
@@ -1,0 +1,115 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sharedLockerFactory produces Lockers that all share the same underlying
+// filer.Filer. The shared filer is what makes the two Apply calls race on
+// the same lock file — required for the contention test below.
+func sharedLockerFactory(t *testing.T, user string) (lockerFactory, libsfiler.Filer) {
+	t.Helper()
+	f, err := libsfiler.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+	factory := func(_ context.Context, _ *ucm.Ucm, who string) (*lock.Locker, error) {
+		holder := who
+		if holder == "" {
+			holder = user
+		}
+		return lock.NewLockerWithFiler(holder, "/state", f), nil
+	}
+	return factory, f
+}
+
+func newApplyTerraform(t *testing.T, u *ucm.Ucm, runner *fakeRunner, lf lockerFactory, user string) *Terraform {
+	t.Helper()
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+	return &Terraform{
+		ExecPath:      "/stub/terraform",
+		WorkingDir:    workingDir,
+		Env:           map[string]string{"DATABRICKS_HOST": "https://example.cloud.databricks.com"},
+		runnerFactory: newFakeRunnerFactory(runner),
+		lockerFactory: lf,
+		user:          user,
+	}
+}
+
+func TestApplyRunsUnderLock(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newApplyTerraform(t, u, runner, factory, "alice")
+
+	require.NoError(t, tf.Apply(t.Context(), u))
+	assert.Equal(t, 1, runner.ApplyCalls)
+	// Lock is released on defer — next Apply should succeed too.
+	require.NoError(t, tf.Apply(t.Context(), u))
+	assert.Equal(t, 2, runner.ApplyCalls)
+}
+
+func TestApplyLockContentionReturnsErrLockHeld(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	factory, _ := sharedLockerFactory(t, "shared")
+
+	// First Apply holds the lock via an ApplyHook that blocks on a channel.
+	// While it is blocked, a second Apply runs and should surface *ErrLockHeld.
+	hold := make(chan struct{})
+	release := make(chan struct{})
+	firstRunner := &fakeRunner{
+		ApplyHook: func(_ context.Context) {
+			close(hold)
+			<-release
+		},
+	}
+	firstTf := newApplyTerraform(t, u, firstRunner, factory, "alice")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- firstTf.Apply(t.Context(), u)
+	}()
+
+	// Wait until the first Apply is holding the lock.
+	<-hold
+
+	secondRunner := &fakeRunner{}
+	secondTf := newApplyTerraform(t, u, secondRunner, factory, "bob")
+
+	err := secondTf.Apply(t.Context(), u)
+	require.Error(t, err)
+	var held *lock.ErrLockHeld
+	require.True(t, errors.As(err, &held), "expected ErrLockHeld, got %T: %v", err, err)
+	assert.Equal(t, "alice", held.Holder)
+	assert.Equal(t, 0, secondRunner.ApplyCalls, "second Apply must not invoke the runner")
+
+	// Let the first Apply finish.
+	close(release)
+	require.NoError(t, <-errCh)
+}
+
+func TestApplyUsesPlanPathWhenAvailable(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{PlanHasChanges: true}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newApplyTerraform(t, u, runner, factory, "alice")
+
+	planResult, err := tf.Plan(t.Context(), u)
+	require.NoError(t, err)
+	require.NotNil(t, planResult)
+	assert.True(t, planResult.HasChanges)
+
+	require.NoError(t, tf.Apply(t.Context(), u))
+	require.Len(t, runner.LastApplyOpts, 1, "Apply should have received the plan-path option")
+
+	// The plan path should be the one returned by Plan.
+	assert.Equal(t, filepath.Join(tf.WorkingDir, PlanFileName), planResult.PlanPath)
+}

--- a/ucm/deploy/terraform/destroy.go
+++ b/ucm/deploy/terraform/destroy.go
@@ -1,0 +1,51 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+)
+
+// Destroy acquires the U2 deployment lock and runs `terraform destroy
+// -auto-approve` in the working directory. Init is called first to make
+// sure main.tf.json is up to date (destroy still needs the config to know
+// the resource graph) and the provider is installed.
+//
+// The lock is released on defer with GoalDestroy, which tolerates a
+// missing lock file (destroy may have wiped the state dir before Release
+// runs — see ucm/deploy/lock.Release).
+func (t *Terraform) Destroy(ctx context.Context, u *ucm.Ucm) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Init(ctx, u); err != nil {
+		return err
+	}
+
+	factory := t.lockerFactory
+	if factory == nil {
+		factory = defaultLockerFactory
+	}
+	locker, err := factory(ctx, u, t.user)
+	if err != nil {
+		return fmt.Errorf("create deployment locker: %w", err)
+	}
+	if err := locker.Acquire(ctx, false); err != nil {
+		return err
+	}
+	defer func() {
+		if relErr := locker.Release(ctx, lock.GoalDestroy); relErr != nil {
+			log.Warnf(ctx, "terraform destroy: release lock: %v", relErr)
+		}
+	}()
+
+	if err := t.runner.Destroy(ctx); err != nil {
+		return fmt.Errorf("terraform destroy: %w", err)
+	}
+	log.Infof(ctx, "terraform destroy completed")
+	return nil
+}

--- a/ucm/deploy/terraform/destroy_test.go
+++ b/ucm/deploy/terraform/destroy_test.go
@@ -1,0 +1,33 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDestroyRunsUnderLock(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newApplyTerraform(t, u, runner, factory, "alice")
+
+	require.NoError(t, tf.Destroy(t.Context(), u))
+	assert.Equal(t, 1, runner.DestroyCalls)
+
+	// Lock released on defer: a second Destroy should succeed and re-run.
+	require.NoError(t, tf.Destroy(t.Context(), u))
+	assert.Equal(t, 2, runner.DestroyCalls)
+}
+
+func TestDestroyPropagatesRunnerError(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{DestroyErr: assert.AnError}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newApplyTerraform(t, u, runner, factory, "alice")
+
+	err := tf.Destroy(t.Context(), u)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/ucm/deploy/terraform/dir.go
+++ b/ucm/deploy/terraform/dir.go
@@ -1,0 +1,38 @@
+package terraform
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/databricks/cli/ucm"
+)
+
+// cacheDirName is the per-root directory where ucm keeps its generated
+// terraform config, plan artefacts, and (on M1+) a downloaded terraform
+// binary. Mirrors bundle/deploy/terraform's `.databricks/bundle/<target>`
+// layout but under a ucm-owned subtree so the two subcommands don't
+// accidentally share state.
+const cacheDirName = ".databricks/ucm"
+
+// WorkingDir returns the absolute path of the terraform working directory
+// for the currently selected target: `<root>/.databricks/ucm/<target>/terraform`.
+// The directory is created on demand with 0o700 permissions.
+//
+// Errors if no target has been selected — the caller should have run
+// SelectTarget (or SelectDefaultTarget) before reaching here.
+func WorkingDir(u *ucm.Ucm) (string, error) {
+	if u == nil {
+		return "", errors.New("ucm is nil")
+	}
+	target := u.Config.Ucm.Target
+	if target == "" {
+		return "", errors.New("target not set; run SelectTarget before terraform operations")
+	}
+	dir := filepath.Join(u.RootPath, filepath.FromSlash(cacheDirName), target, "terraform")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create terraform working directory %s: %w", dir, err)
+	}
+	return dir, nil
+}

--- a/ucm/deploy/terraform/fakerunner_test.go
+++ b/ucm/deploy/terraform/fakerunner_test.go
@@ -1,0 +1,98 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// fakeRunner is a stand-in for *tfexec.Terraform used by the init/plan/apply
+// /destroy tests. It records call counts per method and lets tests inject
+// return values for Plan.HasChanges and errors.
+type fakeRunner struct {
+	mu sync.Mutex
+
+	InitCalls    int
+	PlanCalls    int
+	ApplyCalls   int
+	DestroyCalls int
+	SetEnvCalls  int
+
+	// LastEnv captures the map passed to the most recent SetEnv call.
+	LastEnv map[string]string
+	// LastApplyOpts captures the options passed to the most recent Apply call.
+	LastApplyOpts []tfexec.ApplyOption
+
+	// PlanHasChanges is returned by Plan.
+	PlanHasChanges bool
+	// ApplyErr, InitErr, DestroyErr, PlanErr make the next corresponding
+	// call return the given error.
+	InitErr    error
+	PlanErr    error
+	ApplyErr   error
+	DestroyErr error
+
+	// ApplyHook is invoked synchronously inside Apply before returning. Used
+	// by the lock contention test to hold the lock while a second goroutine
+	// tries to acquire it.
+	ApplyHook func(ctx context.Context)
+}
+
+func (f *fakeRunner) Init(_ context.Context, _ ...tfexec.InitOption) error {
+	f.mu.Lock()
+	f.InitCalls++
+	err := f.InitErr
+	f.mu.Unlock()
+	return err
+}
+
+func (f *fakeRunner) Plan(_ context.Context, _ ...tfexec.PlanOption) (bool, error) {
+	f.mu.Lock()
+	f.PlanCalls++
+	err := f.PlanErr
+	changes := f.PlanHasChanges
+	f.mu.Unlock()
+	return changes, err
+}
+
+func (f *fakeRunner) Apply(ctx context.Context, opts ...tfexec.ApplyOption) error {
+	f.mu.Lock()
+	f.ApplyCalls++
+	f.LastApplyOpts = opts
+	hook := f.ApplyHook
+	err := f.ApplyErr
+	f.mu.Unlock()
+	if hook != nil {
+		hook(ctx)
+	}
+	return err
+}
+
+func (f *fakeRunner) Destroy(_ context.Context, _ ...tfexec.DestroyOption) error {
+	f.mu.Lock()
+	f.DestroyCalls++
+	err := f.DestroyErr
+	f.mu.Unlock()
+	return err
+}
+
+func (f *fakeRunner) SetEnv(e map[string]string) error {
+	f.mu.Lock()
+	f.SetEnvCalls++
+	f.LastEnv = e
+	f.mu.Unlock()
+	return nil
+}
+
+// newFakeRunnerFactory returns a tfRunnerFactory that always hands back the
+// same fakeRunner — so tests can observe calls after the wrapper returns.
+func newFakeRunnerFactory(r *fakeRunner) tfRunnerFactory {
+	return func(_, _ string) (tfRunner, error) {
+		if r == nil {
+			return nil, errors.New("fakeRunner is nil")
+		}
+		return r, nil
+	}
+}

--- a/ucm/deploy/terraform/init.go
+++ b/ucm/deploy/terraform/init.go
@@ -1,0 +1,43 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// Init ensures main.tf.json is current (calls Render) and then runs
+// `terraform init` in the working directory.
+//
+// Init is idempotent: calling it twice on the same *Terraform will re-render
+// main.tf.json (cheap) but skip the underlying terraform init the second
+// time. Callers that want to force a re-init (e.g. after a provider version
+// bump) should construct a fresh *Terraform.
+func (t *Terraform) Init(ctx context.Context, u *ucm.Ucm) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Render(ctx, u); err != nil {
+		return err
+	}
+
+	if err := t.ensureRunner(ctx); err != nil {
+		return err
+	}
+
+	if t.initialized {
+		log.Debugf(ctx, "terraform init: already initialized, skipping")
+		return nil
+	}
+
+	if err := t.runner.Init(ctx, tfexec.Upgrade(true)); err != nil {
+		return fmt.Errorf("terraform init: %w", err)
+	}
+	t.initialized = true
+	log.Infof(ctx, "terraform init completed")
+	return nil
+}

--- a/ucm/deploy/terraform/init_test.go
+++ b/ucm/deploy/terraform/init_test.go
@@ -1,0 +1,66 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newInitTerraform builds a *Terraform wired to a fakeRunner so Init can be
+// exercised without a real terraform binary install.
+func newInitTerraform(t *testing.T) (*Terraform, *fakeRunner) {
+	t.Helper()
+	root := t.TempDir()
+	workingDir := filepath.Join(root, ".databricks", "ucm", "dev", "terraform")
+	require.NoError(t, os.MkdirAll(workingDir, 0o700))
+
+	runner := &fakeRunner{}
+	tf := &Terraform{
+		ExecPath:      "/stub/terraform",
+		WorkingDir:    workingDir,
+		Env:           map[string]string{"DATABRICKS_HOST": "https://example.cloud.databricks.com"},
+		runnerFactory: newFakeRunnerFactory(runner),
+	}
+	return tf, runner
+}
+
+func TestInitRendersMainTfJson(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	tf, runner := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+
+	require.NoError(t, tf.Init(t.Context(), u))
+
+	_, err := os.Stat(filepath.Join(tf.WorkingDir, MainConfigFileName))
+	require.NoError(t, err, "main.tf.json should exist after Init")
+	assert.Equal(t, 1, runner.InitCalls)
+	assert.Equal(t, 1, runner.SetEnvCalls)
+	assert.Equal(t, tf.Env, runner.LastEnv)
+}
+
+func TestInitIsIdempotent(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	tf, runner := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+
+	require.NoError(t, tf.Init(t.Context(), u))
+	require.NoError(t, tf.Init(t.Context(), u))
+
+	assert.Equal(t, 1, runner.InitCalls, "second Init should skip the underlying terraform init")
+	// SetEnv is called once, when the runner is first bound.
+	assert.Equal(t, 1, runner.SetEnvCalls)
+}
+
+func TestInitPropagatesRunnerError(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	tf, runner := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+	runner.InitErr = assert.AnError
+
+	err := tf.Init(t.Context(), u)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/ucm/deploy/terraform/install.go
+++ b/ucm/deploy/terraform/install.go
@@ -1,0 +1,48 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/hc-install/releases"
+)
+
+// Installer resolves a Terraform binary on disk. Split out behind an
+// interface so tests can stub the download step.
+type Installer interface {
+	// Install downloads terraform v into dir and returns the absolute path
+	// of the installed binary.
+	Install(ctx context.Context, dir string, v *version.Version) (string, error)
+}
+
+// hcInstaller is the production Installer — delegates to hashicorp/hc-install.
+type hcInstaller struct{}
+
+// Install downloads terraform via hashicorp/hc-install.
+func (hcInstaller) Install(ctx context.Context, dir string, v *version.Version) (string, error) {
+	installer := &releases.ExactVersion{
+		Product:    product.Terraform,
+		Version:    v,
+		InstallDir: dir,
+		Timeout:    1 * time.Minute,
+	}
+	return installer.Install(ctx)
+}
+
+// lookupVersionFromEnv returns the terraform version configured via
+// DATABRICKS_TF_VERSION, or (nil, false, nil) if unset.
+func lookupVersionFromEnv(ctx context.Context) (*version.Version, bool, error) {
+	raw, ok := env.Lookup(ctx, VersionEnv)
+	if !ok || raw == "" {
+		return nil, false, nil
+	}
+	v, err := version.NewVersion(raw)
+	if err != nil {
+		return nil, false, fmt.Errorf("parse %s=%q: %w", VersionEnv, raw, err)
+	}
+	return v, true, nil
+}

--- a/ucm/deploy/terraform/lock.go
+++ b/ucm/deploy/terraform/lock.go
@@ -1,0 +1,24 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+)
+
+// defaultLockerFactory is the production factory — builds a Locker backed by
+// a local-disk filer under <root>/.databricks/ucm/<target>/state. Using the
+// local-disk filer for M1 keeps U5 landable ahead of U4 (which brings the
+// workspace-files state backend). When U4 lands, callers wanting remote
+// locking can override lockerFactory to point at a workspace-files filer.
+func defaultLockerFactory(ctx context.Context, u *ucm.Ucm, user string) (*lock.Locker, error) {
+	_, lockDir := lockIdentity(ctx, u)
+	f, err := libsfiler.NewLocalClient(lockDir)
+	if err != nil {
+		return nil, fmt.Errorf("init local-disk filer at %s: %w", lockDir, err)
+	}
+	return lock.NewLockerWithFiler(user, lockDir, f), nil
+}

--- a/ucm/deploy/terraform/pkg.go
+++ b/ucm/deploy/terraform/pkg.go
@@ -1,0 +1,53 @@
+// Package terraform is the terraform-engine wrapper for ucm. It sits on top
+// of the ucm/deploy/terraform/tfdyn converter (U3) and the ucm/deploy/lock
+// Locker (U2), mirroring the shape of bundle/deploy/terraform without
+// importing from bundle.
+//
+// Production code drives hashicorp/terraform-exec directly; tests inject a
+// fake tfRunner so the full init/plan/apply/destroy surface is exercised
+// without installing a real terraform binary.
+package terraform
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-version"
+)
+
+// MainConfigFileName is the on-disk name of the generated Terraform JSON
+// configuration written by Render. Mirrors bundle/deploy/terraform's
+// TerraformConfigFileName (bundle.tf.json) — the "main.tf.json" name is
+// chosen to match terraform's own convention for auto-loaded JSON config.
+const MainConfigFileName = "main.tf.json"
+
+// PlanFileName is the on-disk name of the plan artefact produced by Plan and
+// consumed by Apply. Kept identical to bundle/deploy/terraform so reviewers
+// have one fewer divergence to remember.
+const PlanFileName = "plan"
+
+// Terraform CLI override env vars. Same wire names as bundle/deploy/terraform
+// so a user's DATABRICKS_TF_EXEC_PATH works for both subcommands.
+const (
+	ExecPathEnv        = "DATABRICKS_TF_EXEC_PATH"
+	VersionEnv         = "DATABRICKS_TF_VERSION"
+	CliConfigPathEnv   = "DATABRICKS_TF_CLI_CONFIG_FILE"
+	ProviderVersionEnv = "DATABRICKS_TF_PROVIDER_VERSION"
+)
+
+// defaultTerraformVersion is the Terraform CLI version we download when the
+// user does not override it. Kept in lockstep with bundle/deploy/terraform so
+// the two subcommands use a single binary on disk.
+var defaultTerraformVersion = version.Must(version.NewVersion("1.5.5"))
+
+// GetTerraformVersion returns the terraform version to use, honouring
+// DATABRICKS_TF_VERSION when set.
+func GetTerraformVersion(ctx context.Context) (*version.Version, bool, error) {
+	v, ok, err := lookupVersionFromEnv(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if ok {
+		return v, false, nil
+	}
+	return defaultTerraformVersion, true, nil
+}

--- a/ucm/deploy/terraform/plan.go
+++ b/ucm/deploy/terraform/plan.go
@@ -1,0 +1,62 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// PlanResult is the outcome of a Plan call. PlanPath points at the on-disk
+// plan artefact Apply will consume; HasChanges is false when the plan is
+// empty (terraform exits 0 with no diffs) so callers can short-circuit.
+type PlanResult struct {
+	// PlanPath is the absolute on-disk path of the saved plan (-out).
+	PlanPath string
+	// HasChanges is true when terraform plan detected at least one change.
+	HasChanges bool
+	// Summary is a one-line human-readable summary ("plan: N change(s)" or
+	// "no changes").
+	Summary string
+}
+
+// Plan runs `terraform plan -out=<planfile>` in the working directory after
+// ensuring init has happened. The returned *PlanResult is kept on the
+// *Terraform as well, so a later Apply can pick up the plan artefact
+// without the caller having to thread it through.
+func (t *Terraform) Plan(ctx context.Context, u *ucm.Ucm) (*PlanResult, error) {
+	if t == nil {
+		return nil, fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Init(ctx, u); err != nil {
+		return nil, err
+	}
+
+	planPath := filepath.Join(t.WorkingDir, PlanFileName)
+	hasChanges, err := t.runner.Plan(ctx, tfexec.Out(planPath))
+	if err != nil {
+		return nil, fmt.Errorf("terraform plan: %w", err)
+	}
+
+	t.lastPlanPath = planPath
+	t.lastPlanExists = true
+
+	result := &PlanResult{
+		PlanPath:   planPath,
+		HasChanges: hasChanges,
+		Summary:    planSummary(hasChanges),
+	}
+	log.Infof(ctx, "terraform plan: %s (at %s)", result.Summary, filepath.ToSlash(planPath))
+	return result, nil
+}
+
+func planSummary(hasChanges bool) string {
+	if hasChanges {
+		return "plan has changes"
+	}
+	return "no changes"
+}

--- a/ucm/deploy/terraform/plan_test.go
+++ b/ucm/deploy/terraform/plan_test.go
@@ -1,0 +1,49 @@
+package terraform
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanReturnsResultWithChanges(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{PlanHasChanges: true}
+	tf, _ := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+	tf.runnerFactory = newFakeRunnerFactory(runner)
+
+	result, err := tf.Plan(t.Context(), u)
+	require.NoError(t, err)
+	assert.True(t, result.HasChanges)
+	assert.Equal(t, filepath.Join(tf.WorkingDir, PlanFileName), result.PlanPath)
+	assert.Equal(t, "plan has changes", result.Summary)
+	assert.Equal(t, 1, runner.PlanCalls)
+}
+
+func TestPlanReturnsResultWithoutChanges(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{PlanHasChanges: false}
+	tf, _ := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+	tf.runnerFactory = newFakeRunnerFactory(runner)
+
+	result, err := tf.Plan(t.Context(), u)
+	require.NoError(t, err)
+	assert.False(t, result.HasChanges)
+	assert.Equal(t, "no changes", result.Summary)
+}
+
+func TestPlanInitsFirst(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{}
+	tf, _ := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+	tf.runnerFactory = newFakeRunnerFactory(runner)
+
+	_, err := tf.Plan(t.Context(), u)
+	require.NoError(t, err)
+	assert.Equal(t, 1, runner.InitCalls, "Plan must call Init first")
+}

--- a/ucm/deploy/terraform/render.go
+++ b/ucm/deploy/terraform/render.go
@@ -1,0 +1,44 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/databricks/cli/libs/dyn/jsonsaver"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/terraform/tfdyn"
+)
+
+// Render converts the ucm config tree into a Terraform JSON resource map
+// and writes it to <workingDir>/main.tf.json. The conversion itself lives
+// in tfdyn (U3); Render is the thin filesystem adapter.
+//
+// The output is indented JSON for readability. Keys appear in insertion
+// order — libs/dyn/jsonsaver preserves the dyn.Value key order set by the
+// tfdyn walkers so diffs between Render runs are minimal.
+func (t *Terraform) Render(ctx context.Context, u *ucm.Ucm) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	tree, err := tfdyn.Convert(ctx, u)
+	if err != nil {
+		return fmt.Errorf("convert ucm to terraform: %w", err)
+	}
+
+	data, err := jsonsaver.MarshalIndent(tree, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal terraform json: %w", err)
+	}
+
+	outPath := filepath.Join(t.WorkingDir, MainConfigFileName)
+	if err := os.WriteFile(outPath, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+
+	log.Infof(ctx, "Rendered terraform config at %s", filepath.ToSlash(outPath))
+	return nil
+}

--- a/ucm/deploy/terraform/render_test.go
+++ b/ucm/deploy/terraform/render_test.go
@@ -1,0 +1,120 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// golden is the expected main.tf.json body for a 1-catalog + 1-schema +
+// 1-grant input. Indentation and key order must match jsonsaver's output
+// exactly — converters emit keys in insertion order and jsonsaver preserves
+// that order.
+const golden = `{
+  "resource": {
+    "databricks_catalog": {
+      "sales": {
+        "name": "sales_prod",
+        "comment": "sales data",
+        "force_destroy": true
+      }
+    },
+    "databricks_schema": {
+      "raw": {
+        "name": "raw",
+        "catalog_name": "sales",
+        "force_destroy": true,
+        "depends_on": [
+          "databricks_catalog.sales"
+        ]
+      }
+    },
+    "databricks_grants": {
+      "sales_admins": {
+        "catalog": "${databricks_catalog.sales.name}",
+        "grant": [
+          {
+            "principal": "sales-admins",
+            "privileges": [
+              "USE_CATALOG"
+            ]
+          }
+        ],
+        "depends_on": [
+          "databricks_catalog.sales"
+        ]
+      }
+    }
+  }
+}
+`
+
+func newRenderUcm(t *testing.T) (*ucm.Ucm, string) {
+	t.Helper()
+	root := t.TempDir()
+
+	cfg, diags := config.LoadFromBytes(filepath.Join(root, "ucm.yml"), []byte(`
+ucm:
+  name: render-test
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+      comment: sales data
+  schemas:
+    raw:
+      name: raw
+      catalog: sales
+  grants:
+    sales_admins:
+      securable:
+        type: catalog
+        name: sales
+      principal: sales-admins
+      privileges: [USE_CATALOG]
+`))
+	require.False(t, diags.HasError(), "load diagnostics: %v", diags)
+	cfg.Ucm.Target = "dev"
+
+	return &ucm.Ucm{RootPath: root, Config: *cfg}, root
+}
+
+func TestRenderWritesExpectedMainTfJson(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+
+	tf := &Terraform{
+		WorkingDir:    workingDir,
+		runnerFactory: defaultRunnerFactory,
+	}
+
+	require.NoError(t, tf.Render(t.Context(), u))
+
+	body, err := os.ReadFile(filepath.Join(workingDir, MainConfigFileName))
+	require.NoError(t, err)
+	assert.Equal(t, golden, string(body))
+}
+
+func TestRenderIsIdempotent(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+
+	tf := &Terraform{WorkingDir: workingDir}
+
+	require.NoError(t, tf.Render(t.Context(), u))
+	first, err := os.ReadFile(filepath.Join(workingDir, MainConfigFileName))
+	require.NoError(t, err)
+
+	require.NoError(t, tf.Render(t.Context(), u))
+	second, err := os.ReadFile(filepath.Join(workingDir, MainConfigFileName))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}

--- a/ucm/deploy/terraform/terraform.go
+++ b/ucm/deploy/terraform/terraform.go
@@ -1,0 +1,279 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// tfRunner is the minimal terraform-exec surface used by the wrapper.
+// Having an explicit interface keeps tests independent of a real terraform
+// binary — the production impl is *tfexec.Terraform; tests inject a fake.
+type tfRunner interface {
+	Init(ctx context.Context, opts ...tfexec.InitOption) error
+	Plan(ctx context.Context, opts ...tfexec.PlanOption) (bool, error)
+	Apply(ctx context.Context, opts ...tfexec.ApplyOption) error
+	Destroy(ctx context.Context, opts ...tfexec.DestroyOption) error
+	SetEnv(env map[string]string) error
+}
+
+// tfRunnerFactory builds a tfRunner given a working dir and exec path. Split
+// so tests can swap out the real binary for a fake.
+type tfRunnerFactory func(workingDir, execPath string) (tfRunner, error)
+
+// defaultRunnerFactory is the production factory — returns a real
+// *tfexec.Terraform bound to the given workingDir+execPath.
+func defaultRunnerFactory(workingDir, execPath string) (tfRunner, error) {
+	return tfexec.NewTerraform(workingDir, execPath)
+}
+
+// lockerFactory constructs a Locker scoped to the target-specific state
+// directory. Overridable by tests (so Apply/Destroy can hand a contending
+// Locker a shared in-memory filer).
+type lockerFactory func(ctx context.Context, u *ucm.Ucm, user string) (*lock.Locker, error)
+
+// Terraform is the top-level terraform-engine wrapper. One instance per
+// ucm.Ucm; calls to Render/Init/Plan/Apply/Destroy drive the underlying
+// tfRunner in sequence. The Terraform value itself is safe to reuse across
+// calls — Init is idempotent.
+type Terraform struct {
+	// ExecPath is the absolute path of the terraform binary.
+	ExecPath string
+	// WorkingDir is where main.tf.json, the plan artefact, and the state
+	// backend config live.
+	WorkingDir string
+	// Env is the environment map passed to terraform-exec. Populated by New;
+	// includes DATABRICKS_HOST/CLIENT_ID/CLIENT_SECRET + cloud-cred passthrough.
+	Env map[string]string
+
+	runner         tfRunner
+	runnerFactory  tfRunnerFactory
+	installer      Installer
+	lockerFactory  lockerFactory
+	user           string
+	lockTargetDir  string
+	initialized    bool
+	lastPlanPath   string
+	lastPlanExists bool
+}
+
+// New wires up a Terraform for the given ucm. It resolves (and if necessary
+// downloads via hc-install) the terraform binary, computes the working
+// directory, and assembles the env-var map used for auth and cloud-cred
+// passthrough. The caller is expected to have run SelectTarget first.
+func New(ctx context.Context, u *ucm.Ucm) (*Terraform, error) {
+	workingDir, err := WorkingDir(u)
+	if err != nil {
+		return nil, err
+	}
+
+	execPath, err := resolveExecPath(ctx, workingDir, hcInstaller{})
+	if err != nil {
+		return nil, err
+	}
+
+	envMap := buildEnv(ctx)
+
+	user, lockDir := lockIdentity(ctx, u)
+
+	return &Terraform{
+		ExecPath:      execPath,
+		WorkingDir:    workingDir,
+		Env:           envMap,
+		runnerFactory: defaultRunnerFactory,
+		installer:     hcInstaller{},
+		lockerFactory: defaultLockerFactory,
+		user:          user,
+		lockTargetDir: lockDir,
+	}, nil
+}
+
+// resolveExecPath returns an absolute path to a usable terraform binary.
+// Preference order:
+//  1. DATABRICKS_TF_EXEC_PATH (validated by exec.LookPath).
+//  2. <workingDir>/bin/<terraform binary> if already present.
+//  3. Download via hc-install into <workingDir>/bin.
+func resolveExecPath(ctx context.Context, workingDir string, installer Installer) (string, error) {
+	if p, ok := env.Lookup(ctx, ExecPathEnv); ok && p != "" {
+		abs, err := exec.LookPath(p)
+		if err != nil {
+			return "", fmt.Errorf("locate %s=%q: %w", ExecPathEnv, p, err)
+		}
+		log.Debugf(ctx, "Using terraform at %s (from %s)", filepath.ToSlash(abs), ExecPathEnv)
+		return abs, nil
+	}
+
+	binDir := filepath.Join(workingDir, "bin")
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		return "", fmt.Errorf("create terraform bin dir %s: %w", binDir, err)
+	}
+
+	existing := filepath.Join(binDir, product.Terraform.BinaryName())
+	if _, err := os.Stat(existing); err == nil {
+		log.Debugf(ctx, "Using terraform at %s", filepath.ToSlash(existing))
+		return existing, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("stat %s: %w", existing, err)
+	}
+
+	tv, _, err := GetTerraformVersion(ctx)
+	if err != nil {
+		return "", err
+	}
+	log.Infof(ctx, "Downloading terraform %s to %s", tv.String(), filepath.ToSlash(binDir))
+	path, err := installer.Install(ctx, binDir, tv)
+	if err != nil {
+		return "", fmt.Errorf("install terraform: %w", err)
+	}
+	return path, nil
+}
+
+// buildEnv assembles the env map passed to terraform-exec.
+//
+// It starts with the auth variables the databricks terraform provider reads
+// natively (DATABRICKS_HOST / DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET
+// / DATABRICKS_TOKEN / DATABRICKS_CONFIG_PROFILE), then layers on the cloud
+// credentials that the underlay resources will eventually need (AWS, Azure,
+// GCP), then PATH/HOME/TMPDIR/proxy variables so the subprocess inherits a
+// sane environment. Everything flows from the current process env — there is
+// no `--profile` resolution here; that is the CLI layer's job.
+func buildEnv(ctx context.Context) map[string]string {
+	out := map[string]string{}
+
+	passthroughKeys := []string{
+		// Databricks auth — consumed by the terraform-provider-databricks.
+		// See https://registry.terraform.io/providers/databricks/databricks/latest/docs
+		"DATABRICKS_HOST",
+		"DATABRICKS_CLIENT_ID",
+		"DATABRICKS_CLIENT_SECRET",
+		"DATABRICKS_TOKEN",
+		"DATABRICKS_CONFIG_PROFILE",
+		"DATABRICKS_CONFIG_FILE",
+		"DATABRICKS_ACCOUNT_ID",
+		"DATABRICKS_AUTH_TYPE",
+		"DATABRICKS_METADATA_SERVICE_URL",
+
+		// AWS cloud-underlay credentials. Out-of-scope for M1, but passing
+		// them through now keeps the wrapper from re-shaping once AWS
+		// resources land.
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_REGION",
+		"AWS_DEFAULT_REGION",
+		"AWS_PROFILE",
+		"AWS_WEB_IDENTITY_TOKEN_FILE",
+		"AWS_ROLE_ARN",
+		"AWS_ROLE_SESSION_NAME",
+
+		// Azure cloud-underlay credentials.
+		"AZURE_TENANT_ID",
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET",
+		"AZURE_SUBSCRIPTION_ID",
+		"AZURE_FEDERATED_TOKEN_FILE",
+
+		// GCP cloud-underlay credentials.
+		"GOOGLE_CREDENTIALS",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"GOOGLE_PROJECT",
+		"GOOGLE_REGION",
+
+		// Process plumbing.
+		"HOME",
+		"USERPROFILE",
+		"PATH",
+		"TF_CLI_CONFIG_FILE",
+	}
+	for _, k := range passthroughKeys {
+		if v, ok := env.Lookup(ctx, k); ok {
+			out[k] = v
+		}
+	}
+
+	// $DATABRICKS_TF_CLI_CONFIG_FILE maps to $TF_CLI_CONFIG_FILE so the
+	// VSCode extension's filesystem-mirror config is picked up when it lines
+	// up with the provider version we actually use.
+	if v, ok := env.Lookup(ctx, CliConfigPathEnv); ok && v != "" {
+		if _, err := os.Stat(v); err == nil {
+			out["TF_CLI_CONFIG_FILE"] = v
+		}
+	}
+
+	// Proxy variables — both upper and lower case; terraform-exec is fine
+	// with either, but downstream tools on macOS/Linux commonly read the
+	// uppercase form.
+	for _, v := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+		for _, key := range []string{v, strings.ToLower(v)} {
+			if val, ok := env.Lookup(ctx, key); ok {
+				out[strings.ToUpper(v)] = val
+			}
+		}
+	}
+
+	// TMPDIR / TMP — let terraform create temp files in a place it can write.
+	if runtime.GOOS == "windows" {
+		for _, k := range []string{"TMP", "TEMP"} {
+			if v, ok := env.Lookup(ctx, k); ok {
+				out[k] = v
+			}
+		}
+	} else if v, ok := env.Lookup(ctx, "TMPDIR"); ok {
+		out["TMPDIR"] = v
+	}
+
+	return out
+}
+
+// lockIdentity returns the (user, lockTargetDir) pair used to construct a
+// Locker for Apply/Destroy. user identifies the holder in the on-the-wire
+// lock record; lockTargetDir is the state dir whose race we are resolving.
+//
+// The lock dir follows the same `.databricks/ucm/<target>/state` convention
+// U4 will use for terraform state. Keeping the path client-derived (rather
+// than pulling it from a not-yet-wired Ucm field) lets U5 ship ahead of U4.
+func lockIdentity(ctx context.Context, u *ucm.Ucm) (string, string) {
+	user := env.Get(ctx, "USER")
+	if user == "" {
+		user = env.Get(ctx, "USERNAME")
+	}
+	if user == "" {
+		user = "ucm"
+	}
+	lockDir := filepath.Join(u.RootPath, filepath.FromSlash(cacheDirName), u.Config.Ucm.Target, "state")
+	return user, lockDir
+}
+
+// ensureRunner lazily binds a tfRunner to the Terraform wrapper. Split so
+// Init can re-use it and tests can bypass the factory by pre-populating the
+// runner field.
+func (t *Terraform) ensureRunner(_ context.Context) error {
+	if t.runner != nil {
+		return nil
+	}
+	factory := t.runnerFactory
+	if factory == nil {
+		factory = defaultRunnerFactory
+	}
+	r, err := factory(t.WorkingDir, t.ExecPath)
+	if err != nil {
+		return fmt.Errorf("init terraform-exec: %w", err)
+	}
+	if err := r.SetEnv(t.Env); err != nil {
+		return fmt.Errorf("set terraform env: %w", err)
+	}
+	t.runner = r
+	return nil
+}

--- a/ucm/deploy/terraform/terraform_test.go
+++ b/ucm/deploy/terraform/terraform_test.go
@@ -1,0 +1,70 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildEnvPassesAuthAndCloudVars pins the wire-level auth and cloud-cred
+// env variables we expect to forward to the terraform subprocess. The test
+// uses libs/env's context-backed environment so it doesn't pollute the
+// process-wide os.Environ.
+func TestBuildEnvPassesAuthAndCloudVars(t *testing.T) {
+	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://example.cloud.databricks.com")
+	ctx = env.Set(ctx, "DATABRICKS_CLIENT_ID", "sp-client-id")
+	ctx = env.Set(ctx, "DATABRICKS_CLIENT_SECRET", "sp-client-secret")
+	ctx = env.Set(ctx, "AWS_ACCESS_KEY_ID", "AKIA...")
+	ctx = env.Set(ctx, "AWS_SECRET_ACCESS_KEY", "secret")
+	ctx = env.Set(ctx, "AZURE_TENANT_ID", "azure-tenant")
+	ctx = env.Set(ctx, "GOOGLE_CREDENTIALS", `{"type":"service_account"}`)
+
+	got := buildEnv(ctx)
+
+	for _, key := range []string{
+		"DATABRICKS_HOST",
+		"DATABRICKS_CLIENT_ID",
+		"DATABRICKS_CLIENT_SECRET",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AZURE_TENANT_ID",
+		"GOOGLE_CREDENTIALS",
+	} {
+		_, ok := got[key]
+		assert.Truef(t, ok, "expected %s to be passed through", key)
+	}
+
+	assert.Equal(t, "https://example.cloud.databricks.com", got["DATABRICKS_HOST"])
+	assert.Equal(t, "sp-client-id", got["DATABRICKS_CLIENT_ID"])
+}
+
+func TestBuildEnvOmitsUnsetVars(t *testing.T) {
+	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://example.cloud.databricks.com")
+	got := buildEnv(ctx)
+
+	_, ok := got["DATABRICKS_CLIENT_ID"]
+	assert.False(t, ok, "unset var should not leak into env map")
+	_, ok = got["AWS_ACCESS_KEY_ID"]
+	assert.False(t, ok)
+}
+
+func TestBuildEnvMapsProxyVarsUppercase(t *testing.T) {
+	ctx := env.Set(t.Context(), "http_proxy", "http://proxy.example:3128")
+	ctx = env.Set(ctx, "HTTPS_PROXY", "http://proxy.example:3129")
+
+	got := buildEnv(ctx)
+	assert.Equal(t, "http://proxy.example:3128", got["HTTP_PROXY"])
+	assert.Equal(t, "http://proxy.example:3129", got["HTTPS_PROXY"])
+}
+
+func TestLockIdentityDerivesPathFromTarget(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	user, dir := lockIdentity(t.Context(), u)
+	require.NotEmpty(t, user)
+	assert.Contains(t, dir, ".databricks")
+	assert.Contains(t, dir, "ucm")
+	assert.Contains(t, dir, "dev")
+	assert.Contains(t, dir, "state")
+}


### PR DESCRIPTION
Closes #17

## Summary
- New `ucm/deploy/terraform/` package: `Terraform` struct with `New`, `Render`, `Init`, `Plan`, `Apply`, `Destroy` methods mirroring the shape of `bundle/deploy/terraform` without importing from `bundle`.
- `Apply` and `Destroy` acquire the U2 `Locker` (goals `deploy` / `destroy`) and release on defer; contention surfaces as `*lock.ErrLockHeld` reachable via `errors.As`.
- `Render` runs `tfdyn.Convert` (U3) and writes the result to `.databricks/ucm/<target>/terraform/main.tf.json` via `libs/dyn/jsonsaver` so key order — and therefore diffs — stay stable across runs.
- Internal `tfRunner` interface (Init/Plan/Apply/Destroy/SetEnv) is satisfied by `*tfexec.Terraform` in production and by a fake in tests, so the full lifecycle is exercised without a real terraform binary install.
- `New` resolves the terraform binary from `DATABRICKS_TF_EXEC_PATH`, from a cached copy under `<workingDir>/bin`, or by downloading via `hashicorp/hc-install` (same approach as `bundle/`).
- `buildEnv` forwards Databricks auth (`DATABRICKS_HOST/CLIENT_ID/CLIENT_SECRET/...`), AWS/Azure/GCP cloud credentials, and HTTP(S) proxy / TMPDIR plumbing to the terraform subprocess.

## Why
M1 needs the terraform engine path for `ucm deploy` and `ucm destroy`. U2 (lock) and U3 (tfdyn) are already in `ci/wave1-integration`; this PR stitches them together and adds the binary wrapper so U6 (phase orchestration) can wire `Render → Plan → Apply` into phases.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`
- [x] Render golden-file test against the 1-catalog/1-schema/1-grant fixture from U3.
- [x] Init idempotence test (second `Init` skips the underlying `terraform init`).
- [x] Lock contention test: two `Apply` calls share a filer; the second observes the first's record via `errors.As(err, &*ErrLockHeld)`.
- [x] Env var passthrough test asserts Databricks + AWS + Azure + GCP + proxy vars flow into the subprocess env.

## Fork-divergence notes
- Edits to upstream files: none.
- New touchpoints outside `cmd/ucm/**`, `ucm/**`, `.claude/**`, `.github/workflows/upstream-sync.yml`: none.
- No new dependencies — `hashicorp/terraform-exec`, `hashicorp/hc-install`, and `hashicorp/go-version` were already in `go.mod` from `bundle/`.
- Grep confirms no `github.com/databricks/cli/bundle` imports under `ucm/`.

## Base branch
Stacked on `ci/wave1-integration` per the U5 workstream dependencies on U2 (PR #13) and U3 (PR #14). Merge to `main` only after wave 1 lands.

## Dependencies
- U2 (Locker) — `ucm/deploy/lock` from `ci/wave1-integration`.
- U3 (tfdyn) — `ucm/deploy/terraform/tfdyn` from `ci/wave1-integration`.
- Intentionally ahead of U4 (state pull/push): the lock uses a local-disk filer by default; when U4 lands, callers that want remote locking can override `lockerFactory` to point at a workspace-files filer. No API change needed for the swap.

## Out of scope (tracked separately)
- State pull/push — U4.
- Direct-engine path — M2+.
- Phase orchestration wiring — U6.
- UC-specific post-apply diagnostics.