### PR TITLE
Test #23: Smoke fixture + runtime auth for M1

### DIFF
--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -23,7 +23,8 @@ the previous seq; re-running the command will re-attempt from a fresh pull.
 Common invocations:
   databricks ucm deploy                  # Deploy the default target
   databricks ucm deploy --target prod    # Deploy a specific target`,
-		Args: root.NoArgs,
+		Args:              root.NoArgs,
+		PersistentPreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -25,7 +25,8 @@ cached from the last apply.
 Common invocations:
   databricks ucm destroy --auto-approve                # Destroy default target
   databricks ucm destroy --target dev --auto-approve   # Destroy a specific target`,
-		Args: root.NoArgs,
+		Args:              root.NoArgs,
+		PersistentPreRunE: root.MustWorkspaceClient,
 	}
 
 	var autoApprove bool

--- a/cmd/ucm/helpers_test.go
+++ b/cmd/ucm/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
 	"github.com/databricks/cli/ucm/deploy/terraform"
 	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,6 +140,10 @@ func runVerbInDir(t *testing.T, workDir string, args ...string) (string, string,
 	t.Cleanup(func() { _ = os.Chdir(prev) })
 
 	cmd := New()
+	// plan/deploy/destroy/summary attach PersistentPreRunE: root.MustWorkspaceClient
+	// for real-world auth. Tests fake the workspace client via buildPhaseOptions,
+	// so strip the hook on every subcommand before invoking cobra.
+	stripPersistentPreRunE(cmd)
 	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
@@ -185,3 +190,16 @@ func validFixtureDir(t *testing.T) string {
 // phase error bubbles up to the cobra RunE. Name deliberately parallels the
 // phases-package errSentinel without colliding.
 var assertSentinel = errors.New("ucm verb test sentinel")
+
+// stripPersistentPreRunE recursively clears PersistentPreRunE on cmd and all
+// of its subcommands. The ucm verbs that need live auth wire
+// root.MustWorkspaceClient there; tests stand in their own Backend via
+// buildPhaseOptions so the real auth hook would just fail on a missing
+// ~/.databrickscfg.
+func stripPersistentPreRunE(cmd *cobra.Command) {
+	cmd.PersistentPreRunE = nil
+	cmd.PersistentPreRun = nil
+	for _, sub := range cmd.Commands() {
+		stripPersistentPreRunE(sub)
+	}
+}

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -23,7 +23,8 @@ touched.
 Common invocations:
   databricks ucm plan                   # Plan against the default target
   databricks ucm plan --target prod     # Plan against a specific target`,
-		Args: root.NoArgs,
+		Args:              root.NoArgs,
+		PersistentPreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/plan_smoke_test.go
+++ b/cmd/ucm/plan_smoke_test.go
@@ -1,0 +1,94 @@
+package ucm
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn/jsonsaver"
+	"github.com/databricks/cli/libs/logdiag"
+	ucmpkg "github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/deploy/terraform/tfdyn"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// updateSmokeGolden toggles rewrite of the plan-smoke golden file when a
+// deliberate change to the converter output warrants it. Pass -update to the
+// test binary to regenerate. Mirrors libs/testdiff's OverwriteMode pattern
+// but scoped to this test file so the global flag surface stays unchanged.
+var updateSmokeGolden = flag.Bool("update-smoke", false, "regenerate cmd/ucm/testdata/deploy_smoke/expected.tf.json.golden")
+
+// TestCmd_PlanSmoke_EndToEnd exercises the full ucm.yml → phases → tf JSON
+// pipeline against cmd/ucm/testdata/deploy_smoke. It is the M1 close-out
+// fixture: minimal project, nested form with tag inheritance, one grant.
+//
+// The test does NOT stand up a real terraform binary. It invokes the load and
+// mutator chain via phases.LoadDefaultTarget, then drives tfdyn.Convert
+// directly and diffs the marshalled JSON against a committed golden file.
+//
+// Companion to TestCmd_Plan_HappyPathPrintsSummary (verb wiring coverage)
+// which uses the fake-tf harness to prove the cobra path end-to-end; this
+// test guarantees the converter side of the same pipeline stays stable.
+func TestCmd_PlanSmoke_EndToEnd(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	fixture := filepath.Join("testdata", "deploy_smoke")
+
+	u, err := ucmpkg.Load(ctx, fixture)
+	require.NoError(t, err)
+	require.NotNil(t, u)
+
+	phases.LoadDefaultTarget(ctx, u)
+	require.False(t, logdiag.HasError(ctx), "LoadDefaultTarget reported errors")
+	require.NotNil(t, u.Target, "expected default target to be selected")
+
+	assertSmokeGolden(t, ctx, u)
+}
+
+// assertSmokeGolden runs the converter, marshals the tree the same way
+// Render does in production, and asserts against the committed golden file.
+// When -update-smoke is passed the test overwrites the golden file instead
+// of failing — keep the toggle close to the assertion to make regeneration
+// obvious in diff review.
+func assertSmokeGolden(t *testing.T, ctx context.Context, u *ucmpkg.Ucm) {
+	t.Helper()
+
+	tree, err := tfdyn.Convert(ctx, u)
+	require.NoError(t, err)
+
+	got, err := jsonsaver.MarshalIndent(tree, "", "  ")
+	require.NoError(t, err)
+
+	goldenPath := filepath.Join("testdata", "deploy_smoke", "expected.tf.json.golden")
+	if *updateSmokeGolden {
+		require.NoError(t, os.WriteFile(goldenPath, got, 0o644))
+		t.Logf("wrote %s", goldenPath)
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "read golden (pass -update-smoke to regenerate)")
+	assert.JSONEq(t, string(want), string(got), "rendered tf JSON diverged from golden; run with -update-smoke to regenerate")
+}
+
+// TestCmd_PlanSmoke_VerbHappyPath drives the cobra plan verb against the same
+// smoke fixture with the fake-tf harness. Complements TestCmd_PlanSmoke_EndToEnd
+// by proving the full CLI pivot (ucm plan → phases.Plan → TerraformWrapper)
+// stays wired once PersistentPreRunE auth is stripped out for tests.
+func TestCmd_PlanSmoke_VerbHappyPath(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "smoke plan ready"}
+
+	stdout, stderr, err := runVerb(t, filepath.Join("testdata", "deploy_smoke"), "plan")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "smoke plan ready")
+	assert.Equal(t, 1, h.tf.RenderCalls)
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.PlanCalls)
+}

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -35,7 +35,8 @@ func newSummaryCommand() *cobra.Command {
 Reads the local terraform state cached under .databricks/ucm/<target>/ and
 prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
 ` + "`ucm plan`" + `) first; without a local state the table is empty.`,
-		Args: root.NoArgs,
+		Args:              root.NoArgs,
+		PersistentPreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/testdata/deploy_smoke/expected.tf.json.golden
+++ b/cmd/ucm/testdata/deploy_smoke/expected.tf.json.golden
@@ -1,0 +1,49 @@
+{
+  "resource": {
+    "databricks_catalog": {
+      "main": {
+        "name": "main",
+        "comment": "smoke catalog",
+        "properties": {
+          "data_owner": "platform",
+          "classification": "internal",
+          "cost_center": "9999"
+        },
+        "force_destroy": true
+      }
+    },
+    "databricks_schema": {
+      "default": {
+        "name": "default",
+        "catalog_name": "main",
+        "comment": "smoke schema",
+        "properties": {
+          "classification": "internal",
+          "cost_center": "9999",
+          "data_owner": "platform"
+        },
+        "force_destroy": true,
+        "depends_on": [
+          "databricks_catalog.main"
+        ]
+      }
+    },
+    "databricks_grants": {
+      "default_reader": {
+        "schema": "${databricks_schema.default.id}",
+        "grant": [
+          {
+            "principal": "platform-readers",
+            "privileges": [
+              "USE_SCHEMA",
+              "SELECT"
+            ]
+          }
+        ],
+        "depends_on": [
+          "databricks_schema.default"
+        ]
+      }
+    }
+  }
+}

--- a/cmd/ucm/testdata/deploy_smoke/ucm.yml
+++ b/cmd/ucm/testdata/deploy_smoke/ucm.yml
@@ -1,0 +1,24 @@
+ucm:
+  name: smoke
+  engine: terraform
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    main:
+      name: main
+      comment: smoke catalog
+      tags:
+        cost_center: "9999"
+        data_owner: platform
+        classification: internal
+      schemas:
+        default:
+          name: default
+          comment: smoke schema
+          grants:
+            default_reader:
+              principal: platform-readers
+              privileges: [USE_SCHEMA, SELECT]


### PR DESCRIPTION
Closes #23

## Summary
- Smoke fixture at `cmd/ucm/testdata/deploy_smoke` — minimal ucm.yml with a nested schema + grant.
- `plan_smoke_test.go` runs two complementary smokes:
  - `TestCmd_PlanSmoke_EndToEnd` drives `ucm.Load` → `phases.LoadDefaultTarget` → `tfdyn.Convert` and diffs the marshalled JSON against `expected.tf.json.golden` (regenerate with `-update-smoke`).
  - `TestCmd_PlanSmoke_VerbHappyPath` drives the `plan` cobra verb through the existing fake-tf harness against the same fixture.
- `PersistentPreRunE: root.MustWorkspaceClient` on `plan`/`deploy`/`destroy`/`summary` (validate/schema/policy-check intentionally excluded).
- Test harness clears `PersistentPreRunE` recursively so existing U7 verb tests keep working against the fake tf factory.

## Why
Final unit of M1. Closes the loop: ucm.yml → phases → tf JSON golden. Also fixes the runtime-auth gap U7 left open — the default `buildPhaseOptions` reads `cmdctx.WorkspaceClient` but no verb was attaching the hook that populates it.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [ ] Manual (live workspace):
      ```
      cd cmd/ucm/testdata/deploy_smoke
      DATABRICKS_HOST=... DATABRICKS_CLIENT_ID=... DATABRICKS_CLIENT_SECRET=... \
        ../../../../databricks ucm plan --target default
      ```

Stacks on `ci/wave4a-integration`; this completes M1.