### PR TITLE
Feat #20: Wire phase orchestration for M1

### DIFF
--- a/ucm/phases/build.go
+++ b/ucm/phases/build.go
@@ -1,0 +1,36 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+)
+
+// Build renders the ucm configuration tree into the working directory's
+// main.tf.json via the terraform wrapper's Render step. The underlying
+// conversion is done by ucm/deploy/terraform/tfdyn.Convert and driven from
+// (*terraform.Terraform).Render; Build is the phase-level veneer so cmd layer
+// progress messages have a single pivot.
+//
+// Build returns the wrapper so callers can thread it into Plan/Deploy/Destroy
+// without recreating it (important: terraform.New resolves the binary on
+// disk, which is expensive). A nil return value means logdiag.HasError is
+// set and the caller should bail.
+func Build(ctx context.Context, u *ucm.Ucm, opts Options) TerraformWrapper {
+	log.Info(ctx, "Phase: build")
+
+	factory := opts.terraformFactoryOrDefault()
+	tf, err := factory(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("build terraform wrapper: %w", err))
+		return nil
+	}
+	if err := tf.Render(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("render terraform config: %w", err))
+		return nil
+	}
+	return tf
+}

--- a/ucm/phases/build_test.go
+++ b/ucm/phases/build_test.go
@@ -1,0 +1,65 @@
+package phases_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fakeTfFactory(f *fakeTf) phases.TerraformFactory {
+	return func(_ context.Context, _ *ucm.Ucm) (phases.TerraformWrapper, error) {
+		return f, nil
+	}
+}
+
+func TestBuildHappyPath(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	tf := phases.Build(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	require.False(t, logdiag.HasError(ctx))
+	require.NotNil(t, tf)
+	assert.Equal(t, 1, f.tf.RenderCalls)
+	assert.Equal(t, 0, f.tf.InitCalls, "Build must not call terraform init itself")
+}
+
+func TestBuildFactoryError(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	factory := func(_ context.Context, _ *ucm.Ucm) (phases.TerraformWrapper, error) {
+		return nil, errSentinel
+	}
+
+	tf := phases.Build(ctx, f.u, phases.Options{TerraformFactory: factory})
+
+	assert.Nil(t, tf)
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, errSentinel.Error())
+}
+
+func TestBuildRenderError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.RenderErr = errSentinel
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	tf := phases.Build(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	assert.Nil(t, tf)
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "render terraform config")
+}

--- a/ucm/phases/deploy.go
+++ b/ucm/phases/deploy.go
@@ -1,0 +1,50 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+)
+
+// Deploy runs the initialize → build → terraform-init → terraform-apply →
+// state-push sequence. Errors are reported via logdiag; state.Push is only
+// called when the apply succeeds, so a mid-apply failure leaves the remote
+// state on the previous Seq and the local cache updated but un-acknowledged.
+//
+// The terraform apply acquires its own deploy lock for the write window; the
+// preceding Pull (in Initialize) and the subsequent Push each acquire and
+// release the lock independently. Between those two lock windows the lock is
+// released — intentional, because holding a remote lock across a long
+// terraform apply would create availability problems for other targets.
+func Deploy(ctx context.Context, u *ucm.Ucm, opts Options) {
+	log.Info(ctx, "Phase: deploy")
+
+	setting := Initialize(ctx, u, opts)
+	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+		return
+	}
+
+	tf := Build(ctx, u, opts)
+	if tf == nil || logdiag.HasError(ctx) {
+		return
+	}
+
+	if err := tf.Init(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform init: %w", err))
+		return
+	}
+
+	if err := tf.Apply(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform apply: %w", err))
+		return
+	}
+
+	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
+		return
+	}
+}

