### PR TITLE
Feat #22: Wire M1 verbs

### DIFF
--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -1,0 +1,51 @@
+package ucm
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+func newDeployCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Apply ucm configuration to the target Databricks account/workspace.",
+		Long: `Apply ucm configuration to the target Databricks account/workspace.
+
+Runs the full deploy sequence: initialize → build → terraform init →
+terraform apply → state push. A failure mid-apply leaves the remote state on
+the previous seq; re-running the command will re-attempt from a fresh pull.
+
+Common invocations:
+  databricks ucm deploy                  # Deploy the default target
+  databricks ucm deploy --target prod    # Deploy a specific target`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		opts, err := buildPhaseOptions(ctx, u)
+		if err != nil {
+			return fmt.Errorf("resolve deploy options: %w", err)
+		}
+
+		phases.Deploy(ctx, u, opts)
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Deploy OK!")
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/deploy_test.go
+++ b/cmd/ucm/deploy_test.go
@@ -1,0 +1,32 @@
+package ucm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_Deploy_HappyPath(t *testing.T) {
+	h := newVerbHarness(t)
+
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "deploy")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Deploy OK!")
+	assert.Equal(t, 1, h.tf.RenderCalls)
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.ApplyCalls)
+	assert.Equal(t, 0, h.tf.DestroyCalls)
+}
+
+func TestCmd_Deploy_PropagatesApplyError(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.ApplyErr = assertSentinel
+
+	_, _, err := runVerb(t, validFixtureDir(t), "deploy")
+
+	require.Error(t, err)
+	assert.Equal(t, 1, h.tf.ApplyCalls)
+}

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -1,0 +1,61 @@
+package ucm
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+func newDestroyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "destroy",
+		Short: "Tear down everything managed by the current target.",
+		Long: `Tear down everything managed by the current target.
+
+Runs the initialize → terraform init → terraform destroy → state push sequence
+against the selected target. Operates on the already-rendered terraform config
+cached from the last apply.
+
+Common invocations:
+  databricks ucm destroy --auto-approve                # Destroy default target
+  databricks ucm destroy --target dev --auto-approve   # Destroy a specific target`,
+		Args: root.NoArgs,
+	}
+
+	var autoApprove bool
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip interactive approvals for deleting resources.")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if !cmdio.IsPromptSupported(ctx) && !autoApprove {
+			return errors.New("please specify --auto-approve since terminal does not support interactive prompts")
+		}
+
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx = cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		opts, err := buildPhaseOptions(ctx, u)
+		if err != nil {
+			return fmt.Errorf("resolve deploy options: %w", err)
+		}
+
+		phases.Destroy(ctx, u, opts)
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Destroy OK!")
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/destroy_test.go
+++ b/cmd/ucm/destroy_test.go
@@ -1,0 +1,41 @@
+package ucm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_Destroy_RequiresAutoApprove(t *testing.T) {
+	_ = newVerbHarness(t)
+
+	_, _, err := runVerb(t, validFixtureDir(t), "destroy")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auto-approve")
+}
+
+func TestCmd_Destroy_HappyPathWithAutoApprove(t *testing.T) {
+	h := newVerbHarness(t)
+
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "destroy", "--auto-approve")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Destroy OK!")
+	assert.Equal(t, 0, h.tf.RenderCalls, "destroy should not call Render")
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.DestroyCalls)
+	assert.Equal(t, 0, h.tf.ApplyCalls)
+}
+
+func TestCmd_Destroy_PropagatesDestroyError(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.DestroyErr = assertSentinel
+
+	_, _, err := runVerb(t, validFixtureDir(t), "destroy", "--auto-approve")
+
+	require.Error(t, err)
+	assert.Equal(t, 1, h.tf.DestroyCalls)
+}

--- a/cmd/ucm/helpers_test.go
+++ b/cmd/ucm/helpers_test.go
@@ -1,0 +1,187 @@
+package ucm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/databricks/cli/libs/cmdio"
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/libs/logdiag"
+	ucmpkg "github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTf satisfies phases.TerraformWrapper for verb smoke tests. Mirrors the
+// shape of ucm/phases/helpers_test.go's fakeTf but lives in this package so
+// we don't have to re-export it.
+type fakeTf struct {
+	mu sync.Mutex
+
+	RenderCalls  int
+	InitCalls    int
+	PlanCalls    int
+	ApplyCalls   int
+	DestroyCalls int
+
+	RenderErr  error
+	InitErr    error
+	PlanErr    error
+	ApplyErr   error
+	DestroyErr error
+
+	PlanResult *terraform.PlanResult
+}
+
+func (f *fakeTf) Render(_ context.Context, _ *ucmpkg.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.RenderCalls++
+	return f.RenderErr
+}
+
+func (f *fakeTf) Init(_ context.Context, _ *ucmpkg.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.InitCalls++
+	return f.InitErr
+}
+
+func (f *fakeTf) Plan(_ context.Context, _ *ucmpkg.Ucm) (*terraform.PlanResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.PlanCalls++
+	return f.PlanResult, f.PlanErr
+}
+
+func (f *fakeTf) Apply(_ context.Context, _ *ucmpkg.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ApplyCalls++
+	return f.ApplyErr
+}
+
+func (f *fakeTf) Destroy(_ context.Context, _ *ucmpkg.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.DestroyCalls++
+	return f.DestroyErr
+}
+
+// verbHarness bundles the fake terraform wrapper, the remote-state filer
+// backing Pull/Push, and an override of buildPhaseOptions so the verb under
+// test runs against the fake instead of reaching for a real workspace client.
+type verbHarness struct {
+	tf     *fakeTf
+	remote libsfiler.Filer
+}
+
+// newVerbHarness builds a harness keyed to a temp-dir "remote" filer and
+// reassigns the package-level buildPhaseOptions to emit phases.Options that
+// point at the fake. The original buildPhaseOptions is restored on test
+// cleanup so later tests observe the production default.
+func newVerbHarness(t *testing.T) *verbHarness {
+	t.Helper()
+
+	remoteDir := t.TempDir()
+	remote, err := libsfiler.NewLocalClient(remoteDir)
+	require.NoError(t, err)
+
+	h := &verbHarness{
+		tf:     &fakeTf{},
+		remote: remote,
+	}
+
+	prev := buildPhaseOptions
+	buildPhaseOptions = func(_ context.Context, _ *ucmpkg.Ucm) (phases.Options, error) {
+		return phases.Options{
+			Backend: deploy.Backend{
+				StateFiler: ucmfiler.NewStateFilerFromFiler(remote),
+				LockFiler:  remote,
+				User:       "alice@example.com",
+			},
+			TerraformFactory: func(_ context.Context, _ *ucmpkg.Ucm) (phases.TerraformWrapper, error) {
+				return h.tf, nil
+			},
+		}, nil
+	}
+	t.Cleanup(func() { buildPhaseOptions = prev })
+
+	return h
+}
+
+// runVerb clones fixtureDir into a fresh temp dir and then invokes
+// `databricks ucm <args...>` with cwd set to the clone. Cloning keeps
+// state-pull side effects out of the repo checkout.
+func runVerb(t *testing.T, fixtureDir string, args ...string) (string, string, error) {
+	t.Helper()
+	work := cloneFixture(t, fixtureDir)
+	return runVerbInDir(t, work, args...)
+}
+
+// runVerbInDir runs the ucm cobra tree in workDir as-is (no cloning). Use
+// this from tests that need to seed files into the cwd before invocation
+// (e.g. summary tests seeding a tfstate).
+func runVerbInDir(t *testing.T, workDir string, args ...string) (string, string, error) {
+	t.Helper()
+
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	cmd := New()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+
+	ctx, diagOut := cmdio.NewTestContextWithStderr(context.Background())
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetRoot(ctx, workDir)
+	cmd.SetContext(ctx)
+
+	err = cmd.Execute()
+	return out.String(), diagOut.String() + errOut.String(), err
+}
+
+// cloneFixture copies the flat set of files in fixtureDir into a per-test
+// temp dir. Only top-level files are copied — the ucm fixtures don't nest
+// and the state-pull side of verb tests would otherwise mutate the repo
+// checkout.
+func cloneFixture(t *testing.T, fixtureDir string) string {
+	t.Helper()
+	dst := t.TempDir()
+	entries, err := os.ReadDir(fixtureDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(fixtureDir, e.Name()))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dst, e.Name()), data, 0o644))
+	}
+	return dst
+}
+
+// validFixtureDir is the canonical on-disk ucm.yml the verb smoke tests drive
+// against. Kept next to the cobra wiring so the test's intent (a happy-path
+// run) stays obvious.
+func validFixtureDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join("testdata", "valid")
+}
+
+// assertSentinel is a stable error identity for tests that assert a specific
+// phase error bubbles up to the cobra RunE. Name deliberately parallels the
+// phases-package errSentinel without colliding.
+var assertSentinel = errors.New("ucm verb test sentinel")