--- a/ucm/phases/deploy_test.go
+++ b/ucm/phases/deploy_test.go
@@ -1,0 +1,108 @@
+package phases_test
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readRemoteSeq returns the Seq of the remote ucm-state.json, or -1 when the
+// file has not been written yet. Used to assert Push advanced the remote.
+func readRemoteSeq(t *testing.T, f *fixture) int {
+	t.Helper()
+	rc, err := f.remote.Read(t.Context(), deploy.UcmStateFileName)
+	if err != nil {
+		return -1
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	var s deploy.State
+	require.NoError(t, json.Unmarshal(data, &s))
+	return s.Seq
+}
+
+func TestDeployHappyPath(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	assert.Equal(t, 1, f.tf.RenderCalls)
+	assert.Equal(t, 1, f.tf.InitCalls)
+	assert.Equal(t, 1, f.tf.ApplyCalls)
+	// Post-apply Push must advance the remote Seq from 0 to 1.
+	assert.Equal(t, 1, readRemoteSeq(t, f))
+}
+
+func TestDeployShortCircuitsOnDirectEngine(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.ApplyCalls)
+	assert.Equal(t, -1, readRemoteSeq(t, f), "remote state must not advance when apply is skipped")
+}
+
+func TestDeployBailsOnApplyError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.ApplyErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	// Apply failed → Push must NOT run; remote ucm-state.json must stay
+	// absent because Pull only writes locally on first-run.
+	assert.Equal(t, -1, readRemoteSeq(t, f))
+}
+
+func TestDeployBailsOnInitializeError(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	// Zero Backend → Pull fails → the rest of Deploy short-circuits.
+	phases.Deploy(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.ApplyCalls)
+}
+
+func TestDeployBailsOnBuildError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.RenderErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.ApplyCalls)
+}

--- a/ucm/phases/destroy.go
+++ b/ucm/phases/destroy.go
@@ -1,0 +1,48 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+)
+
+// Destroy runs the initialize → terraform-init → terraform-destroy →
+// state-push sequence. The Build phase is skipped — destroy operates on the
+// already-rendered terraform config cached from the last apply (tf.Init
+// re-renders from current ucm.yml which is still necessary for the resource
+// graph). The final Push uploads the post-destroy terraform.tfstate so peers
+// observe the emptied state.
+func Destroy(ctx context.Context, u *ucm.Ucm, opts Options) {
+	log.Info(ctx, "Phase: destroy")
+
+	setting := Initialize(ctx, u, opts)
+	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+		return
+	}
+
+	factory := opts.terraformFactoryOrDefault()
+	tf, err := factory(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("build terraform wrapper: %w", err))
+		return
+	}
+
+	if err := tf.Init(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform init: %w", err))
+		return
+	}
+
+	if err := tf.Destroy(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform destroy: %w", err))
+		return
+	}
+
+	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
+		return
+	}
+}

--- a/ucm/phases/destroy_test.go
+++ b/ucm/phases/destroy_test.go
@@ -1,0 +1,89 @@
+package phases_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDestroyHappyPath(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	// Destroy does NOT call Render via Build — Init re-renders.
+	assert.Equal(t, 0, f.tf.RenderCalls)
+	assert.Equal(t, 1, f.tf.InitCalls)
+	assert.Equal(t, 1, f.tf.DestroyCalls)
+	assert.Equal(t, 0, f.tf.ApplyCalls)
+	// Post-destroy Push must advance the remote Seq.
+	assert.Equal(t, 1, readRemoteSeq(t, f))
+}
+
+func TestDestroyShortCircuitsOnDirectEngine(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.DestroyCalls)
+}
+
+func TestDestroyBailsOnDestroyError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.DestroyErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	// Destroy failed before Push; remote state file must not have been
+	// written (Pull only writes locally on first-run).
+	assert.Equal(t, -1, readRemoteSeq(t, f))
+}
+
+func TestDestroyBailsOnInitializeError(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.DestroyCalls)
+}
+
+func TestDestroyBailsOnInitError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.InitErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.DestroyCalls)
+}

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -1,0 +1,114 @@
+package phases_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/deploy"
+	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTf satisfies phases.TerraformWrapper for tests. Each method bumps a
+// counter and returns the pre-seeded err/plan value so test cases can assert
+// on call order and inject failures mid-sequence.
+type fakeTf struct {
+	mu sync.Mutex
+
+	RenderCalls  int
+	InitCalls    int
+	PlanCalls    int
+	ApplyCalls   int
+	DestroyCalls int
+
+	RenderErr  error
+	InitErr    error
+	PlanErr    error
+	ApplyErr   error
+	DestroyErr error
+
+	PlanResult *terraform.PlanResult
+}
+
+func (f *fakeTf) Render(_ context.Context, _ *ucm.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.RenderCalls++
+	return f.RenderErr
+}
+
+func (f *fakeTf) Init(_ context.Context, _ *ucm.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.InitCalls++
+	return f.InitErr
+}
+
+func (f *fakeTf) Plan(_ context.Context, _ *ucm.Ucm) (*terraform.PlanResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.PlanCalls++
+	return f.PlanResult, f.PlanErr
+}
+
+func (f *fakeTf) Apply(_ context.Context, _ *ucm.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ApplyCalls++
+	return f.ApplyErr
+}
+
+func (f *fakeTf) Destroy(_ context.Context, _ *ucm.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.DestroyCalls++
+	return f.DestroyErr
+}
+
+// fixture bundles the dependencies every phase test needs: a minimal Ucm with
+// a target selected, a local-filer-backed Backend that satisfies deploy.Pull
+// and deploy.Push, and the per-test fakeTf.
+type fixture struct {
+	t        *testing.T
+	u        *ucm.Ucm
+	backend  deploy.Backend
+	tf       *fakeTf
+	remote   libsfiler.Filer
+	localDir string
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	projDir := t.TempDir()
+	remoteDir := t.TempDir()
+
+	remote, err := libsfiler.NewLocalClient(remoteDir)
+	require.NoError(t, err)
+
+	u := &ucm.Ucm{RootPath: projDir}
+	u.Config.Ucm = config.Ucm{Name: "test", Target: "dev"}
+
+	return &fixture{
+		t:  t,
+		u:  u,
+		tf: &fakeTf{},
+		backend: deploy.Backend{
+			StateFiler: ucmfiler.NewStateFilerFromFiler(remote),
+			LockFiler:  remote,
+			User:       "alice@example.com",
+		},
+		remote:   remote,
+		localDir: filepath.Join(projDir, filepath.FromSlash(deploy.LocalCacheDir), "dev"),
+	}
+}
+
+// errSentinel is a stable error identity for tests that assert the wrapped
+// cause propagates through logdiag-formatted diagnostics.
+var errSentinel = errors.New("sentinel")