--- a/cmd/ucm/options.go
+++ b/cmd/ucm/options.go
@@ -1,0 +1,36 @@
+package ucm
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/phases"
+)
+
+// buildPhaseOptions is the indirection used by plan/deploy/destroy to assemble
+// phases.Options. Tests overwrite this variable in-package to inject a fake
+// TerraformFactory and a local-disk Backend without standing up a real
+// workspace client. Production callers get the default implementation which
+// resolves the state backend from ctx + ucm config.
+var buildPhaseOptions = defaultBuildPhaseOptions
+
+// defaultBuildPhaseOptions is the production implementation of
+// buildPhaseOptions. It reads the workspace client from ctx (populated by
+// root.MustWorkspaceClient when the user supplies auth) and delegates the
+// state-backend shape to ucm/deploy.BackendFromUcm. The returned Options
+// always uses phases.DefaultTerraformFactory — the terraform wrapper
+// constructor is expensive (binary resolution + working dir) and we only
+// stand it up on first invocation.
+func defaultBuildPhaseOptions(ctx context.Context, u *ucm.Ucm) (phases.Options, error) {
+	w := cmdctx.WorkspaceClient(ctx)
+	backend, err := deploy.BackendFromUcm(ctx, u, w)
+	if err != nil {
+		return phases.Options{}, err
+	}
+	return phases.Options{
+		Backend:          backend,
+		TerraformFactory: phases.DefaultTerraformFactory,
+	}, nil
+}

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -1,0 +1,54 @@
+package ucm
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+func newPlanCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plan",
+		Short: "Preview the changes ucm deploy would make.",
+		Long: `Preview the changes ucm deploy would make.
+
+Runs the initialize → build → terraform init → terraform plan sequence and
+prints a one-line summary. No state is mutated and no remote resources are
+touched.
+
+Common invocations:
+  databricks ucm plan                   # Plan against the default target
+  databricks ucm plan --target prod     # Plan against a specific target`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		opts, err := buildPhaseOptions(ctx, u)
+		if err != nil {
+			return fmt.Errorf("resolve deploy options: %w", err)
+		}
+
+		result := phases.Plan(ctx, u, opts)
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+		if result == nil {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), result.Summary)
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/plan_test.go
+++ b/cmd/ucm/plan_test.go
@@ -1,0 +1,33 @@
+package ucm
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_Plan_HappyPathPrintsSummary(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "plan has changes"}
+
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "plan")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "plan has changes")
+	assert.Equal(t, 1, h.tf.RenderCalls)
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.PlanCalls)
+}
+
+func TestCmd_Plan_NoChangesPrintsSummary(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.PlanResult = &terraform.PlanResult{HasChanges: false, Summary: "no changes"}
+
+	stdout, _, err := runVerb(t, validFixtureDir(t), "plan")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "no changes")
+}

--- a/cmd/ucm/policy_check.go
+++ b/cmd/ucm/policy_check.go
@@ -1,0 +1,41 @@
+package ucm
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+func newPolicyCheckCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy-check",
+		Short: "Run only the ucm validation mutators (tags, naming, required fields).",
+		Long: `Run the subset of ucm validation mutators that are cheap enough for a
+pre-commit hook. Unlike ` + "`ucm validate`" + `, which runs the full mutator chain,
+policy-check only runs the validation rules (tag enforcement, naming,
+required fields). No network I/O.`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		phases.PolicyCheck(ctx, u)
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Policy check OK!")
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/policy_check_test.go
+++ b/cmd/ucm/policy_check_test.go
@@ -1,0 +1,24 @@
+package ucm
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_PolicyCheck_ValidFixturePasses(t *testing.T) {
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "policy-check")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Policy check OK!")
+}
+
+func TestCmd_PolicyCheck_MissingTagFixtureFails(t *testing.T) {
+	_, stderr, err := runVerb(t, filepath.Join("testdata", "missing_tag"), "policy-check")
+
+	require.Error(t, err)
+	assert.Contains(t, stderr, "requires tag")
+}

--- a/cmd/ucm/stubs.go
+++ b/cmd/ucm/stubs.go
@@ -21,22 +21,6 @@ func stub(use, short string) *cobra.Command {
 	return cmd
 }
 
-func newPlanCommand() *cobra.Command {
-	return stub("plan", "Preview the changes ucm deploy would make.")
-}
-
-func newDeployCommand() *cobra.Command {
-	return stub("deploy", "Apply ucm configuration to the target Databricks account/workspace.")
-}
-
-func newDestroyCommand() *cobra.Command {
-	return stub("destroy", "Tear down everything managed by the current target.")
-}
-
-func newSummaryCommand() *cobra.Command {
-	return stub("summary", "Summarize deployed resources and their ids/URLs.")
-}
-
 func newInitCommand() *cobra.Command {
 	return stub("init [template]", "Scaffold a new ucm.yml project from a starter template.")
 }
@@ -63,8 +47,4 @@ func newDriftCommand() *cobra.Command {
 
 func newImportCommand() *cobra.Command {
 	return stub("import <type> <name>", "Import a single existing UC or cloud resource into ucm state.")
-}
-
-func newPolicyCheckCommand() *cobra.Command {
-	return stub("policy-check", "Run only the ucm validation mutators (tags, naming, required fields).")
 }

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -1,0 +1,99 @@
+package ucm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/spf13/cobra"
+)
+
+// tfstateEnvelope is the minimal shape we need out of terraform.tfstate to
+// produce a resource-count summary. Forked (not imported) from the terraform
+// project's Go API so ucm doesn't pin on an internal schema.
+type tfstateEnvelope struct {
+	Resources []struct {
+		Type string `json:"type"`
+	} `json:"resources"`
+}
+
+func newSummaryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Summarize deployed resources by type.",
+		Long: `Summarize the resources currently tracked by the ucm deploy state.
+
+Reads the local terraform state cached under .databricks/ucm/<target>/ and
+prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
+` + "`ucm plan`" + `) first; without a local state the table is empty.`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		statePath := filepath.Join(deploy.LocalStateDir(u), deploy.TfStateFileName)
+		counts, err := readTfstateCounts(statePath)
+		if err != nil {
+			return fmt.Errorf("read local state %s: %w", filepath.ToSlash(statePath), err)
+		}
+
+		out := cmd.OutOrStdout()
+		if len(counts) == 0 {
+			fmt.Fprintln(out, "No deployed resources found. Run `ucm deploy` first.")
+			return nil
+		}
+
+		types := make([]string, 0, len(counts))
+		for t := range counts {
+			types = append(types, t)
+		}
+		sort.Strings(types)
+
+		tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "TYPE\tCOUNT")
+		for _, t := range types {
+			fmt.Fprintf(tw, "%s\t%d\n", t, counts[t])
+		}
+		return tw.Flush()
+	}
+
+	return cmd
+}
+
+// readTfstateCounts opens the terraform.tfstate at path and returns a map of
+// resource type → count. A missing state file is treated as "no resources"
+// rather than an error so the first-run / pre-deploy path stays clean.
+func readTfstateCounts(path string) (map[string]int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var env tfstateEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("parse tfstate: %w", err)
+	}
+
+	counts := make(map[string]int, len(env.Resources))
+	for _, r := range env.Resources {
+		counts[r.Type]++
+	}
+	return counts, nil
+}

--- a/cmd/ucm/summary_test.go
+++ b/cmd/ucm/summary_test.go
@@ -1,0 +1,55 @@
+package ucm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTfstateForTarget seeds .databricks/ucm/<target>/terraform.tfstate
+// under fixtureDir with the resources slice.
+func writeTfstateForTarget(t *testing.T, fixtureDir, target string, resources []map[string]any) {
+	t.Helper()
+	dir := filepath.Join(fixtureDir, filepath.FromSlash(deploy.LocalCacheDir), target)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	blob := map[string]any{
+		"version":   4,
+		"resources": resources,
+	}
+	data, err := json.Marshal(blob)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, deploy.TfStateFileName), data, 0o600))
+}
+
+func TestCmd_Summary_NoStatePrintsPlaceholder(t *testing.T) {
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "summary")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "No deployed resources")
+}
+
+func TestCmd_Summary_WithStatePrintsCounts(t *testing.T) {
+	work := cloneFixture(t, validFixtureDir(t))
+	// The valid fixture declares no explicit target, so SelectDefaultTarget
+	// chooses the synthesised "default" target. Seed a tfstate there.
+	writeTfstateForTarget(t, work, "default", []map[string]any{
+		{"type": "databricks_catalog"},
+		{"type": "databricks_catalog"},
+		{"type": "databricks_schema"},
+	})
+
+	stdout, stderr, err := runVerbInDir(t, work, "summary")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "databricks_catalog")
+	assert.Contains(t, stdout, "databricks_schema")
+	assert.Contains(t, stdout, "2")
+	assert.Contains(t, stdout, "1")
+}