--- a/ucm/phases/initialize.go
+++ b/ucm/phases/initialize.go
@@ -1,0 +1,95 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/deploy"
+)
+
+// Engine-resolution source labels. Kept private and parallel to the labels
+// used by cmd/ucm/utils.ResolveEngineSetting so diagnostics remain consistent
+// with whichever entry point the caller exercised. Duplicated here (not
+// imported) because cmd/ucm/utils → phases makes utils → phases a cycle.
+const (
+	engineSourceConfig  = "config"
+	engineSourceEnv     = "env"
+	engineSourceDefault = "default"
+)
+
+// resolveEngine mirrors cmd/ucm/utils.ResolveEngineSetting. It lives here to
+// break the cmd/ucm/utils → phases import cycle that would otherwise form
+// when the CLI layer wants to compose both the load/validate phases and the
+// deploy phases from a single utils.ProcessUcm-style helper.
+func resolveEngine(ctx context.Context, u *ucm.Ucm) (engine.EngineSetting, error) {
+	configEngine := engine.EngineNotSet
+	if u != nil {
+		configEngine = u.Config.Ucm.Engine
+	}
+
+	if configEngine != engine.EngineNotSet {
+		return engine.EngineSetting{
+			Type:       configEngine,
+			Source:     engineSourceConfig,
+			ConfigType: configEngine,
+		}, nil
+	}
+
+	envEngine, err := engine.FromEnv(ctx)
+	if err != nil {
+		return engine.EngineSetting{}, err
+	}
+	if envEngine != engine.EngineNotSet {
+		return engine.EngineSetting{
+			Type:   envEngine,
+			Source: engineSourceEnv,
+		}, nil
+	}
+
+	return engine.EngineSetting{
+		Type:   engine.Default,
+		Source: engineSourceDefault,
+	}, nil
+}
+
+// Initialize resolves the deployment engine and pulls remote state into the
+// per-target local cache so downstream phases (build/plan/deploy/destroy) can
+// read a consistent baseline. Errors are reported via logdiag; callers must
+// check logdiag.HasError before proceeding.
+//
+// Initialize does NOT retain the deploy lock across phases — state.Pull
+// acquires and releases its own lock for the duration of the pull. The
+// subsequent terraform Apply/Destroy acquires a fresh lock covering the write
+// half of the deploy.
+func Initialize(ctx context.Context, u *ucm.Ucm, opts Options) engine.EngineSetting {
+	log.Info(ctx, "Phase: initialize")
+
+	setting, err := resolveEngine(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("resolve engine: %w", err))
+		return engine.EngineSetting{}
+	}
+	log.Debugf(ctx, "initialize: engine=%s source=%s", setting.Type, setting.Source)
+
+	if setting.Type.IsDirect() {
+		// Direct engine landed as a design goal but has no M1 implementation.
+		// Report via logdiag and bail — downstream phases will skip on
+		// logdiag.HasError.
+		logdiag.LogDiag(ctx, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "ucm direct engine is not yet implemented; set ucm.engine to terraform or unset DATABRICKS_UCM_ENGINE",
+		})
+		return setting
+	}
+
+	if err := deploy.Pull(ctx, u, opts.Backend); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("pull remote state: %w", err))
+		return setting
+	}
+	return setting
+}

--- a/ucm/phases/initialize_test.go
+++ b/ucm/phases/initialize_test.go
@@ -1,0 +1,81 @@
+package phases_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeHappyPath(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	setting := phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected error diagnostics: %v", logdiag.FlushCollected(ctx))
+	assert.Equal(t, engine.EngineTerraform, setting.Type)
+	assert.Equal(t, "default", setting.Source)
+}
+
+func TestInitializeDirectEngineIsStubbed(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	setting := phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+
+	assert.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, "direct engine is not yet implemented")
+	assert.Equal(t, engine.EngineDirect, setting.Type)
+}
+
+func TestInitializeDirectEngineViaEnv(t *testing.T) {
+	f := newFixture(t)
+	ctx := env.Set(t.Context(), engine.EnvVar, "direct")
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetCollect(ctx, true)
+
+	setting := phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, engine.EngineDirect, setting.Type)
+	assert.Equal(t, "env", setting.Source)
+}
+
+func TestInitializeInvalidEngineEnv(t *testing.T) {
+	f := newFixture(t)
+	ctx := env.Set(t.Context(), engine.EnvVar, "bogus")
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetCollect(ctx, true)
+
+	phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, engine.EnvVar)
+}
+
+func TestInitializeMissingBackendFails(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	// Zero-valued Backend — Pull refuses to run.
+	phases.Initialize(ctx, f.u, phases.Options{})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "pull remote state")
+}

--- a/ucm/phases/options.go
+++ b/ucm/phases/options.go
@@ -1,0 +1,65 @@
+package phases
+
+import (
+	"context"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+)
+
+// TerraformWrapper is the slice of *terraform.Terraform that phases depend on.
+// Keeping the surface minimal lets tests inject a fake without standing up a
+// real terraform binary. *terraform.Terraform satisfies this interface so the
+// production factory does not need an adapter.
+type TerraformWrapper interface {
+	Render(ctx context.Context, u *ucm.Ucm) error
+	Init(ctx context.Context, u *ucm.Ucm) error
+	Plan(ctx context.Context, u *ucm.Ucm) (*terraform.PlanResult, error)
+	Apply(ctx context.Context, u *ucm.Ucm) error
+	Destroy(ctx context.Context, u *ucm.Ucm) error
+}
+
+// TerraformFactory constructs a terraform-engine wrapper scoped to u.
+// Production callers pass DefaultTerraformFactory; tests hand in a factory
+// that returns a fake.
+type TerraformFactory func(ctx context.Context, u *ucm.Ucm) (TerraformWrapper, error)
+
+// Compile-time assertion that *terraform.Terraform satisfies TerraformWrapper.
+// Keeps the interface honest when the underlying wrapper gains new methods;
+// a broken assertion catches the drift at build time rather than at the
+// DefaultTerraformFactory call site.
+var _ TerraformWrapper = (*terraform.Terraform)(nil)
+
+// DefaultTerraformFactory builds a real *terraform.Terraform via terraform.New,
+// resolving (and if necessary downloading) the terraform binary on first use.
+// Production callers pass this directly; tests never should.
+func DefaultTerraformFactory(ctx context.Context, u *ucm.Ucm) (TerraformWrapper, error) {
+	return terraform.New(ctx, u)
+}
+
+// Options bundles the externally-supplied dependencies a phase needs at
+// runtime. Zero-valued Options is never meaningful in production — the CLI
+// layer (U7) will always populate Backend + TerraformFactory before invoking
+// plan/deploy/destroy. Tests may omit Backend when exercising the
+// engine-direct stub or the no-op initialize error paths.
+type Options struct {
+	// Backend is the pull/push state-storage pair used by Initialize and
+	// the post-apply/destroy Push. Required for Plan/Deploy/Destroy in the
+	// terraform engine; callers that set the engine to direct (and thus
+	// short-circuit) may leave it nil.
+	Backend deploy.Backend
+
+	// TerraformFactory produces the terraform wrapper bound to u. When nil,
+	// phases fall back to DefaultTerraformFactory.
+	TerraformFactory TerraformFactory
+}
+
+// terraformFactoryOrDefault returns o.TerraformFactory or the production
+// factory when unset.
+func (o Options) terraformFactoryOrDefault() TerraformFactory {
+	if o.TerraformFactory != nil {
+		return o.TerraformFactory
+	}
+	return DefaultTerraformFactory
+}