--- a/ucm/deploy/backend.go
+++ b/ucm/deploy/backend.go
@@ -1,0 +1,63 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/databricks-sdk-go"
+)
+
+// DefaultWorkspaceStateRoot is the per-user workspace directory where ucm
+// stores remote state when no explicit `ucm.state.backend` is configured.
+// The ucm.name and selected target are appended at resolution time so
+// multi-project / multi-target users don't collide.
+const DefaultWorkspaceStateRoot = "databricks/ucm"
+
+// BackendFromUcm constructs a production Backend from the ucm config and the
+// workspace client attached to ctx via cmdctx.SetWorkspaceClient. It resolves
+// the workspace state path (v1: `~/<DefaultWorkspaceStateRoot>/<name>/<target>/state`),
+// instantiates a workspace-files filer, and wraps it as both StateFiler and
+// LockFiler. The pluggable `ucm.state.backend` config selector lands in a
+// later milestone; for now only the workspace backend is wired.
+func BackendFromUcm(ctx context.Context, u *ucm.Ucm, w *databricks.WorkspaceClient) (Backend, error) {
+	if u == nil {
+		return Backend{}, fmt.Errorf("ucm deploy: BackendFromUcm called with nil Ucm")
+	}
+	if w == nil {
+		return Backend{}, fmt.Errorf("ucm deploy: BackendFromUcm called with nil workspace client")
+	}
+
+	me, err := w.CurrentUser.Me(ctx)
+	if err != nil {
+		return Backend{}, fmt.Errorf("ucm deploy: resolve current user: %w", err)
+	}
+	if me.UserName == "" {
+		return Backend{}, fmt.Errorf("ucm deploy: current user has no username")
+	}
+
+	name := u.Config.Ucm.Name
+	if name == "" {
+		return Backend{}, fmt.Errorf("ucm deploy: ucm.name is required to resolve the state path")
+	}
+	target := u.Config.Ucm.Target
+	if target == "" {
+		return Backend{}, fmt.Errorf("ucm deploy: no target selected; call LoadDefaultTarget or LoadNamedTarget first")
+	}
+
+	root := path.Join("/Users", me.UserName, DefaultWorkspaceStateRoot, name, target, "state")
+
+	inner, err := libsfiler.NewWorkspaceFilesClient(w, root)
+	if err != nil {
+		return Backend{}, fmt.Errorf("ucm deploy: init workspace-files filer at %s: %w", root, err)
+	}
+
+	return Backend{
+		StateFiler: ucmfiler.NewStateFilerFromFiler(inner),
+		LockFiler:  inner,
+		User:       me.UserName,
+	}, nil
+}


### PR DESCRIPTION
Closes #22

## Summary
- Replace stubs in cmd/ucm/stubs.go with real verb impls: plan, deploy, destroy, summary, policy-check.
- Add ucm/deploy/backend.go with BackendFromUcm: resolves workspace state path (default ~/databricks/ucm/<name>/<target>/state), wraps libs/filer.NewWorkspaceFilesClient as both StateFiler and LockFiler.
- Add cmd/ucm/options.go with buildPhaseOptions (package-level var) as the seam the verbs go through to construct phases.Options. Production returns DefaultTerraformFactory + BackendFromUcm(ctx, u, cmdctx.WorkspaceClient(ctx)); tests overwrite it with a local-filer Backend and a fakeTf.
- summary parses the local terraform.tfstate under deploy.LocalStateDir(u) and prints a type -> count table; missing state is handled as "No deployed resources".
- policy-check runs phases.PolicyCheck only (no deploy wiring).
- destroy guards on cmdio.IsPromptSupported and requires --auto-approve for non-interactive terminals.

## Why
Verb wiring closes out M1 parallelization — users can now invoke plan/deploy/destroy/summary/policy-check end-to-end against the real Wave-1/2/3 engine.

## Test plan
- [x] go build ./...
- [x] go test ./cmd/ucm/... ./ucm/...
- [x] go vet ./cmd/ucm/... ./ucm/...
- [ ] Smoke: ./databricks ucm plan --target <t> (documented in U8 follow-up)

Stacks on ci/wave3-integration; merge after Wave 3 validates.

This pull request and its description were written by Isaac.