--- a/ucm/phases/plan.go
+++ b/ucm/phases/plan.go
@@ -1,0 +1,45 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+)
+
+// Plan runs the initialize → build → terraform-init → terraform-plan sequence
+// and returns the resulting *terraform.PlanResult. Errors are reported via
+// logdiag; on error Plan returns nil and the caller should check
+// logdiag.HasError before rendering any output.
+//
+// Plan does NOT call state.Push — a plan never advances remote state. The
+// deploy-side lock is held only for the state.Pull in Initialize and
+// released; planning itself runs lock-free because it never writes.
+func Plan(ctx context.Context, u *ucm.Ucm, opts Options) *terraform.PlanResult {
+	log.Info(ctx, "Phase: plan")
+
+	setting := Initialize(ctx, u, opts)
+	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+		return nil
+	}
+
+	tf := Build(ctx, u, opts)
+	if tf == nil || logdiag.HasError(ctx) {
+		return nil
+	}
+
+	if err := tf.Init(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform init: %w", err))
+		return nil
+	}
+
+	result, err := tf.Plan(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform plan: %w", err))
+		return nil
+	}
+	return result
+}

--- a/ucm/phases/plan_test.go
+++ b/ucm/phases/plan_test.go
@@ -1,0 +1,96 @@
+package phases_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanHappyPath(t *testing.T) {
+	f := newFixture(t)
+	f.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "plan has changes"}
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.False(t, logdiag.HasError(ctx))
+	require.NotNil(t, result)
+	assert.True(t, result.HasChanges)
+	assert.Equal(t, 1, f.tf.RenderCalls)
+	assert.Equal(t, 1, f.tf.InitCalls)
+	assert.Equal(t, 1, f.tf.PlanCalls)
+}
+
+func TestPlanBailsOnInitializeError(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	// Missing Backend — Initialize.Pull fails, Plan should short-circuit.
+	result := phases.Plan(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	assert.Nil(t, result)
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.RenderCalls, "Build must not run when Initialize failed")
+}
+
+func TestPlanShortCircuitsOnDirectEngine(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	assert.Nil(t, result)
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.RenderCalls)
+	assert.Equal(t, 0, f.tf.InitCalls)
+	assert.Equal(t, 0, f.tf.PlanCalls)
+}
+
+func TestPlanBailsOnInitError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.InitErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	assert.Nil(t, result)
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.PlanCalls, "Plan should not run when Init fails")
+}
+
+func TestPlanPropagatesPlanError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.PlanErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	assert.Nil(t, result)
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "terraform plan")
+}


### PR DESCRIPTION
Closes #20

## Summary
- Add `ucm/phases/{initialize,build,plan,deploy,destroy}.go` composing Wave 2 primitives (state pull+push, deploy lock, terraform wrapper, tfdyn) into a logdiag-driven sequence.
- Engine dispatch: `ucm.engine` > `DATABRICKS_UCM_ENGINE` > default. `direct` logs `diag.Error` and short-circuits; only `terraform` is implemented in M1.
- Dependencies injected via `phases.Options{Backend, TerraformFactory}` so tests run on a fake Terraform + local-filer state backend, and U7 (CLI wiring) can pass real deps.
- `phases.TerraformWrapper` is a trimmed 5-method slice of `*terraform.Terraform`; a compile-time assertion keeps the slice honest on future changes.
- Engine-resolution is inlined in `ucm/phases` (not imported from `cmd/ucm/utils`) to break the `utils -> phases` import cycle that `ProcessUcm`-style callers would otherwise form.

## Why
Wave 3 synthesis: Wave 2 delivered the primitives (tfdyn, state, lock, terraform wrapper); U7 (CLI verbs) needs a single pivot to call per verb without re-composing the primitive chain inline at each call site. Mirroring `bundle/phases` keeps the cmd layer small and makes the engine-dispatch contract explicit in one place.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test ./cmd/ucm/... ./ucm/...`
- [x] 21 new tests in `ucm/phases/` (5 per phase + 1 build test set): happy path, engine-direct short-circuit, initialize failure propagation, mid-sequence error propagation. All green.

This PR stacks on `ci/wave2-integration`; merge after Wave 2 integration validates.