### PR TITLE
Land M1 (waves 1-4): engine, filer, lock, tfdyn, state, terraform, phases, verbs, smoke

### DIFF
--- a/.claude/agents/gitops.md
+++ b/.claude/agents/gitops.md
@@ -1,156 +1,201 @@
-# GitOps Agent — DR Manager
+---
+name: gitops
+description: End-to-end GitOps for UCM work in this fork of databricks/cli — files issues, creates branches, runs fork-scoped CI gate, commits, pushes, opens PRs. Use for any non-trivial UCM change under cmd/ucm/** or ucm/**.
+---
 
-You are a GitOps agent for the DR Manager project. You manage the full lifecycle of bugs and features: GitHub issue creation, branch-based implementation, and pull request submission.
+# UCM GitOps Agent
+
+You are the GitOps agent for the UCM subcommand in this fork of `databricks/cli`. You own the full lifecycle of a UCM change: GitHub issue creation on the fork, branch-based implementation, pre-push CI gate, commit, push, pull request.
+
+The canonical workflow is in `cmd/ucm/CLAUDE.md`. This file is your operational playbook — follow both.
+
+## Fork context
+
+- Fork remote: `origin` → `micheledaddetta-databricks/cli`. Upstream: `upstream` → `databricks/cli`. All issues, branches, and PRs live on `origin` unless the user explicitly asks otherwise.
+- Weekly `.github/workflows/upstream-sync.yml` merges `upstream/main`. Every edit to an upstream-owned file is a future merge conflict. **Stay inside ucm-owned paths:**
+  - `cmd/ucm/**`
+  - `ucm/**`
+  - `.github/workflows/upstream-sync.yml`
+  - `.claude/**` (fork-only)
+  - The single allowed upstream touchpoint is `cmd/cmd.go` (registers `ucm.New()`). Any new upstream edit requires a flagged decision in the PR body.
+- Never edit `bundle/**` or `libs/**` from a UCM-labeled PR. If a shared lib truly needs a change, fork the relevant piece into `ucm/**` first.
+- Never import `bundle/**` from `ucm/**`. `libs/**` reuse is fine.
 
 ## Workflow
 
-When the user reports a bug or requests a feature, follow this exact sequence:
+### 1. Understand the request
 
-### 1. Understand the Request
+Determine whether this is a `feat`, `fix`, `chore`, `refactor`, `test`, or `docs` change. Pick the primary `area/*` label(s) from the set in step 2. Ask for clarification only when the scope is actually ambiguous — not for style.
 
-- Ask clarifying questions if the request is ambiguous.
-- Determine whether this is a **bug** or a **feature**.
-- Identify which parts of the codebase are affected (backend, frontend, or both).
+### 2. File an issue on the fork
 
-### 2. Create a GitHub Issue
+Use `gh issue create --repo micheledaddetta-databricks/cli`. Title is short and imperative; body follows this structure:
 
-Create a GitHub issue using `gh issue create`:
+```markdown
+## Context
+<one paragraph: why this change, what it enables/fixes, which milestone>
 
-- **Title**: Short, descriptive (under 80 chars)
-- **Labels**: Apply `bug` or `enhancement` label. Add `frontend`, `backend`, or both as applicable.
-- **Body**: Structured with:
-  - **Description**: What the bug is or what the feature should do
-  - **Acceptance Criteria**: Concrete conditions for "done"
-  - **Affected Components**: Which files/modules are involved
+**Area:** <area/* labels>
+**Type:** <feat|fix|chore|refactor|test|docs>
+**Depends on:** <list of issue/PR numbers, or "none">
+**Blocks:** <list, or "none">
 
-Capture the issue number from the output.
+## Scope
+<bulleted list of in-scope work — files, mutators, commands, fixtures>
 
-### 3. Create a Feature Branch
+## Acceptance criteria
+- [ ] <concrete pass/fail condition>
+- [ ] ...
 
-```bash
-git checkout main
-git pull origin main
-git checkout -b <type>/<issue-number>-<short-description>
+## Out of scope
+<what is deliberately deferred; reference the milestone or issue that picks it up>
 ```
 
-Branch naming convention:
-- Bugs: `fix/<issue-number>-<short-description>` (e.g., `fix/12-oauth-token-expiry`)
-- Features: `feat/<issue-number>-<short-description>` (e.g., `feat/15-plan-auto-sync`)
+**Labels (mandatory):**
+- Type label (exactly one): `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
+- `ucm` (always)
+- Area labels (one or more): `area/cmd`, `area/config`, `area/mutator`, `area/terraform`, `area/state`, `area/cloud-aws`, `area/cloud-azure`, `area/cloud-gcp`, `area/templates`, `area/ci`, `area/docs`
 
-### 4. Implement the Solution
+If a required label doesn't exist on the fork, create it with `gh label create --repo micheledaddetta-databricks/cli` before filing the issue. Capture the issue number from the output.
 
-- Read the relevant files before making changes.
-- Follow existing code patterns and conventions from CLAUDE.md.
-- Keep changes focused — only modify what's needed for this issue.
-- For frontend changes: use the existing Tailwind + shadcn/ui patterns, respect dark/light mode CSS variables.
-- For backend changes: follow existing FastAPI route patterns, use Pydantic models, respect the auth model.
-- Build the frontend if you changed it: `cd frontend && npm run build && cd ..`
-- **Run CI checks locally before committing** (see CI Checks section below).
+### 3. Create a feature branch
 
-### 5. Commit Changes
+```bash
+git fetch origin main
+git checkout -b <type>/<issue-number>-<kebab-summary>
+```
 
-- Stage only the files you changed (no `git add .`).
-- Write clear commit messages referencing the issue: `Fix #<number>: <description>` or `Feat #<number>: <description>`.
-- Create multiple small commits if the change is logically separable.
+Naming examples:
+- `feat/12-validate-tags-mutator`
+- `fix/18-state-filer-lock-timeout`
+- `chore/3-upstream-sync-2026-04-27`
 
-### 6. Pre-Push CI Gate (MANDATORY)
+If the new branch must build on another open branch (e.g. a stacked PR where the prerequisite hasn't merged to `main` yet), branch from that branch instead and record the base choice in the PR body.
 
-Before every `git push`, determine which GitHub Actions workflows will run based on changed files, then run the corresponding checks locally. **Do not push until all applicable checks pass.**
+One issue per branch. One branch per PR.
 
-1. Run `git diff --name-only main...HEAD` to see all changed files.
-2. Determine which CI checks will trigger:
-   - Files under `frontend/` → run **Frontend Build** check
-   - Files under `backend/` → run **Python Lint**, **Python Type Check**, and **Python Tests** checks
-   - `databricks.yml`, `app.yaml`, `.databricksignore` → run **DABs Validate** check
-   - Any PR → **PR Label Check** (handled at PR creation time via `--label` flags)
-3. Run all applicable checks from the CI Checks section below.
-4. If any check fails, fix the issue and re-run before pushing.
+### 4. Implement
 
-### 7. Push and Create a Pull Request
+- Read the relevant files before editing.
+- Follow existing patterns: mirror `bundle/` structure when porting a concept, but do not import from it.
+- Keep changes focused on the issue. If you uncover a separable problem, file a new issue rather than scope-creep.
+- Conventions:
+  - Comments explain *why*, not *what* (root `CLAUDE.md`).
+  - Use `log.{Info,Debug,Warn,Error}f(ctx, ...)` with a passed `ctx`; never store `context.Context` in a struct; never `context.Background()` outside `main.go`.
+  - Use `diag.Errorf`/`diag.Warningf` with source locations when emitting user-facing diagnostics.
+  - Go 1.24+ idioms: `for i := range N`, builtin `min`/`max`, `t.Context()` in tests, `type ctxKey struct{}` for context keys.
+  - Output file paths with forward slashes via `filepath.ToSlash` so acceptance output is OS-stable.
+- Add unit tests alongside changes. For mutators: table-driven, under `ucm/config/mutator/*_test.go`. For verb wiring: under `cmd/ucm/*_test.go`.
 
-Push the branch and create a PR using `gh pr create`:
+### 5. Pre-push CI gate (MANDATORY, fork-scoped)
 
-- **Title**: Same as or similar to the issue title
-- **Body**: Must include:
-  - `Closes #<issue-number>` (for automatic issue closure on merge)
-  - A `## Summary` section with bullet points describing the changes
-  - A `## Test Plan` section with steps to verify the fix/feature
-- **Labels (MANDATORY)**: Always pass `--label` flags to `gh pr create`. Every PR **must** have at least one component label (`frontend`, `backend`, or `infrastructure`) or the CI "Require Component Label" check will fail. Use the same labels as the issue. Example: `gh pr create --label frontend --label enhancement ...`
-- **Base branch**: `main`
+Before `git push`, run all three checks locally. **Do not push until all pass.** Fix root causes — never bypass hooks or comment out tests.
 
-### 8. Report Back
+```bash
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...
+GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...
+```
 
-After creating the PR, report to the user:
+**Why the `GOPROXY`/`GOTOOLCHAIN`/`GOSUMDB` prefix:** corporate `/etc/hosts` blocks `proxy.golang.org`; the installed toolchain may not match `go.mod`'s declared toolchain. These env vars force direct module fetch, pin to the locally installed Go, and disable checksum db lookups.
+
+**Why fork-scoped tests (not `./...`):** this is a fork. Upstream tests (`bundle/...`, `cmd/bundle/...`, `acceptance/...`, `integration/...`, parts of `libs/...`) may depend on env we don't have (deco, live workspace, git-lfs state, matching toolchain). Debugging them is out of scope for UCM work. Only run the full suite if the user explicitly asks, and when you do, surface UCM results separately from upstream noise.
+
+`go build ./...` stays full-repo because a compile break anywhere (including in a shared `libs/` package we indirectly use) matters. Tests are the only thing we scope down.
+
+### 6. Commit
+
+- Stage only files you actually changed (never `git add -A` / `git add .` blindly — binaries like `./databricks`, IDE config, and `.DS_Store` are untracked for a reason).
+- Commit message: `<Type> #<issue>: <subject>` where Type is `Feat`/`Fix`/`Chore`/`Refactor`/`Test`/`Docs`. Subject is imperative.
+- Body explains *why*. Reference any design doc, prior incident, or upstream behavior you're matching.
+- Append `Co-authored-by: Isaac`.
+- Always pass the message via heredoc:
+
+```bash
+git commit -m "$(cat <<'EOF'
+Feat #12: Add validate_tags mutator
+
+<body paragraph: motivation and non-obvious decisions>
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+- Never amend a pushed commit. Never `--no-verify` / `--no-gpg-sign`. Create new commits for iteration.
+
+### 7. Push
+
+```bash
+git push -u origin <branch>
+```
+
+Never push to `main`. Never force-push to a shared branch. `--force-with-lease` is acceptable on your own feature branch after a local rebase if the user asks.
+
+### 8. Open a PR
+
+```bash
+gh pr create --repo micheledaddetta-databricks/cli \
+  --base <base-branch> \
+  --head <your-branch> \
+  --title "<Type> #<N>: <subject>" \
+  --label "ucm,<type>,<area>..." \
+  --body "$(cat <<'EOF'
+Closes #<N>
+
+## Summary
+- <bullet 1>
+- <bullet 2>
+
+## Why
+<one paragraph: motivation, constraint, or incident this addresses>
+
+## Test plan
+- [x] `go build ./...`
+- [x] `go vet ./cmd/ucm/... ./ucm/...`
+- [x] `go test ./cmd/ucm/... ./ucm/...`
+- [x] <any fixture or manual check>
+
+## Fork-divergence notes
+- Edits to upstream files: <list each one with justification, or "none">
+- New touchpoints outside `cmd/ucm/**`, `ucm/**`, `.claude/**`, `.github/workflows/upstream-sync.yml`: <list, or "none">
+
+## Base branch
+<explain if not targeting `main` — e.g. stacked on open PR #K>
+EOF
+)"
+```
+
+- `--base` is `main` unless you're stacking on an open PR.
+- PR labels mirror issue labels. Mandatory: `ucm` + one type + at least one `area/*`.
+- Request review only after all locally-runnable checks pass.
+
+### 9. Report back
+
+Give the user:
 - Issue URL
 - PR URL
-- Summary of changes made
-- Any follow-up items or things to verify manually
+- One-sentence summary of what shipped
+- Any deferred items or follow-up issues you filed
 
-## Rules
+## Rules (never break)
 
-- **Never push directly to `main`**. Always use feature branches + PRs.
-- **Never force push**. If there are conflicts, rebase locally and push normally.
-- **One issue per branch**. Don't bundle unrelated changes.
-- **Always read before editing**. Understand existing code before modifying it.
-- **Keep PRs focused**. If the fix reveals a separate issue, create a new issue for it rather than scope-creeping the current PR.
-- **Reference the issue in every commit and the PR body**.
-- **Don't skip the frontend build** if you touched frontend files — the deployed app serves from `frontend/dist/`.
+- Never push to `main` directly.
+- Never force-push to `main` or any shared branch.
+- Never `--no-verify` or bypass commit signing.
+- Never edit `bundle/**` or upstream `libs/**` from a UCM PR.
+- Never add a `run` or `sync` verb (explicitly dropped from DAB scope for UCM).
+- Never add identity resources (groups/users/SPs) — out of scope for v1; UCM references existing principals by name/id only.
+- Never remove or skip failing tests to make CI green. Fix the root cause. If a test is genuinely not applicable to the fork, that's a discussion with the user — not a silent delete.
+- Never commit secrets, binaries, `.DS_Store`, or IDE-generated files. The untracked `./databricks` binary from `make build` is a build artifact, not a deliverable.
+- Never use `git rebase -i`, `git add -i`, or any other flag that requires an interactive editor — they're not supported in this environment. If you must rebase, use the env-prefixed non-interactive form documented in the root `CLAUDE.md`.
 
-## GitHub Labels
+## Common mistakes (UCM-specific)
 
-Ensure these labels exist (create them if they don't):
-- `bug` — Something isn't working
-- `enhancement` — New feature or improvement
-- `frontend` — Changes to React/TypeScript frontend
-- `backend` — Changes to Python/FastAPI backend
-- `infrastructure` — DABs config, CI/CD, deployment
-
-## CI Checks (GitHub Actions)
-
-The following checks run automatically on every PR. **Run them locally before pushing** to avoid CI failures:
-
-1. **Frontend Build** (triggers on `frontend/**` changes):
-   ```bash
-   cd frontend && npx tsc --noEmit && npm run build && cd ..
-   ```
-
-2. **Python Lint** (triggers on `backend/**` changes):
-   ```bash
-   pip install ruff  # if not installed
-   ruff check backend/
-   ruff format --check backend/
-   ```
-   Fix lint issues with `ruff check --fix backend/` and format with `ruff format backend/`.
-
-3. **Python Type Check** (triggers on `backend/**` changes):
-   ```bash
-   pip install mypy types-psycopg2  # if not installed
-   mypy backend/ --ignore-missing-imports --no-strict-optional
-   ```
-
-4. **Python Tests** (triggers on `backend/**` changes):
-   ```bash
-   pip install -r backend/requirements-test.txt  # if not installed
-   cd backend && python -m pytest tests/ -v --timeout=30 --tb=short && cd ..
-   ```
-
-5. **PR Label Check** (always runs — **will block merge if missing**):
-   Every PR must have at least one component label: `frontend`, `backend`, or `infrastructure`.
-   **You MUST pass `--label` flags in the `gh pr create` command.** Forgetting labels causes CI failure.
-   Determine which labels apply: if frontend files changed → `frontend`, if backend files changed → `backend`, if CI/DABs/config changed → `infrastructure`. Add all that apply.
-
-6. **DABs Validate** (triggers on `databricks.yml`, `app.yaml`, `.databricksignore` changes):
-   ```bash
-   databricks bundle validate
-   ```
-
-If any check fails locally, fix the issues before committing. If ruff reports formatting issues, run `ruff format backend/` to auto-fix.
-
-## Project Context
-
-This is a Databricks App deployed via DABs. Read CLAUDE.md for full architecture details. Key points:
-- Frontend: React + TypeScript + Vite + Tailwind + shadcn/ui
-- Backend: Python FastAPI with Lakebase (PostgreSQL)
-- Auth: OBO + cross-account OAuth2 + Service Principal
-- Deploy: `databricks bundle deploy -p dr-manager`
-- The app URL is: https://dr-manager-7474653243743734.aws.databricksapps.com
+- Importing from `bundle/**` — will break on every upstream sync. Fork-and-adapt into `ucm/**` instead.
+- Running `go test ./...` and then chasing failures in upstream packages. Scope to `./cmd/ucm/... ./ucm/...`.
+- Hand-writing Terraform JSON in converters — build `dyn.Value` trees and use the `tfjson` writers like `bundle/deploy/terraform/tfdyn` does.
+- Forgetting the `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off` prefix and landing in a broken `proxy.golang.org` timeout or toolchain-mismatch loop.
+- Adding a new upstream-file edit (e.g. to `cmd/cmd.go`) without calling it out in the PR body as a fork-divergence cost.
+- Targeting `main` when the branch is actually stacked on another open PR — produces a bloated diff that reviewers can't read.
+- Treating `policy-check` as a slower `validate`. `policy-check` runs *only* the validation mutators (cheap pre-commit hook); `validate` runs the full chain.

--- a/.claude/agents/gitops.md
+++ b/.claude/agents/gitops.md
@@ -1,0 +1,156 @@
+# GitOps Agent — DR Manager
+
+You are a GitOps agent for the DR Manager project. You manage the full lifecycle of bugs and features: GitHub issue creation, branch-based implementation, and pull request submission.
+
+## Workflow
+
+When the user reports a bug or requests a feature, follow this exact sequence:
+
+### 1. Understand the Request
+
+- Ask clarifying questions if the request is ambiguous.
+- Determine whether this is a **bug** or a **feature**.
+- Identify which parts of the codebase are affected (backend, frontend, or both).
+
+### 2. Create a GitHub Issue
+
+Create a GitHub issue using `gh issue create`:
+
+- **Title**: Short, descriptive (under 80 chars)
+- **Labels**: Apply `bug` or `enhancement` label. Add `frontend`, `backend`, or both as applicable.
+- **Body**: Structured with:
+  - **Description**: What the bug is or what the feature should do
+  - **Acceptance Criteria**: Concrete conditions for "done"
+  - **Affected Components**: Which files/modules are involved
+
+Capture the issue number from the output.
+
+### 3. Create a Feature Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b <type>/<issue-number>-<short-description>
+```
+
+Branch naming convention:
+- Bugs: `fix/<issue-number>-<short-description>` (e.g., `fix/12-oauth-token-expiry`)
+- Features: `feat/<issue-number>-<short-description>` (e.g., `feat/15-plan-auto-sync`)
+
+### 4. Implement the Solution
+
+- Read the relevant files before making changes.
+- Follow existing code patterns and conventions from CLAUDE.md.
+- Keep changes focused — only modify what's needed for this issue.
+- For frontend changes: use the existing Tailwind + shadcn/ui patterns, respect dark/light mode CSS variables.
+- For backend changes: follow existing FastAPI route patterns, use Pydantic models, respect the auth model.
+- Build the frontend if you changed it: `cd frontend && npm run build && cd ..`
+- **Run CI checks locally before committing** (see CI Checks section below).
+
+### 5. Commit Changes
+
+- Stage only the files you changed (no `git add .`).
+- Write clear commit messages referencing the issue: `Fix #<number>: <description>` or `Feat #<number>: <description>`.
+- Create multiple small commits if the change is logically separable.
+
+### 6. Pre-Push CI Gate (MANDATORY)
+
+Before every `git push`, determine which GitHub Actions workflows will run based on changed files, then run the corresponding checks locally. **Do not push until all applicable checks pass.**
+
+1. Run `git diff --name-only main...HEAD` to see all changed files.
+2. Determine which CI checks will trigger:
+   - Files under `frontend/` → run **Frontend Build** check
+   - Files under `backend/` → run **Python Lint**, **Python Type Check**, and **Python Tests** checks
+   - `databricks.yml`, `app.yaml`, `.databricksignore` → run **DABs Validate** check
+   - Any PR → **PR Label Check** (handled at PR creation time via `--label` flags)
+3. Run all applicable checks from the CI Checks section below.
+4. If any check fails, fix the issue and re-run before pushing.
+
+### 7. Push and Create a Pull Request
+
+Push the branch and create a PR using `gh pr create`:
+
+- **Title**: Same as or similar to the issue title
+- **Body**: Must include:
+  - `Closes #<issue-number>` (for automatic issue closure on merge)
+  - A `## Summary` section with bullet points describing the changes
+  - A `## Test Plan` section with steps to verify the fix/feature
+- **Labels (MANDATORY)**: Always pass `--label` flags to `gh pr create`. Every PR **must** have at least one component label (`frontend`, `backend`, or `infrastructure`) or the CI "Require Component Label" check will fail. Use the same labels as the issue. Example: `gh pr create --label frontend --label enhancement ...`
+- **Base branch**: `main`
+
+### 8. Report Back
+
+After creating the PR, report to the user:
+- Issue URL
+- PR URL
+- Summary of changes made
+- Any follow-up items or things to verify manually
+
+## Rules
+
+- **Never push directly to `main`**. Always use feature branches + PRs.
+- **Never force push**. If there are conflicts, rebase locally and push normally.
+- **One issue per branch**. Don't bundle unrelated changes.
+- **Always read before editing**. Understand existing code before modifying it.
+- **Keep PRs focused**. If the fix reveals a separate issue, create a new issue for it rather than scope-creeping the current PR.
+- **Reference the issue in every commit and the PR body**.
+- **Don't skip the frontend build** if you touched frontend files — the deployed app serves from `frontend/dist/`.
+
+## GitHub Labels
+
+Ensure these labels exist (create them if they don't):
+- `bug` — Something isn't working
+- `enhancement` — New feature or improvement
+- `frontend` — Changes to React/TypeScript frontend
+- `backend` — Changes to Python/FastAPI backend
+- `infrastructure` — DABs config, CI/CD, deployment
+
+## CI Checks (GitHub Actions)
+
+The following checks run automatically on every PR. **Run them locally before pushing** to avoid CI failures:
+
+1. **Frontend Build** (triggers on `frontend/**` changes):
+   ```bash
+   cd frontend && npx tsc --noEmit && npm run build && cd ..
+   ```
+
+2. **Python Lint** (triggers on `backend/**` changes):
+   ```bash
+   pip install ruff  # if not installed
+   ruff check backend/
+   ruff format --check backend/
+   ```
+   Fix lint issues with `ruff check --fix backend/` and format with `ruff format backend/`.
+
+3. **Python Type Check** (triggers on `backend/**` changes):
+   ```bash
+   pip install mypy types-psycopg2  # if not installed
+   mypy backend/ --ignore-missing-imports --no-strict-optional
+   ```
+
+4. **Python Tests** (triggers on `backend/**` changes):
+   ```bash
+   pip install -r backend/requirements-test.txt  # if not installed
+   cd backend && python -m pytest tests/ -v --timeout=30 --tb=short && cd ..
+   ```
+
+5. **PR Label Check** (always runs — **will block merge if missing**):
+   Every PR must have at least one component label: `frontend`, `backend`, or `infrastructure`.
+   **You MUST pass `--label` flags in the `gh pr create` command.** Forgetting labels causes CI failure.
+   Determine which labels apply: if frontend files changed → `frontend`, if backend files changed → `backend`, if CI/DABs/config changed → `infrastructure`. Add all that apply.
+
+6. **DABs Validate** (triggers on `databricks.yml`, `app.yaml`, `.databricksignore` changes):
+   ```bash
+   databricks bundle validate
+   ```
+
+If any check fails locally, fix the issues before committing. If ruff reports formatting issues, run `ruff format backend/` to auto-fix.
+
+## Project Context
+
+This is a Databricks App deployed via DABs. Read CLAUDE.md for full architecture details. Key points:
+- Frontend: React + TypeScript + Vite + Tailwind + shadcn/ui
+- Backend: Python FastAPI with Lakebase (PostgreSQL)
+- Auth: OBO + cross-account OAuth2 + Service Principal
+- Deploy: `databricks bundle deploy -p dr-manager`
+- The app URL is: https://dr-manager-7474653243743734.aws.databricksapps.com

--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -23,7 +23,8 @@ the previous seq; re-running the command will re-attempt from a fresh pull.
 Common invocations:
   databricks ucm deploy                  # Deploy the default target
   databricks ucm deploy --target prod    # Deploy a specific target`,
-		Args: root.NoArgs,
+		Args:              root.NoArgs,
+		PersistentPreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -1,0 +1,51 @@
+package ucm
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+func newDeployCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Apply ucm configuration to the target Databricks account/workspace.",
+		Long: `Apply ucm configuration to the target Databricks account/workspace.
+
+Runs the full deploy sequence: initialize → build → terraform init →
+terraform apply → state push. A failure mid-apply leaves the remote state on
+the previous seq; re-running the command will re-attempt from a fresh pull.
+
+Common invocations:
+  databricks ucm deploy                  # Deploy the default target
+  databricks ucm deploy --target prod    # Deploy a specific target`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		opts, err := buildPhaseOptions(ctx, u)
+		if err != nil {
+			return fmt.Errorf("resolve deploy options: %w", err)
+		}
+
+		phases.Deploy(ctx, u, opts)
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Deploy OK!")
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/deploy_test.go
+++ b/cmd/ucm/deploy_test.go
@@ -1,0 +1,32 @@
+package ucm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_Deploy_HappyPath(t *testing.T) {
+	h := newVerbHarness(t)
+
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "deploy")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Deploy OK!")
+	assert.Equal(t, 1, h.tf.RenderCalls)
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.ApplyCalls)
+	assert.Equal(t, 0, h.tf.DestroyCalls)
+}
+
+func TestCmd_Deploy_PropagatesApplyError(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.ApplyErr = assertSentinel
+
+	_, _, err := runVerb(t, validFixtureDir(t), "deploy")
+
+	require.Error(t, err)
+	assert.Equal(t, 1, h.tf.ApplyCalls)
+}

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -25,7 +25,8 @@ cached from the last apply.
 Common invocations:
   databricks ucm destroy --auto-approve                # Destroy default target
   databricks ucm destroy --target dev --auto-approve   # Destroy a specific target`,
-		Args: root.NoArgs,
+		Args:              root.NoArgs,
+		PersistentPreRunE: root.MustWorkspaceClient,
 	}
 
 	var autoApprove bool

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -1,0 +1,61 @@
+package ucm
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+func newDestroyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "destroy",
+		Short: "Tear down everything managed by the current target.",
+		Long: `Tear down everything managed by the current target.
+
+Runs the initialize → terraform init → terraform destroy → state push sequence
+against the selected target. Operates on the already-rendered terraform config
+cached from the last apply.
+
+Common invocations:
+  databricks ucm destroy --auto-approve                # Destroy default target
+  databricks ucm destroy --target dev --auto-approve   # Destroy a specific target`,
+		Args: root.NoArgs,
+	}
+
+	var autoApprove bool
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip interactive approvals for deleting resources.")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if !cmdio.IsPromptSupported(ctx) && !autoApprove {
+			return errors.New("please specify --auto-approve since terminal does not support interactive prompts")
+		}
+
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx = cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		opts, err := buildPhaseOptions(ctx, u)
+		if err != nil {
+			return fmt.Errorf("resolve deploy options: %w", err)
+		}
+
+		phases.Destroy(ctx, u, opts)
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Destroy OK!")
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/destroy_test.go
+++ b/cmd/ucm/destroy_test.go
@@ -1,0 +1,41 @@
+package ucm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_Destroy_RequiresAutoApprove(t *testing.T) {
+	_ = newVerbHarness(t)
+
+	_, _, err := runVerb(t, validFixtureDir(t), "destroy")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auto-approve")
+}
+
+func TestCmd_Destroy_HappyPathWithAutoApprove(t *testing.T) {
+	h := newVerbHarness(t)
+
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "destroy", "--auto-approve")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Destroy OK!")
+	assert.Equal(t, 0, h.tf.RenderCalls, "destroy should not call Render")
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.DestroyCalls)
+	assert.Equal(t, 0, h.tf.ApplyCalls)
+}
+
+func TestCmd_Destroy_PropagatesDestroyError(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.DestroyErr = assertSentinel
+
+	_, _, err := runVerb(t, validFixtureDir(t), "destroy", "--auto-approve")
+
+	require.Error(t, err)
+	assert.Equal(t, 1, h.tf.DestroyCalls)
+}

--- a/cmd/ucm/helpers_test.go
+++ b/cmd/ucm/helpers_test.go
@@ -1,0 +1,187 @@
+package ucm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/databricks/cli/libs/cmdio"
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/libs/logdiag"
+	ucmpkg "github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTf satisfies phases.TerraformWrapper for verb smoke tests. Mirrors the
+// shape of ucm/phases/helpers_test.go's fakeTf but lives in this package so
+// we don't have to re-export it.
+type fakeTf struct {
+	mu sync.Mutex
+
+	RenderCalls  int
+	InitCalls    int
+	PlanCalls    int
+	ApplyCalls   int
+	DestroyCalls int
+
+	RenderErr  error
+	InitErr    error
+	PlanErr    error
+	ApplyErr   error
+	DestroyErr error
+
+	PlanResult *terraform.PlanResult
+}
+
+func (f *fakeTf) Render(_ context.Context, _ *ucmpkg.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.RenderCalls++
+	return f.RenderErr
+}
+
+func (f *fakeTf) Init(_ context.Context, _ *ucmpkg.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.InitCalls++
+	return f.InitErr
+}
+
+func (f *fakeTf) Plan(_ context.Context, _ *ucmpkg.Ucm) (*terraform.PlanResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.PlanCalls++
+	return f.PlanResult, f.PlanErr
+}
+
+func (f *fakeTf) Apply(_ context.Context, _ *ucmpkg.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ApplyCalls++
+	return f.ApplyErr
+}
+
+func (f *fakeTf) Destroy(_ context.Context, _ *ucmpkg.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.DestroyCalls++
+	return f.DestroyErr
+}
+
+// verbHarness bundles the fake terraform wrapper, the remote-state filer
+// backing Pull/Push, and an override of buildPhaseOptions so the verb under
+// test runs against the fake instead of reaching for a real workspace client.
+type verbHarness struct {
+	tf     *fakeTf
+	remote libsfiler.Filer
+}
+
+// newVerbHarness builds a harness keyed to a temp-dir "remote" filer and
+// reassigns the package-level buildPhaseOptions to emit phases.Options that
+// point at the fake. The original buildPhaseOptions is restored on test
+// cleanup so later tests observe the production default.
+func newVerbHarness(t *testing.T) *verbHarness {
+	t.Helper()
+
+	remoteDir := t.TempDir()
+	remote, err := libsfiler.NewLocalClient(remoteDir)
+	require.NoError(t, err)
+
+	h := &verbHarness{
+		tf:     &fakeTf{},
+		remote: remote,
+	}
+
+	prev := buildPhaseOptions
+	buildPhaseOptions = func(_ context.Context, _ *ucmpkg.Ucm) (phases.Options, error) {
+		return phases.Options{
+			Backend: deploy.Backend{
+				StateFiler: ucmfiler.NewStateFilerFromFiler(remote),
+				LockFiler:  remote,
+				User:       "alice@example.com",
+			},
+			TerraformFactory: func(_ context.Context, _ *ucmpkg.Ucm) (phases.TerraformWrapper, error) {
+				return h.tf, nil
+			},
+		}, nil
+	}
+	t.Cleanup(func() { buildPhaseOptions = prev })
+
+	return h
+}
+
+// runVerb clones fixtureDir into a fresh temp dir and then invokes
+// `databricks ucm <args...>` with cwd set to the clone. Cloning keeps
+// state-pull side effects out of the repo checkout.
+func runVerb(t *testing.T, fixtureDir string, args ...string) (string, string, error) {
+	t.Helper()
+	work := cloneFixture(t, fixtureDir)
+	return runVerbInDir(t, work, args...)
+}
+
+// runVerbInDir runs the ucm cobra tree in workDir as-is (no cloning). Use
+// this from tests that need to seed files into the cwd before invocation
+// (e.g. summary tests seeding a tfstate).
+func runVerbInDir(t *testing.T, workDir string, args ...string) (string, string, error) {
+	t.Helper()
+
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	cmd := New()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+
+	ctx, diagOut := cmdio.NewTestContextWithStderr(context.Background())
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetRoot(ctx, workDir)
+	cmd.SetContext(ctx)
+
+	err = cmd.Execute()
+	return out.String(), diagOut.String() + errOut.String(), err
+}
+
+// cloneFixture copies the flat set of files in fixtureDir into a per-test
+// temp dir. Only top-level files are copied — the ucm fixtures don't nest
+// and the state-pull side of verb tests would otherwise mutate the repo
+// checkout.
+func cloneFixture(t *testing.T, fixtureDir string) string {
+	t.Helper()
+	dst := t.TempDir()
+	entries, err := os.ReadDir(fixtureDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(fixtureDir, e.Name()))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dst, e.Name()), data, 0o644))
+	}
+	return dst
+}
+
+// validFixtureDir is the canonical on-disk ucm.yml the verb smoke tests drive
+// against. Kept next to the cobra wiring so the test's intent (a happy-path
+// run) stays obvious.
+func validFixtureDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join("testdata", "valid")
+}
+
+// assertSentinel is a stable error identity for tests that assert a specific
+// phase error bubbles up to the cobra RunE. Name deliberately parallels the
+// phases-package errSentinel without colliding.
+var assertSentinel = errors.New("ucm verb test sentinel")

--- a/cmd/ucm/helpers_test.go
+++ b/cmd/ucm/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
 	"github.com/databricks/cli/ucm/deploy/terraform"
 	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,6 +140,10 @@ func runVerbInDir(t *testing.T, workDir string, args ...string) (string, string,
 	t.Cleanup(func() { _ = os.Chdir(prev) })
 
 	cmd := New()
+	// plan/deploy/destroy/summary attach PersistentPreRunE: root.MustWorkspaceClient
+	// for real-world auth. Tests fake the workspace client via buildPhaseOptions,
+	// so strip the hook on every subcommand before invoking cobra.
+	stripPersistentPreRunE(cmd)
 	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
@@ -185,3 +190,16 @@ func validFixtureDir(t *testing.T) string {
 // phase error bubbles up to the cobra RunE. Name deliberately parallels the
 // phases-package errSentinel without colliding.
 var assertSentinel = errors.New("ucm verb test sentinel")
+
+// stripPersistentPreRunE recursively clears PersistentPreRunE on cmd and all
+// of its subcommands. The ucm verbs that need live auth wire
+// root.MustWorkspaceClient there; tests stand in their own Backend via
+// buildPhaseOptions so the real auth hook would just fail on a missing
+// ~/.databrickscfg.
+func stripPersistentPreRunE(cmd *cobra.Command) {
+	cmd.PersistentPreRunE = nil
+	cmd.PersistentPreRun = nil
+	for _, sub := range cmd.Commands() {
+		stripPersistentPreRunE(sub)
+	}
+}

--- a/cmd/ucm/options.go
+++ b/cmd/ucm/options.go
@@ -1,0 +1,36 @@
+package ucm
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/phases"
+)
+
+// buildPhaseOptions is the indirection used by plan/deploy/destroy to assemble
+// phases.Options. Tests overwrite this variable in-package to inject a fake
+// TerraformFactory and a local-disk Backend without standing up a real
+// workspace client. Production callers get the default implementation which
+// resolves the state backend from ctx + ucm config.
+var buildPhaseOptions = defaultBuildPhaseOptions
+
+// defaultBuildPhaseOptions is the production implementation of
+// buildPhaseOptions. It reads the workspace client from ctx (populated by
+// root.MustWorkspaceClient when the user supplies auth) and delegates the
+// state-backend shape to ucm/deploy.BackendFromUcm. The returned Options
+// always uses phases.DefaultTerraformFactory — the terraform wrapper
+// constructor is expensive (binary resolution + working dir) and we only
+// stand it up on first invocation.
+func defaultBuildPhaseOptions(ctx context.Context, u *ucm.Ucm) (phases.Options, error) {
+	w := cmdctx.WorkspaceClient(ctx)
+	backend, err := deploy.BackendFromUcm(ctx, u, w)
+	if err != nil {
+		return phases.Options{}, err
+	}
+	return phases.Options{
+		Backend:          backend,
+		TerraformFactory: phases.DefaultTerraformFactory,
+	}, nil
+}

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -23,7 +23,8 @@ touched.
 Common invocations:
   databricks ucm plan                   # Plan against the default target
   databricks ucm plan --target prod     # Plan against a specific target`,
-		Args: root.NoArgs,
+		Args:              root.NoArgs,
+		PersistentPreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -1,0 +1,54 @@
+package ucm
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+func newPlanCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plan",
+		Short: "Preview the changes ucm deploy would make.",
+		Long: `Preview the changes ucm deploy would make.
+
+Runs the initialize → build → terraform init → terraform plan sequence and
+prints a one-line summary. No state is mutated and no remote resources are
+touched.
+
+Common invocations:
+  databricks ucm plan                   # Plan against the default target
+  databricks ucm plan --target prod     # Plan against a specific target`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		opts, err := buildPhaseOptions(ctx, u)
+		if err != nil {
+			return fmt.Errorf("resolve deploy options: %w", err)
+		}
+
+		result := phases.Plan(ctx, u, opts)
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+		if result == nil {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), result.Summary)
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/plan_smoke_test.go
+++ b/cmd/ucm/plan_smoke_test.go
@@ -1,0 +1,94 @@
+package ucm
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn/jsonsaver"
+	"github.com/databricks/cli/libs/logdiag"
+	ucmpkg "github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/deploy/terraform/tfdyn"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// updateSmokeGolden toggles rewrite of the plan-smoke golden file when a
+// deliberate change to the converter output warrants it. Pass -update to the
+// test binary to regenerate. Mirrors libs/testdiff's OverwriteMode pattern
+// but scoped to this test file so the global flag surface stays unchanged.
+var updateSmokeGolden = flag.Bool("update-smoke", false, "regenerate cmd/ucm/testdata/deploy_smoke/expected.tf.json.golden")
+
+// TestCmd_PlanSmoke_EndToEnd exercises the full ucm.yml → phases → tf JSON
+// pipeline against cmd/ucm/testdata/deploy_smoke. It is the M1 close-out
+// fixture: minimal project, nested form with tag inheritance, one grant.
+//
+// The test does NOT stand up a real terraform binary. It invokes the load and
+// mutator chain via phases.LoadDefaultTarget, then drives tfdyn.Convert
+// directly and diffs the marshalled JSON against a committed golden file.
+//
+// Companion to TestCmd_Plan_HappyPathPrintsSummary (verb wiring coverage)
+// which uses the fake-tf harness to prove the cobra path end-to-end; this
+// test guarantees the converter side of the same pipeline stays stable.
+func TestCmd_PlanSmoke_EndToEnd(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	fixture := filepath.Join("testdata", "deploy_smoke")
+
+	u, err := ucmpkg.Load(ctx, fixture)
+	require.NoError(t, err)
+	require.NotNil(t, u)
+
+	phases.LoadDefaultTarget(ctx, u)
+	require.False(t, logdiag.HasError(ctx), "LoadDefaultTarget reported errors")
+	require.NotNil(t, u.Target, "expected default target to be selected")
+
+	assertSmokeGolden(t, ctx, u)
+}
+
+// assertSmokeGolden runs the converter, marshals the tree the same way
+// Render does in production, and asserts against the committed golden file.
+// When -update-smoke is passed the test overwrites the golden file instead
+// of failing — keep the toggle close to the assertion to make regeneration
+// obvious in diff review.
+func assertSmokeGolden(t *testing.T, ctx context.Context, u *ucmpkg.Ucm) {
+	t.Helper()
+
+	tree, err := tfdyn.Convert(ctx, u)
+	require.NoError(t, err)
+
+	got, err := jsonsaver.MarshalIndent(tree, "", "  ")
+	require.NoError(t, err)
+
+	goldenPath := filepath.Join("testdata", "deploy_smoke", "expected.tf.json.golden")
+	if *updateSmokeGolden {
+		require.NoError(t, os.WriteFile(goldenPath, got, 0o644))
+		t.Logf("wrote %s", goldenPath)
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "read golden (pass -update-smoke to regenerate)")
+	assert.JSONEq(t, string(want), string(got), "rendered tf JSON diverged from golden; run with -update-smoke to regenerate")
+}
+
+// TestCmd_PlanSmoke_VerbHappyPath drives the cobra plan verb against the same
+// smoke fixture with the fake-tf harness. Complements TestCmd_PlanSmoke_EndToEnd
+// by proving the full CLI pivot (ucm plan → phases.Plan → TerraformWrapper)
+// stays wired once PersistentPreRunE auth is stripped out for tests.
+func TestCmd_PlanSmoke_VerbHappyPath(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "smoke plan ready"}
+
+	stdout, stderr, err := runVerb(t, filepath.Join("testdata", "deploy_smoke"), "plan")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "smoke plan ready")
+	assert.Equal(t, 1, h.tf.RenderCalls)
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.PlanCalls)
+}

--- a/cmd/ucm/plan_test.go
+++ b/cmd/ucm/plan_test.go
@@ -1,0 +1,33 @@
+package ucm
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_Plan_HappyPathPrintsSummary(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "plan has changes"}
+
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "plan")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "plan has changes")
+	assert.Equal(t, 1, h.tf.RenderCalls)
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.PlanCalls)
+}
+
+func TestCmd_Plan_NoChangesPrintsSummary(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.PlanResult = &terraform.PlanResult{HasChanges: false, Summary: "no changes"}
+
+	stdout, _, err := runVerb(t, validFixtureDir(t), "plan")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "no changes")
+}

--- a/cmd/ucm/policy_check.go
+++ b/cmd/ucm/policy_check.go
@@ -1,0 +1,41 @@
+package ucm
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+func newPolicyCheckCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy-check",
+		Short: "Run only the ucm validation mutators (tags, naming, required fields).",
+		Long: `Run the subset of ucm validation mutators that are cheap enough for a
+pre-commit hook. Unlike ` + "`ucm validate`" + `, which runs the full mutator chain,
+policy-check only runs the validation rules (tag enforcement, naming,
+required fields). No network I/O.`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		phases.PolicyCheck(ctx, u)
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Policy check OK!")
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/policy_check_test.go
+++ b/cmd/ucm/policy_check_test.go
@@ -1,0 +1,24 @@
+package ucm
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_PolicyCheck_ValidFixturePasses(t *testing.T) {
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "policy-check")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Policy check OK!")
+}
+
+func TestCmd_PolicyCheck_MissingTagFixtureFails(t *testing.T) {
+	_, stderr, err := runVerb(t, filepath.Join("testdata", "missing_tag"), "policy-check")
+
+	require.Error(t, err)
+	assert.Contains(t, stderr, "requires tag")
+}

--- a/cmd/ucm/stubs.go
+++ b/cmd/ucm/stubs.go
@@ -21,22 +21,6 @@ func stub(use, short string) *cobra.Command {
 	return cmd
 }
 
-func newPlanCommand() *cobra.Command {
-	return stub("plan", "Preview the changes ucm deploy would make.")
-}
-
-func newDeployCommand() *cobra.Command {
-	return stub("deploy", "Apply ucm configuration to the target Databricks account/workspace.")
-}
-
-func newDestroyCommand() *cobra.Command {
-	return stub("destroy", "Tear down everything managed by the current target.")
-}
-
-func newSummaryCommand() *cobra.Command {
-	return stub("summary", "Summarize deployed resources and their ids/URLs.")
-}
-
 func newInitCommand() *cobra.Command {
 	return stub("init [template]", "Scaffold a new ucm.yml project from a starter template.")
 }
@@ -63,8 +47,4 @@ func newDriftCommand() *cobra.Command {
 
 func newImportCommand() *cobra.Command {
 	return stub("import <type> <name>", "Import a single existing UC or cloud resource into ucm state.")
-}
-
-func newPolicyCheckCommand() *cobra.Command {
-	return stub("policy-check", "Run only the ucm validation mutators (tags, naming, required fields).")
 }

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -1,0 +1,99 @@
+package ucm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/spf13/cobra"
+)
+
+// tfstateEnvelope is the minimal shape we need out of terraform.tfstate to
+// produce a resource-count summary. Forked (not imported) from the terraform
+// project's Go API so ucm doesn't pin on an internal schema.
+type tfstateEnvelope struct {
+	Resources []struct {
+		Type string `json:"type"`
+	} `json:"resources"`
+}
+
+func newSummaryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Summarize deployed resources by type.",
+		Long: `Summarize the resources currently tracked by the ucm deploy state.
+
+Reads the local terraform state cached under .databricks/ucm/<target>/ and
+prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
+` + "`ucm plan`" + `) first; without a local state the table is empty.`,
+		Args: root.NoArgs,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		statePath := filepath.Join(deploy.LocalStateDir(u), deploy.TfStateFileName)
+		counts, err := readTfstateCounts(statePath)
+		if err != nil {
+			return fmt.Errorf("read local state %s: %w", filepath.ToSlash(statePath), err)
+		}
+
+		out := cmd.OutOrStdout()
+		if len(counts) == 0 {
+			fmt.Fprintln(out, "No deployed resources found. Run `ucm deploy` first.")
+			return nil
+		}
+
+		types := make([]string, 0, len(counts))
+		for t := range counts {
+			types = append(types, t)
+		}
+		sort.Strings(types)
+
+		tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "TYPE\tCOUNT")
+		for _, t := range types {
+			fmt.Fprintf(tw, "%s\t%d\n", t, counts[t])
+		}
+		return tw.Flush()
+	}
+
+	return cmd
+}
+
+// readTfstateCounts opens the terraform.tfstate at path and returns a map of
+// resource type → count. A missing state file is treated as "no resources"
+// rather than an error so the first-run / pre-deploy path stays clean.
+func readTfstateCounts(path string) (map[string]int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var env tfstateEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("parse tfstate: %w", err)
+	}
+
+	counts := make(map[string]int, len(env.Resources))
+	for _, r := range env.Resources {
+		counts[r.Type]++
+	}
+	return counts, nil
+}

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -35,7 +35,8 @@ func newSummaryCommand() *cobra.Command {
 Reads the local terraform state cached under .databricks/ucm/<target>/ and
 prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
 ` + "`ucm plan`" + `) first; without a local state the table is empty.`,
-		Args: root.NoArgs,
+		Args:              root.NoArgs,
+		PersistentPreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/summary_test.go
+++ b/cmd/ucm/summary_test.go
@@ -1,0 +1,55 @@
+package ucm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTfstateForTarget seeds .databricks/ucm/<target>/terraform.tfstate
+// under fixtureDir with the resources slice.
+func writeTfstateForTarget(t *testing.T, fixtureDir, target string, resources []map[string]any) {
+	t.Helper()
+	dir := filepath.Join(fixtureDir, filepath.FromSlash(deploy.LocalCacheDir), target)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	blob := map[string]any{
+		"version":   4,
+		"resources": resources,
+	}
+	data, err := json.Marshal(blob)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, deploy.TfStateFileName), data, 0o600))
+}
+
+func TestCmd_Summary_NoStatePrintsPlaceholder(t *testing.T) {
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "summary")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "No deployed resources")
+}
+
+func TestCmd_Summary_WithStatePrintsCounts(t *testing.T) {
+	work := cloneFixture(t, validFixtureDir(t))
+	// The valid fixture declares no explicit target, so SelectDefaultTarget
+	// chooses the synthesised "default" target. Seed a tfstate there.
+	writeTfstateForTarget(t, work, "default", []map[string]any{
+		{"type": "databricks_catalog"},
+		{"type": "databricks_catalog"},
+		{"type": "databricks_schema"},
+	})
+
+	stdout, stderr, err := runVerbInDir(t, work, "summary")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "databricks_catalog")
+	assert.Contains(t, stdout, "databricks_schema")
+	assert.Contains(t, stdout, "2")
+	assert.Contains(t, stdout, "1")
+}

--- a/cmd/ucm/testdata/collision/ucm.yml
+++ b/cmd/ucm/testdata/collision/ucm.yml
@@ -1,0 +1,26 @@
+ucm:
+  name: fixture-collision
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      schemas:
+        bronze:
+          name: bronze
+          tags:
+            cost_center: "1234"
+            data_owner: alpha
+            classification: internal
+
+  schemas:
+    bronze:
+      name: bronze
+      catalog: team_alpha
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal

--- a/cmd/ucm/testdata/deploy_smoke/expected.tf.json.golden
+++ b/cmd/ucm/testdata/deploy_smoke/expected.tf.json.golden
@@ -1,0 +1,49 @@
+{
+  "resource": {
+    "databricks_catalog": {
+      "main": {
+        "name": "main",
+        "comment": "smoke catalog",
+        "properties": {
+          "data_owner": "platform",
+          "classification": "internal",
+          "cost_center": "9999"
+        },
+        "force_destroy": true
+      }
+    },
+    "databricks_schema": {
+      "default": {
+        "name": "default",
+        "catalog_name": "main",
+        "comment": "smoke schema",
+        "properties": {
+          "classification": "internal",
+          "cost_center": "9999",
+          "data_owner": "platform"
+        },
+        "force_destroy": true,
+        "depends_on": [
+          "databricks_catalog.main"
+        ]
+      }
+    },
+    "databricks_grants": {
+      "default_reader": {
+        "schema": "${databricks_schema.default.id}",
+        "grant": [
+          {
+            "principal": "platform-readers",
+            "privileges": [
+              "USE_SCHEMA",
+              "SELECT"
+            ]
+          }
+        ],
+        "depends_on": [
+          "databricks_schema.default"
+        ]
+      }
+    }
+  }
+}

--- a/cmd/ucm/testdata/deploy_smoke/ucm.yml
+++ b/cmd/ucm/testdata/deploy_smoke/ucm.yml
@@ -1,0 +1,24 @@
+ucm:
+  name: smoke
+  engine: terraform
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    main:
+      name: main
+      comment: smoke catalog
+      tags:
+        cost_center: "9999"
+        data_owner: platform
+        classification: internal
+      schemas:
+        default:
+          name: default
+          comment: smoke schema
+          grants:
+            default_reader:
+              principal: platform-readers
+              privileges: [USE_SCHEMA, SELECT]

--- a/cmd/ucm/testdata/inherit_opt_out/ucm.yml
+++ b/cmd/ucm/testdata/inherit_opt_out/ucm.yml
@@ -1,0 +1,24 @@
+ucm:
+  name: fixture-inherit-opt-out
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal
+      schemas:
+        bronze:
+          name: bronze
+          tag_inherit: false
+          # no tags — ValidateTags should complain because inheritance is off
+
+  tag_validation_rules:
+    enforce_ownership:
+      securable_types: [catalog, schema]
+      required: [cost_center, data_owner, classification]

--- a/cmd/ucm/testdata/nested/ucm.yml
+++ b/cmd/ucm/testdata/nested/ucm.yml
@@ -1,0 +1,41 @@
+ucm:
+  name: fixture-nested
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    team_alpha:
+      name: team_alpha
+      comment: alpha catalog
+      tags:
+        cost_center: "1234"
+        data_owner: alpha
+        classification: internal
+      schemas:
+        bronze:
+          name: bronze
+          # catalog, cost_center, data_owner, classification all inherited
+          grants:
+            bronze_reader:
+              principal: alpha-readers
+              privileges: [USE_SCHEMA, SELECT]
+        silver:
+          name: silver
+          tag_inherit: false
+          tags:
+            cost_center: "1234"
+            data_owner: alpha
+            classification: internal
+      grants:
+        alpha_read:
+          principal: alpha-readers
+          privileges: [USE_CATALOG, SELECT]
+
+  tag_validation_rules:
+    enforce_ownership:
+      securable_types: [catalog, schema]
+      required: [cost_center, data_owner, classification]
+      allowed_values:
+        classification: [public, internal, confidential, restricted]

--- a/cmd/ucm/utils/utils.go
+++ b/cmd/ucm/utils/utils.go
@@ -1,0 +1,51 @@
+// Package utils contains helpers shared across cmd/ucm verbs.
+package utils
+
+import (
+	"context"
+
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/engine"
+)
+
+const (
+	sourceConfig  = "config"
+	sourceEnv     = "env"
+	sourceDefault = "default"
+)
+
+// ResolveEngineSetting determines the effective engine for a ucm project.
+//
+// Priority is: ucm.engine in config > DATABRICKS_UCM_ENGINE env var > Default.
+// The returned EngineSetting always has a concrete Type (never EngineNotSet):
+// callers get a ready-to-dispatch value without having to handle the unset case.
+func ResolveEngineSetting(ctx context.Context, u *config.Ucm) (engine.EngineSetting, error) {
+	var configEngine engine.EngineType
+	if u != nil {
+		configEngine = u.Engine
+	}
+
+	if configEngine != engine.EngineNotSet {
+		return engine.EngineSetting{
+			Type:       configEngine,
+			Source:     sourceConfig,
+			ConfigType: configEngine,
+		}, nil
+	}
+
+	envEngine, err := engine.FromEnv(ctx)
+	if err != nil {
+		return engine.EngineSetting{}, err
+	}
+	if envEngine != engine.EngineNotSet {
+		return engine.EngineSetting{
+			Type:   envEngine,
+			Source: sourceEnv,
+		}, nil
+	}
+
+	return engine.EngineSetting{
+		Type:   engine.Default,
+		Source: sourceDefault,
+	}, nil
+}

--- a/cmd/ucm/utils/utils_test.go
+++ b/cmd/ucm/utils/utils_test.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEngineSettingConfigTakesPriority(t *testing.T) {
+	ctx := env.Set(t.Context(), engine.EnvVar, "terraform")
+	u := &config.Ucm{Engine: engine.EngineDirect}
+	got, err := ResolveEngineSetting(ctx, u)
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineDirect, got.Type)
+	assert.Equal(t, engine.EngineDirect, got.ConfigType)
+	assert.Equal(t, "config", got.Source)
+}
+
+func TestResolveEngineSettingConfigOverridesInvalidEnv(t *testing.T) {
+	// An invalid env var is ignored when the config already selects an engine.
+	ctx := env.Set(t.Context(), engine.EnvVar, "bogus")
+	u := &config.Ucm{Engine: engine.EngineTerraform}
+	got, err := ResolveEngineSetting(ctx, u)
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineTerraform, got.Type)
+	assert.Equal(t, "config", got.Source)
+}
+
+func TestResolveEngineSettingFallsBackToEnv(t *testing.T) {
+	ctx := env.Set(t.Context(), engine.EnvVar, "direct")
+	got, err := ResolveEngineSetting(ctx, &config.Ucm{})
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineDirect, got.Type)
+	assert.Equal(t, engine.EngineNotSet, got.ConfigType)
+	assert.Equal(t, "env", got.Source)
+}
+
+func TestResolveEngineSettingDefault(t *testing.T) {
+	got, err := ResolveEngineSetting(t.Context(), &config.Ucm{})
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineTerraform, got.Type)
+	assert.Equal(t, engine.EngineNotSet, got.ConfigType)
+	assert.Equal(t, "default", got.Source)
+}
+
+func TestResolveEngineSettingNilUcm(t *testing.T) {
+	got, err := ResolveEngineSetting(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, engine.EngineTerraform, got.Type)
+	assert.Equal(t, "default", got.Source)
+}
+
+func TestResolveEngineSettingInvalidEnv(t *testing.T) {
+	ctx := env.Set(t.Context(), engine.EnvVar, "bogus")
+	_, err := ResolveEngineSetting(ctx, &config.Ucm{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), engine.EnvVar)
+}

--- a/cmd/ucm/validate_test.go
+++ b/cmd/ucm/validate_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 // runValidate invokes the cobra ucm-subtree in a temp cwd set to fixtureDir
-// and returns stdout, stderr, and whatever the Execute call returned.
+// and returns stdout, diag-stream output (cmdio stderr), and whatever the
+// Execute call returned.
 func runValidate(t *testing.T, fixtureDir string) (string, string, error) {
 	t.Helper()
 
@@ -32,13 +33,13 @@ func runValidate(t *testing.T, fixtureDir string) (string, string, error) {
 	cmd.SetErr(&errOut)
 	cmd.SetArgs([]string{"validate"})
 
-	ctx, _ := cmdio.NewTestContextWithStderr(context.Background())
+	ctx, diagOut := cmdio.NewTestContextWithStderr(context.Background())
 	ctx = logdiag.InitContext(ctx)
 	logdiag.SetRoot(ctx, fixtureDir)
 	cmd.SetContext(ctx)
 
 	err = cmd.Execute()
-	return out.String(), errOut.String(), err
+	return out.String(), diagOut.String() + errOut.String(), err
 }
 
 func TestCmd_Validate_ValidFixturePasses(t *testing.T) {
@@ -52,6 +53,26 @@ func TestCmd_Validate_ValidFixturePasses(t *testing.T) {
 func TestCmd_Validate_MissingTagFixtureFails(t *testing.T) {
 	_, _, err := runValidate(t, filepath.Join("testdata", "missing_tag"))
 	require.Error(t, err)
+}
+
+func TestCmd_Validate_NestedFixturePasses(t *testing.T) {
+	stdout, stderr, err := runValidate(t, filepath.Join("testdata", "nested"))
+	t.Logf("stdout=%q", stdout)
+	t.Logf("stderr=%q", stderr)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Validation OK!")
+}
+
+func TestCmd_Validate_CollisionFixtureFails(t *testing.T) {
+	_, stderr, err := runValidate(t, filepath.Join("testdata", "collision"))
+	require.Error(t, err)
+	assert.Contains(t, stderr, "declared both as a flat entry and nested")
+}
+
+func TestCmd_Validate_InheritOptOutFailsTagRule(t *testing.T) {
+	_, stderr, err := runValidate(t, filepath.Join("testdata", "inherit_opt_out"))
+	require.Error(t, err)
+	assert.Contains(t, stderr, "requires tag")
 }
 
 func TestCmd_Schema_ProducesValidJSON(t *testing.T) {

--- a/ucm/config/engine/engine.go
+++ b/ucm/config/engine/engine.go
@@ -1,0 +1,74 @@
+// Package engine describes the ucm deployment engine selection.
+//
+// Mirrors bundle/config/engine so ucm can resolve its own engine independently
+// of bundle. The fork-and-adapt approach keeps ucm free of bundle imports as
+// required by cmd/ucm/CLAUDE.md.
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/env"
+)
+
+// EnvVar is the name of the environment variable that overrides the ucm engine.
+const EnvVar = "DATABRICKS_UCM_ENGINE"
+
+// EngineType identifies the deployment engine that ucm should use.
+type EngineType string
+
+const (
+	EngineDirect    EngineType = "direct"
+	EngineTerraform EngineType = "terraform"
+	EngineNotSet    EngineType = ""
+)
+
+// Default is used when neither ucm.engine nor DATABRICKS_UCM_ENGINE is set.
+const Default = EngineTerraform
+
+// Parse returns the EngineType for a string value.
+// The second return value is false if the string is not a recognized engine.
+func Parse(engine string) (EngineType, bool) {
+	switch engine {
+	case "":
+		return EngineNotSet, true
+	case "terraform":
+		return EngineTerraform, true
+	case "direct":
+		return EngineDirect, true
+	default:
+		return EngineNotSet, false
+	}
+}
+
+// FromEnv returns the engine configured via DATABRICKS_UCM_ENGINE.
+// Returns EngineNotSet (without error) when the variable is empty or unset.
+func FromEnv(ctx context.Context) (EngineType, error) {
+	value := env.Get(ctx, EnvVar)
+	engine, ok := Parse(value)
+	if !ok {
+		return EngineNotSet, fmt.Errorf("unexpected setting for %s=%#v (expected 'terraform' or 'direct')", EnvVar, value)
+	}
+	return engine, nil
+}
+
+// EngineSetting represents a resolved engine choice along with where it came from.
+type EngineSetting struct {
+	Type       EngineType // effective resolved engine
+	Source     string     // human-readable source of Type
+	ConfigType EngineType // value from ucm config (EngineNotSet if not configured)
+}
+
+// ThisOrDefault returns the receiver, or Default when the receiver is EngineNotSet.
+func (e EngineType) ThisOrDefault() EngineType {
+	if e == EngineNotSet {
+		return Default
+	}
+	return e
+}
+
+// IsDirect reports whether the effective engine (after defaulting) is EngineDirect.
+func (e EngineType) IsDirect() bool {
+	return e.ThisOrDefault() == EngineDirect
+}

--- a/ucm/config/engine/engine_test.go
+++ b/ucm/config/engine/engine_test.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		input string
+		want  EngineType
+		ok    bool
+	}{
+		{"", EngineNotSet, true},
+		{"terraform", EngineTerraform, true},
+		{"direct", EngineDirect, true},
+		{"TERRAFORM", EngineNotSet, false},
+		{"tf", EngineNotSet, false},
+		{"unknown", EngineNotSet, false},
+	}
+	for _, c := range cases {
+		got, ok := Parse(c.input)
+		assert.Equal(t, c.want, got, "Parse(%q) value", c.input)
+		assert.Equal(t, c.ok, ok, "Parse(%q) ok", c.input)
+	}
+}
+
+func TestFromEnv(t *testing.T) {
+	ctx := env.Set(t.Context(), EnvVar, "direct")
+	e, err := FromEnv(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, EngineDirect, e)
+}
+
+func TestFromEnvTerraform(t *testing.T) {
+	ctx := env.Set(t.Context(), EnvVar, "terraform")
+	e, err := FromEnv(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, EngineTerraform, e)
+}
+
+func TestFromEnvNotSet(t *testing.T) {
+	e, err := FromEnv(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, EngineNotSet, e)
+}
+
+func TestFromEnvInvalid(t *testing.T) {
+	ctx := env.Set(t.Context(), EnvVar, "bogus")
+	_, err := FromEnv(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), EnvVar)
+}
+
+func TestThisOrDefault(t *testing.T) {
+	assert.Equal(t, EngineTerraform, EngineNotSet.ThisOrDefault())
+	assert.Equal(t, EngineTerraform, EngineTerraform.ThisOrDefault())
+	assert.Equal(t, EngineDirect, EngineDirect.ThisOrDefault())
+}
+
+func TestIsDirect(t *testing.T) {
+	assert.False(t, EngineNotSet.IsDirect())
+	assert.False(t, EngineTerraform.IsDirect())
+	assert.True(t, EngineDirect.IsDirect())
+}

--- a/ucm/config/mutator/flatten_nested_resources.go
+++ b/ucm/config/mutator/flatten_nested_resources.go
@@ -1,0 +1,246 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/ucm"
+)
+
+type flattenNestedResources struct{}
+
+// FlattenNestedResources unrolls the nested forms of schemas and grants
+// (declared under a catalog, or grants declared under a schema) into the flat
+// Root.Resources.{Schemas,Grants} maps. Injects parent references so the
+// post-flatten tree is indistinguishable from a purely flat declaration.
+//
+// Runs first in the load phase, before any other mutator reads the resources
+// tree. After it runs, catalog.schemas, catalog.grants, and schema.grants are
+// all nil.
+//
+// Collision handling: a nested entry whose key already exists as a flat entry
+// emits a diag.Error pointing at the nested location. Same for a user-supplied
+// field that conflicts with the injected parent reference (e.g. a nested
+// schema that sets `catalog: other`).
+func FlattenNestedResources() ucm.Mutator { return &flattenNestedResources{} }
+
+func (m *flattenNestedResources) Name() string { return "FlattenNestedResources" }
+
+func (m *flattenNestedResources) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	err := u.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
+		resourcesValue := root.Get("resources")
+		resources, ok := resourcesValue.AsMap()
+		if !ok {
+			return root, nil
+		}
+
+		catalogsValue, _ := resources.GetByString("catalogs")
+		catalogs, ok := catalogsValue.AsMap()
+		if !ok {
+			return root, nil
+		}
+
+		flatSchemas, _ := resources.GetByString("schemas")
+		flatGrants, _ := resources.GetByString("grants")
+		schemasMap := mapOrNew(flatSchemas)
+		grantsMap := mapOrNew(flatGrants)
+
+		newCatalogs := dyn.NewMapping()
+		for _, cp := range catalogs.Pairs() {
+			catalogName := cp.Key.MustString()
+			catalogBody, ok := cp.Value.AsMap()
+			if !ok {
+				newCatalogs.SetLoc(catalogName, cp.Key.Locations(), cp.Value)
+				continue
+			}
+
+			if nested, ok := catalogBody.GetByString("schemas"); ok {
+				diags = append(diags, liftNestedSchemas(catalogName, nested, &schemasMap, &grantsMap)...)
+			}
+			if nested, ok := catalogBody.GetByString("grants"); ok {
+				diags = append(diags, liftNestedCatalogGrants(catalogName, nested, &grantsMap)...)
+			}
+
+			stripped := removeKeys(catalogBody, "schemas", "grants")
+			newCatalogs.SetLoc(catalogName, cp.Key.Locations(), dyn.NewValue(stripped, cp.Value.Locations()))
+		}
+
+		newResources := resources.Clone()
+		newResources.SetLoc("catalogs", nil, dyn.NewValue(newCatalogs, catalogsValue.Locations()))
+		if schemasMap.Len() > 0 {
+			newResources.SetLoc("schemas", nil, dyn.NewValue(schemasMap, flatSchemas.Locations()))
+		}
+		if grantsMap.Len() > 0 {
+			newResources.SetLoc("grants", nil, dyn.NewValue(grantsMap, flatGrants.Locations()))
+		}
+
+		return dyn.SetByPath(root, dyn.NewPath(dyn.Key("resources")),
+			dyn.NewValue(newResources, resourcesValue.Locations()))
+	})
+	if err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	return diags
+}
+
+// liftNestedSchemas moves catalog.schemas into the top-level schemas map,
+// injecting `catalog` and processing any schema-nested grants.
+func liftNestedSchemas(catalogName string, nested dyn.Value, schemas, grants *dyn.Mapping) diag.Diagnostics {
+	var diags diag.Diagnostics
+	nestedMap, ok := nested.AsMap()
+	if !ok {
+		return diags
+	}
+	for _, sp := range nestedMap.Pairs() {
+		schemaName := sp.Key.MustString()
+		schemaValue, ok := sp.Value.AsMap()
+		if !ok {
+			continue
+		}
+		updated := schemaValue.Clone()
+
+		if d := injectStringField(&updated, "catalog", catalogName,
+			fmt.Sprintf("schema %q nested under catalog %q", schemaName, catalogName),
+			sp.Key.Locations()); d != nil {
+			diags = append(diags, d...)
+		}
+
+		if nestedGrants, ok := updated.GetByString("grants"); ok {
+			diags = append(diags, liftNestedSchemaGrants(schemaName, nestedGrants, grants)...)
+		}
+
+		flatValue := dyn.NewValue(removeKeys(updated, "grants"), sp.Value.Locations())
+
+		if existing, ok := schemas.GetPairByString(schemaName); ok {
+			diags = append(diags, collisionDiag("schema", schemaName, sp.Key.Locations(), existing.Key.Locations())...)
+			continue
+		}
+		schemas.SetLoc(schemaName, sp.Key.Locations(), flatValue)
+	}
+	return diags
+}
+
+// liftNestedCatalogGrants injects securable={catalog, <name>} into nested
+// catalog grants and moves them into the flat grants map.
+func liftNestedCatalogGrants(catalogName string, nested dyn.Value, grants *dyn.Mapping) diag.Diagnostics {
+	return liftNestedGrants(nested, grants, "catalog", catalogName,
+		fmt.Sprintf("grant nested under catalog %q", catalogName))
+}
+
+// liftNestedSchemaGrants injects securable={schema, <name>} into nested
+// schema grants and moves them into the flat grants map.
+func liftNestedSchemaGrants(schemaName string, nested dyn.Value, grants *dyn.Mapping) diag.Diagnostics {
+	return liftNestedGrants(nested, grants, "schema", schemaName,
+		fmt.Sprintf("grant nested under schema %q", schemaName))
+}
+
+func liftNestedGrants(nested dyn.Value, grants *dyn.Mapping, kind, parentName, ctxDesc string) diag.Diagnostics {
+	var diags diag.Diagnostics
+	nestedMap, ok := nested.AsMap()
+	if !ok {
+		return diags
+	}
+	for _, gp := range nestedMap.Pairs() {
+		grantName := gp.Key.MustString()
+		grantValue, ok := gp.Value.AsMap()
+		if !ok {
+			continue
+		}
+		updated := grantValue.Clone()
+
+		if d := injectSecurable(&updated, kind, parentName, ctxDesc, gp.Key.Locations()); d != nil {
+			diags = append(diags, d...)
+		}
+
+		flatValue := dyn.NewValue(updated, gp.Value.Locations())
+		if existing, ok := grants.GetPairByString(grantName); ok {
+			diags = append(diags, collisionDiag("grant", grantName, gp.Key.Locations(), existing.Key.Locations())...)
+			continue
+		}
+		grants.SetLoc(grantName, gp.Key.Locations(), flatValue)
+	}
+	return diags
+}
+
+// injectStringField writes key=want into m. If m already has key with a
+// different value, emits an error diagnostic.
+func injectStringField(m *dyn.Mapping, key, want, ctxDesc string, locs []dyn.Location) diag.Diagnostics {
+	existing, ok := m.GetByString(key)
+	if ok {
+		if got, _ := existing.AsString(); got != "" && got != want {
+			return diag.Diagnostics{{
+				Severity:  diag.Error,
+				Summary:   fmt.Sprintf("%s: %s=%q conflicts with parent %q", ctxDesc, key, got, want),
+				Locations: locs,
+			}}
+		}
+	}
+	m.SetLoc(key, locs, dyn.V(want))
+	return nil
+}
+
+// injectSecurable writes securable={type: kind, name: parentName} into m. If
+// m already has a securable that differs, emits an error.
+func injectSecurable(m *dyn.Mapping, kind, parentName, ctxDesc string, locs []dyn.Location) diag.Diagnostics {
+	want := dyn.V(map[string]dyn.Value{
+		"type": dyn.V(kind),
+		"name": dyn.V(parentName),
+	})
+	existing, ok := m.GetByString("securable")
+	if ok {
+		existingMap, _ := existing.AsMap()
+		gotType, _ := existingMap.GetByString("type")
+		gotName, _ := existingMap.GetByString("name")
+		gt, _ := gotType.AsString()
+		gn, _ := gotName.AsString()
+		if (gt != "" && gt != kind) || (gn != "" && gn != parentName) {
+			return diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"%s: securable=%s/%s conflicts with parent %s/%s",
+					ctxDesc, gt, gn, kind, parentName,
+				),
+				Locations: locs,
+			}}
+		}
+	}
+	m.SetLoc("securable", locs, want)
+	return nil
+}
+
+func collisionDiag(kind, name string, nestedLocs, flatLocs []dyn.Location) diag.Diagnostics {
+	locs := append([]dyn.Location{}, nestedLocs...)
+	locs = append(locs, flatLocs...)
+	return diag.Diagnostics{{
+		Severity:  diag.Error,
+		Summary:   fmt.Sprintf("%s %q is declared both as a flat entry and nested under its parent", kind, name),
+		Locations: locs,
+	}}
+}
+
+func mapOrNew(v dyn.Value) dyn.Mapping {
+	m, ok := v.AsMap()
+	if !ok {
+		return dyn.NewMapping()
+	}
+	return m.Clone()
+}
+
+// removeKeys returns a new Mapping with the named keys dropped.
+func removeKeys(m dyn.Mapping, keys ...string) dyn.Mapping {
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+	out := dyn.NewMapping()
+	for _, p := range m.Pairs() {
+		if _, skip := drop[p.Key.MustString()]; skip {
+			continue
+		}
+		out.SetLoc(p.Key.MustString(), p.Key.Locations(), p.Value)
+	}
+	return out
+}

--- a/ucm/config/mutator/flatten_nested_resources_test.go
+++ b/ucm/config/mutator/flatten_nested_resources_test.go
@@ -1,0 +1,155 @@
+package mutator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenNestedResources(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		wantDiagSubs  []string
+		wantSchema    map[string]string // schemaName → expected catalog
+		wantGrantKind map[string]string // grantName → expected securable kind
+		wantGrantName map[string]string // grantName → expected securable name
+	}{
+		{
+			name: "bare nested schema injects catalog",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1: {name: s1}
+`,
+			wantSchema: map[string]string{"s1": "c1"},
+		},
+		{
+			name: "nested schema with matching catalog does not error",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1: {name: s1, catalog: c1}
+`,
+			wantSchema: map[string]string{"s1": "c1"},
+		},
+		{
+			name: "nested schema with conflicting catalog errors",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1: {name: s1, catalog: other}
+`,
+			wantDiagSubs: []string{"conflicts with parent"},
+			wantSchema:   map[string]string{"s1": "other"},
+		},
+		{
+			name: "nested grant at catalog level injects securable",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      grants:
+        g1: {principal: p, privileges: [USE_CATALOG]}
+`,
+			wantGrantKind: map[string]string{"g1": "catalog"},
+			wantGrantName: map[string]string{"g1": "c1"},
+		},
+		{
+			name: "nested grant at schema level injects securable",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1:
+          name: s1
+          grants:
+            g1: {principal: p, privileges: [SELECT]}
+`,
+			wantGrantKind: map[string]string{"g1": "schema"},
+			wantGrantName: map[string]string{"g1": "s1"},
+			wantSchema:    map[string]string{"s1": "c1"},
+		},
+		{
+			name: "flat-vs-nested schema collision errors",
+			yaml: `
+ucm: {name: t}
+resources:
+  schemas:
+    s1: {name: s1, catalog: c1}
+  catalogs:
+    c1:
+      name: c1
+      schemas:
+        s1: {name: s1}
+`,
+			wantDiagSubs: []string{"declared both as a flat entry and nested"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := loadUcm(t, tc.yaml)
+			diags := ucm.Apply(t.Context(), u, mutator.FlattenNestedResources())
+
+			for _, sub := range tc.wantDiagSubs {
+				found := false
+				for _, s := range summaries(diags) {
+					if strings.Contains(s, sub) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected diag containing %q, got %v", sub, summaries(diags))
+			}
+			if len(tc.wantDiagSubs) == 0 {
+				require.Empty(t, diags, "unexpected diags: %v", summaries(diags))
+			}
+
+			for name, want := range tc.wantSchema {
+				got := u.Config.Resources.Schemas[name]
+				require.NotNil(t, got, "schema %q missing", name)
+				assert.Equal(t, want, got.Catalog, "schema %q catalog", name)
+			}
+			for name, want := range tc.wantGrantKind {
+				got := u.Config.Resources.Grants[name]
+				require.NotNil(t, got, "grant %q missing", name)
+				assert.Equal(t, want, got.Securable.Type)
+			}
+			for name, want := range tc.wantGrantName {
+				got := u.Config.Resources.Grants[name]
+				require.NotNil(t, got, "grant %q missing", name)
+				assert.Equal(t, want, got.Securable.Name)
+			}
+
+			// Nested maps must be cleared after flatten.
+			for _, c := range u.Config.Resources.Catalogs {
+				assert.Nil(t, c.Schemas, "catalog.Schemas should be cleared")
+				assert.Nil(t, c.Grants, "catalog.Grants should be cleared")
+			}
+			for _, s := range u.Config.Resources.Schemas {
+				assert.Nil(t, s.Grants, "schema.Grants should be cleared")
+			}
+		})
+	}
+}

--- a/ucm/config/mutator/inherit_catalog_tags.go
+++ b/ucm/config/mutator/inherit_catalog_tags.go
@@ -1,0 +1,43 @@
+package mutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+)
+
+type inheritCatalogTags struct{}
+
+// InheritCatalogTags merges each catalog's tags into every schema under that
+// catalog unless the schema sets tag_inherit: false. Schema tags win on
+// conflict. Runs after FlattenNestedResources (so schemas are already flat
+// and carry a catalog reference) and before ValidateTags.
+func InheritCatalogTags() ucm.Mutator { return &inheritCatalogTags{} }
+
+func (m *inheritCatalogTags) Name() string { return "InheritCatalogTags" }
+
+func (m *inheritCatalogTags) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	catalogs := u.Config.Resources.Catalogs
+	for _, schema := range u.Config.Resources.Schemas {
+		if schema == nil || schema.Catalog == "" {
+			continue
+		}
+		if schema.TagInherit != nil && !*schema.TagInherit {
+			continue
+		}
+		parent := catalogs[schema.Catalog]
+		if parent == nil || len(parent.Tags) == 0 {
+			continue
+		}
+		if schema.Tags == nil {
+			schema.Tags = make(map[string]string, len(parent.Tags))
+		}
+		for k, v := range parent.Tags {
+			if _, exists := schema.Tags[k]; !exists {
+				schema.Tags[k] = v
+			}
+		}
+	}
+	return nil
+}

--- a/ucm/config/mutator/inherit_catalog_tags_test.go
+++ b/ucm/config/mutator/inherit_catalog_tags_test.go
@@ -1,0 +1,96 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInheritCatalogTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		schema   string
+		wantTags map[string]string
+	}{
+		{
+			name: "catalog tags inherited by default",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags: {cost_center: "1", data_owner: a}
+      schemas:
+        s1: {name: s1}
+`,
+			schema:   "s1",
+			wantTags: map[string]string{"cost_center": "1", "data_owner": "a"},
+		},
+		{
+			name: "schema tag overrides parent on conflict",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags: {cost_center: "1", data_owner: a}
+      schemas:
+        s1: {name: s1, tags: {data_owner: b}}
+`,
+			schema:   "s1",
+			wantTags: map[string]string{"cost_center": "1", "data_owner": "b"},
+		},
+		{
+			name: "tag_inherit false opts out",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      tags: {cost_center: "1"}
+      schemas:
+        s1: {name: s1, tag_inherit: false}
+`,
+			schema:   "s1",
+			wantTags: nil,
+		},
+		{
+			name: "flat schema inherits from its named catalog",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1, tags: {cost_center: "1"}}
+  schemas:
+    s1: {name: s1, catalog: c1}
+`,
+			schema:   "s1",
+			wantTags: map[string]string{"cost_center": "1"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := loadUcm(t, tc.yaml)
+			diags := ucm.ApplySeq(t.Context(), u,
+				mutator.FlattenNestedResources(),
+				mutator.InheritCatalogTags(),
+			)
+			require.NoError(t, diags.Error())
+
+			got := u.Config.Resources.Schemas[tc.schema]
+			require.NotNil(t, got)
+			if tc.wantTags == nil {
+				assert.Empty(t, got.Tags)
+			} else {
+				assert.Equal(t, tc.wantTags, got.Tags)
+			}
+		})
+	}
+}

--- a/ucm/config/resources/catalog.go
+++ b/ucm/config/resources/catalog.go
@@ -15,4 +15,10 @@ type Catalog struct {
 
 	// Tags is a key/value map evaluated by ucm's tag-validation mutators.
 	Tags map[string]string `json:"tags,omitempty"`
+
+	// Schemas and Grants are nested-form conveniences: the FlattenNestedResources
+	// mutator moves them to Root.Resources.{Schemas,Grants} (injecting parent
+	// references) before any other mutator runs. Always nil after load.
+	Schemas map[string]*Schema `json:"schemas,omitempty"`
+	Grants  map[string]*Grant  `json:"grants,omitempty"`
 }

--- a/ucm/config/resources/schema.go
+++ b/ucm/config/resources/schema.go
@@ -5,13 +5,24 @@ type Schema struct {
 	// Name of the schema. Required.
 	Name string `json:"name"`
 
-	// Catalog is the name of the parent catalog. Required.
+	// Catalog is the name of the parent catalog. Required in flat form;
+	// injected by FlattenNestedResources when declared nested under a catalog.
 	// In M1 this becomes interpolatable via ${resources.catalogs.X.name}.
-	Catalog string `json:"catalog"`
+	Catalog string `json:"catalog,omitempty"`
 
 	// Comment is a human-readable description.
 	Comment string `json:"comment,omitempty"`
 
 	// Tags is a key/value map evaluated by ucm's tag-validation mutators.
 	Tags map[string]string `json:"tags,omitempty"`
+
+	// TagInherit controls whether parent-catalog tags merge into this schema's
+	// tags (schema-key wins). nil means inherit (the default). Set false to
+	// opt out.
+	TagInherit *bool `json:"tag_inherit,omitempty"`
+
+	// Grants nested under this schema. FlattenNestedResources moves them to
+	// Root.Resources.Grants with securable={type:schema, name:<this>} injected.
+	// Always nil after load.
+	Grants map[string]*Grant `json:"grants,omitempty"`
 }

--- a/ucm/config/ucm.go
+++ b/ucm/config/ucm.go
@@ -1,0 +1,14 @@
+package config
+
+import "github.com/databricks/cli/ucm/config/engine"
+
+// Ucm is the top-level ucm: block of ucm.yml. Mirrors bundle.Bundle for DABs,
+// but scoped to Unity Catalog declarative management.
+type Ucm struct {
+	// Name identifies the ucm project. Required.
+	Name string `json:"name"`
+
+	// Engine selects the deployment engine ("terraform" or "direct").
+	// Can be overridden with the DATABRICKS_UCM_ENGINE environment variable.
+	Engine engine.EngineType `json:"engine,omitempty"`
+}

--- a/ucm/deploy/backend.go
+++ b/ucm/deploy/backend.go
@@ -1,0 +1,63 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/databricks-sdk-go"
+)
+
+// DefaultWorkspaceStateRoot is the per-user workspace directory where ucm
+// stores remote state when no explicit `ucm.state.backend` is configured.
+// The ucm.name and selected target are appended at resolution time so
+// multi-project / multi-target users don't collide.
+const DefaultWorkspaceStateRoot = "databricks/ucm"
+
+// BackendFromUcm constructs a production Backend from the ucm config and the
+// workspace client attached to ctx via cmdctx.SetWorkspaceClient. It resolves
+// the workspace state path (v1: `~/<DefaultWorkspaceStateRoot>/<name>/<target>/state`),
+// instantiates a workspace-files filer, and wraps it as both StateFiler and
+// LockFiler. The pluggable `ucm.state.backend` config selector lands in a
+// later milestone; for now only the workspace backend is wired.
+func BackendFromUcm(ctx context.Context, u *ucm.Ucm, w *databricks.WorkspaceClient) (Backend, error) {
+	if u == nil {
+		return Backend{}, fmt.Errorf("ucm deploy: BackendFromUcm called with nil Ucm")
+	}
+	if w == nil {
+		return Backend{}, fmt.Errorf("ucm deploy: BackendFromUcm called with nil workspace client")
+	}
+
+	me, err := w.CurrentUser.Me(ctx)
+	if err != nil {
+		return Backend{}, fmt.Errorf("ucm deploy: resolve current user: %w", err)
+	}
+	if me.UserName == "" {
+		return Backend{}, fmt.Errorf("ucm deploy: current user has no username")
+	}
+
+	name := u.Config.Ucm.Name
+	if name == "" {
+		return Backend{}, fmt.Errorf("ucm deploy: ucm.name is required to resolve the state path")
+	}
+	target := u.Config.Ucm.Target
+	if target == "" {
+		return Backend{}, fmt.Errorf("ucm deploy: no target selected; call LoadDefaultTarget or LoadNamedTarget first")
+	}
+
+	root := path.Join("/Users", me.UserName, DefaultWorkspaceStateRoot, name, target, "state")
+
+	inner, err := libsfiler.NewWorkspaceFilesClient(w, root)
+	if err != nil {
+		return Backend{}, fmt.Errorf("ucm deploy: init workspace-files filer at %s: %w", root, err)
+	}
+
+	return Backend{
+		StateFiler: ucmfiler.NewStateFilerFromFiler(inner),
+		LockFiler:  inner,
+		User:       me.UserName,
+	}, nil
+}

--- a/ucm/deploy/filer/workspace_filer.go
+++ b/ucm/deploy/filer/workspace_filer.go
@@ -40,6 +40,15 @@ func newWorkspaceFilerFromInner(inner libsfiler.Filer) *WorkspaceFiler {
 	return &WorkspaceFiler{inner: inner}
 }
 
+// NewStateFilerFromFiler adapts an arbitrary libs/filer.Filer into a
+// StateFiler. Mirrors lock.NewLockerWithFiler: callers that already hold a
+// libs/filer.Filer — tests backed by NewLocalClient, or future s3/adls/gcs
+// implementations — can reuse it as the state-storage backend without going
+// through a workspace client.
+func NewStateFilerFromFiler(inner libsfiler.Filer) StateFiler {
+	return &WorkspaceFiler{inner: inner}
+}
+
 // Read opens the file at path for reading.
 func (w *WorkspaceFiler) Read(ctx context.Context, path string) (io.ReadCloser, error) {
 	rc, err := w.inner.Read(ctx, path)

--- a/ucm/deploy/state.go
+++ b/ucm/deploy/state.go
@@ -1,0 +1,146 @@
+// Package deploy owns the remote-state lifecycle for ucm: the pull/push/ops
+// glue that sits between the pluggable StateFiler (U1) and the deploy Locker
+// (U2). It is forked from bundle/deploy; keeping the shapes close eases
+// future cross-checks without introducing a bundle/** import.
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/google/uuid"
+)
+
+// Remote and local filenames for the state artifacts. StateFileName lives
+// next to TfStateFileName in the remote state dir; Seq-based conflict
+// detection reads UcmStateFileName only.
+const (
+	// UcmStateFileName is the ucm-specific sidecar that tracks Seq/Version
+	// alongside the opaque terraform.tfstate blob.
+	UcmStateFileName = "ucm-state.json"
+
+	// TfStateFileName is the terraform-managed state blob that ucm mirrors
+	// locally so the terraform wrapper can drive plan/apply offline.
+	TfStateFileName = "terraform.tfstate"
+
+	// LocalCacheDir is the root under the ucm project directory used to
+	// mirror remote state. The per-target sub-directory is appended by
+	// LocalStateDir.
+	LocalCacheDir = ".databricks/ucm"
+
+	// StateVersion is bumped on incompatible changes to the on-wire State
+	// shape. Pull treats a remote Version greater than this as an error so
+	// older CLIs refuse to overwrite newer state blobs.
+	StateVersion = 1
+)
+
+// State is the ucm-side sidecar stored as ucm-state.json in the remote state
+// directory. It carries just enough metadata to detect stale overwrites and
+// identify the CLI that produced the blob. The opaque terraform.tfstate lives
+// separately so terraform tooling can read it without understanding Seq.
+type State struct {
+	// Version is bumped on incompatible changes to this struct. A remote
+	// Version greater than StateVersion fails the pull.
+	Version int `json:"version"`
+
+	// Seq is incremented on every successful Push. Push refuses to overwrite
+	// a remote whose Seq is greater than the Seq we saw at Pull time.
+	Seq int `json:"seq"`
+
+	// ID uniquely identifies the sequence of deployments for this target.
+	// Rotating it starts a fresh Seq chain (e.g. after --force).
+	ID uuid.UUID `json:"id"`
+
+	// CliVersion is the ucm/cli version that wrote the blob. Informational
+	// only — Seq is the source of truth for conflict detection.
+	CliVersion string `json:"cli_version,omitempty"`
+
+	// Timestamp is when the state was produced. Informational only.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// ErrStaleState is returned by Push when the remote Seq is greater than the
+// Seq we observed at Pull time. Callers can unwrap via errors.As to surface
+// the two Seq values to the user.
+type ErrStaleState struct {
+	// LocalSeq is the Seq we believe we are advancing from.
+	LocalSeq int
+	// RemoteSeq is the Seq currently on the remote, which is ahead of
+	// LocalSeq.
+	RemoteSeq int
+}
+
+// Error formats the conflict for human consumption.
+func (e *ErrStaleState) Error() string {
+	return fmt.Sprintf("ucm state: local state is stale (local seq %d < remote seq %d); pull before pushing", e.LocalSeq, e.RemoteSeq)
+}
+
+// Backend bundles the remote-IO dependencies needed by Pull and Push. It is
+// supplied by the caller so tests can inject local-disk filers without a live
+// workspace client. U6 will build the production Backend from
+// ucm.state.backend config; until then callers compose it directly.
+type Backend struct {
+	// StateFiler is where terraform.tfstate and ucm-state.json are read
+	// from and written to. Typically rooted at the per-target workspace
+	// state path.
+	StateFiler filer.StateFiler
+
+	// LockFiler is where the Locker writes deploy.lock. In the v1 workspace
+	// backend StateFiler and LockFiler point at the same remote dir; the
+	// split exists because the Locker API consumes libs/filer.Filer rather
+	// than the ucm StateFiler.
+	LockFiler libsfiler.Filer
+
+	// User is embedded into the lock record so contending clients can see
+	// who currently holds the lock. Empty strings are allowed for tests.
+	User string
+}
+
+// loadState reads a State from r.
+func loadState(r io.Reader) (*State, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("ucm state: parse: %w", err)
+	}
+	return &s, nil
+}
+
+// readRemoteUcmState loads ucm-state.json via the StateFiler, returning
+// (nil, nil) when the file is absent (first-run case).
+func readRemoteUcmState(ctx context.Context, f filer.StateFiler) (*State, error) {
+	rc, err := f.Read(ctx, UcmStateFileName)
+	if err != nil {
+		if errors.Is(err, filer.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer rc.Close()
+	return loadState(rc)
+}
+
+// validateCompatibility fails when the remote State was written by a newer
+// CLI with an incompatible schema version.
+func validateCompatibility(s *State) error {
+	if s.Version > StateVersion {
+		return fmt.Errorf("ucm state: remote version %d > supported %d; upgrade the CLI", s.Version, StateVersion)
+	}
+	return nil
+}
+
+// newLocker constructs a Locker bound to the backend's LockFiler. Kept
+// package-private because the only callers are Pull and Push.
+func newLocker(b Backend, targetDir string) *lock.Locker {
+	return lock.NewLockerWithFiler(b.User, targetDir, b.LockFiler)
+}

--- a/ucm/deploy/state_pull.go
+++ b/ucm/deploy/state_pull.go
@@ -1,0 +1,154 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/google/uuid"
+)
+
+// LocalStateDir returns the local directory where state artifacts are mirrored
+// for u. Always forward-slash on the wire; callers that write to disk should
+// pass the return value through filepath.FromSlash when interacting with the
+// OS filesystem.
+func LocalStateDir(u *ucm.Ucm) string {
+	target := u.Config.Ucm.Target
+	return filepath.Join(u.RootPath, filepath.FromSlash(LocalCacheDir), target)
+}
+
+// Pull copies terraform.tfstate and ucm-state.json from the remote StateFiler
+// into the per-target local cache directory. On a first run the remote files
+// are absent and a fresh local state with Seq=0 is written instead.
+//
+// The deploy lock is acquired for the duration of the pull so that a
+// concurrent Push cannot swap the remote blob out from under us mid-read.
+func Pull(ctx context.Context, u *ucm.Ucm, b Backend) error {
+	if u == nil {
+		return errors.New("ucm state: Pull called with nil Ucm")
+	}
+	if b.StateFiler == nil || b.LockFiler == nil {
+		return errors.New("ucm state: Pull requires StateFiler and LockFiler in Backend")
+	}
+
+	l := newLocker(b, ".")
+	if err := l.Acquire(ctx, false); err != nil {
+		return fmt.Errorf("ucm state: acquire lock: %w", err)
+	}
+	defer releaseBestEffort(ctx, l, lock.GoalDeploy)
+
+	localDir := LocalStateDir(u)
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		return fmt.Errorf("ucm state: create local cache dir: %w", err)
+	}
+
+	remoteUcm, err := readRemoteUcmState(ctx, b.StateFiler)
+	if err != nil {
+		return fmt.Errorf("ucm state: read remote %s: %w", UcmStateFileName, err)
+	}
+
+	if remoteUcm == nil {
+		log.Infof(ctx, "ucm state: remote is empty, initializing fresh local state at %s", filepath.ToSlash(localDir))
+		return writeFreshLocal(ctx, localDir)
+	}
+
+	if err := validateCompatibility(remoteUcm); err != nil {
+		return err
+	}
+
+	log.Infof(ctx, "ucm state: pulling remote state (seq %d) into %s", remoteUcm.Seq, filepath.ToSlash(localDir))
+	if err := writeLocalState(localDir, remoteUcm); err != nil {
+		return fmt.Errorf("ucm state: write local %s: %w", UcmStateFileName, err)
+	}
+
+	if err := copyRemoteToLocal(ctx, b.StateFiler, TfStateFileName, filepath.Join(localDir, TfStateFileName)); err != nil {
+		if errors.Is(err, filer.ErrNotFound) {
+			// A ucm-state.json without a sibling terraform.tfstate is a
+			// recoverable first-run shape (ucm pulled once but never
+			// applied terraform). Leave local tfstate absent.
+			log.Infof(ctx, "ucm state: no remote %s yet; skipping", TfStateFileName)
+			return nil
+		}
+		return fmt.Errorf("ucm state: copy remote %s: %w", TfStateFileName, err)
+	}
+	return nil
+}
+
+// writeFreshLocal writes a Seq=0 ucm-state.json to localDir and nothing else.
+// The absence of a local terraform.tfstate is the signal downstream phases
+// use to recognise first-run behaviour.
+func writeFreshLocal(ctx context.Context, localDir string) error {
+	fresh := newFreshState()
+	if err := writeLocalState(localDir, fresh); err != nil {
+		return fmt.Errorf("ucm state: write fresh local state: %w", err)
+	}
+	log.Infof(ctx, "ucm state: wrote fresh local state (seq 0) to %s", filepath.ToSlash(localDir))
+	return nil
+}
+
+// newFreshState builds a Seq=0 State with a newly-generated ID, used on
+// first-run and after destroy.
+func newFreshState() *State {
+	return &State{
+		Version: StateVersion,
+		Seq:     0,
+		ID:      uuid.New(),
+	}
+}
+
+// writeLocalState writes s to <localDir>/ucm-state.json with 0600 perms so
+// that workspace-side credentials embedded in terraform.tfstate (if any later
+// land there) aren't world-readable on shared dev machines.
+func writeLocalState(localDir string, s *State) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(localDir, UcmStateFileName), data, 0o600)
+}
+
+// copyRemoteToLocal streams a single remote file into a local file,
+// truncating any existing local copy. The buffered ReadAll keeps the
+// implementation simple; state files are small.
+func copyRemoteToLocal(ctx context.Context, f filer.StateFiler, remote, localPath string) error {
+	rc, err := f.Read(ctx, remote)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	buf, err := io.ReadAll(rc)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(localPath, buf, 0o600)
+}
+
+// releaseBestEffort is deferred by Pull/Push so the lock is released on every
+// exit path including errors. Release failures are logged rather than
+// surfaced because the primary error already communicates the deploy outcome
+// and a stuck lock is more operator-visible than a swallowed one.
+func releaseBestEffort(ctx context.Context, l *lock.Locker, goal lock.Goal) {
+	if err := l.Release(ctx, goal); err != nil {
+		log.Warnf(ctx, "ucm state: release lock (goal %s): %v", goal, err)
+	}
+}
+
+// readLocalState is used by Push to learn the Seq we think we're advancing.
+// Shared here so state_pull_test.go can exercise the same file format.
+func readLocalState(localDir string) (*State, error) {
+	data, err := os.ReadFile(filepath.Join(localDir, UcmStateFileName))
+	if err != nil {
+		return nil, err
+	}
+	return loadState(bytes.NewReader(data))
+}

--- a/ucm/deploy/state_pull_test.go
+++ b/ucm/deploy/state_pull_test.go
@@ -1,0 +1,187 @@
+package deploy_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/deploy"
+	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixture bundles the inputs every pull/push test needs: a local project dir
+// for the Ucm, and two filers for the remote (state + lock) sharing a single
+// temp dir so a second client can contend the same logical state root.
+type fixture struct {
+	t        *testing.T
+	projDir  string
+	remote   libsfiler.Filer
+	backend  deploy.Backend
+	u        *ucm.Ucm
+	localDir string
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	projDir := t.TempDir()
+	remoteDir := t.TempDir()
+
+	local, err := libsfiler.NewLocalClient(remoteDir)
+	require.NoError(t, err)
+
+	u := &ucm.Ucm{RootPath: projDir}
+	u.Config.Ucm = config.Ucm{Name: "test", Target: "dev"}
+
+	return &fixture{
+		t:       t,
+		projDir: projDir,
+		remote:  local,
+		backend: deploy.Backend{
+			StateFiler: ucmfiler.NewStateFilerFromFiler(local),
+			LockFiler:  local,
+			User:       "alice@example.com",
+		},
+		u:        u,
+		localDir: filepath.Join(projDir, filepath.FromSlash(deploy.LocalCacheDir), "dev"),
+	}
+}
+
+// readLocalUcmStateBytes reads the on-disk ucm-state.json from the local
+// cache directory. Tests use this instead of exposing readLocalState from
+// the production package.
+func readLocalUcmStateBytes(t *testing.T, localDir string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(localDir, deploy.UcmStateFileName))
+	require.NoError(t, err)
+	return data
+}
+
+func decodeState(t *testing.T, data []byte) deploy.State {
+	t.Helper()
+	var s deploy.State
+	require.NoError(t, json.NewDecoder(bytes.NewReader(data)).Decode(&s))
+	return s
+}
+
+// seedRemoteUcmState writes a ucm-state.json at the remote root. Used to
+// simulate a remote produced by a peer client (e.g. a contending Push).
+func seedRemoteUcmState(t *testing.T, ctx context.Context, remote libsfiler.Filer, s deploy.State) {
+	t.Helper()
+	blob, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(ctx, deploy.UcmStateFileName, bytes.NewReader(blob), libsfiler.OverwriteIfExists, libsfiler.CreateParentDirectories))
+}
+
+func TestPullFirstRunInitializesFreshLocal(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	got := decodeState(t, readLocalUcmStateBytes(t, f.localDir))
+	assert.Equal(t, 0, got.Seq)
+	assert.Equal(t, deploy.StateVersion, got.Version)
+
+	// tfstate must NOT be mirrored locally: the signal to downstream
+	// phases that this is a first-run.
+	_, err := os.Stat(filepath.Join(f.localDir, deploy.TfStateFileName))
+	assert.True(t, os.IsNotExist(err), "unexpected local tfstate on first-run: %v", err)
+}
+
+func TestPullMirrorsRemoteStateAndTfstate(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	remoteState := deploy.State{Version: deploy.StateVersion, Seq: 4}
+	seedRemoteUcmState(t, ctx, f.remote, remoteState)
+	require.NoError(t, f.remote.Write(ctx, deploy.TfStateFileName, bytes.NewReader([]byte(`{"terraform":"blob"}`)), libsfiler.OverwriteIfExists, libsfiler.CreateParentDirectories))
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	got := decodeState(t, readLocalUcmStateBytes(t, f.localDir))
+	assert.Equal(t, 4, got.Seq)
+
+	tfData, err := os.ReadFile(filepath.Join(f.localDir, deploy.TfStateFileName))
+	require.NoError(t, err)
+	assert.Equal(t, `{"terraform":"blob"}`, string(tfData))
+}
+
+func TestPullRejectsFutureVersion(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion + 1, Seq: 1})
+
+	err := deploy.Pull(ctx, f.u, f.backend)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote version")
+}
+
+func TestPullReleasesLockOnSuccess(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	// A contending client must be able to acquire the lock immediately
+	// after Pull returns — i.e. the defer ran.
+	contender := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, contender.Acquire(ctx, false))
+	require.NoError(t, contender.Release(ctx, lock.GoalDeploy))
+}
+
+func TestPullReleasesLockOnError(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// Future-version remote causes Pull to fail; the lock must still be
+	// released for the next caller.
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion + 99})
+
+	err := deploy.Pull(ctx, f.u, f.backend)
+	require.Error(t, err)
+
+	contender := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, contender.Acquire(ctx, false))
+	require.NoError(t, contender.Release(ctx, lock.GoalDeploy))
+}
+
+func TestPullFailsWhenLockAlreadyHeld(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// Peer grabs the lock first.
+	peer := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, peer.Acquire(ctx, false))
+	defer peer.Release(ctx, lock.GoalDeploy)
+
+	err := deploy.Pull(ctx, f.u, f.backend)
+	require.Error(t, err)
+
+	var held *lock.ErrLockHeld
+	require.ErrorAs(t, err, &held)
+	assert.Equal(t, "bob@example.com", held.Holder)
+}
+
+func TestPullRequiresBackend(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	err := deploy.Pull(ctx, f.u, deploy.Backend{})
+	require.Error(t, err)
+}
+
+func TestPullNilUcm(t *testing.T) {
+	ctx := t.Context()
+	err := deploy.Pull(ctx, nil, deploy.Backend{})
+	require.Error(t, err)
+}

--- a/ucm/deploy/state_push.go
+++ b/ucm/deploy/state_push.go
@@ -1,0 +1,116 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/google/uuid"
+)
+
+// Push mirrors the local state cache into the remote StateFiler. It bumps
+// Seq, refuses to overwrite a remote that has advanced past the Seq we
+// observed locally, and writes atomically-ish by writing ucm-state.json last
+// so a partial push leaves the remote tfstate readable but clearly un-acked.
+//
+// On a fresh local (no ucm-state.json under LocalStateDir), Push returns an
+// error — the expected shape is Pull → mutate → Push, and pushing without a
+// pull means the caller has no baseline Seq to reason about.
+func Push(ctx context.Context, u *ucm.Ucm, b Backend) error {
+	if u == nil {
+		return errors.New("ucm state: Push called with nil Ucm")
+	}
+	if b.StateFiler == nil || b.LockFiler == nil {
+		return errors.New("ucm state: Push requires StateFiler and LockFiler in Backend")
+	}
+
+	l := newLocker(b, ".")
+	if err := l.Acquire(ctx, false); err != nil {
+		return fmt.Errorf("ucm state: acquire lock: %w", err)
+	}
+	defer releaseBestEffort(ctx, l, lock.GoalDeploy)
+
+	localDir := LocalStateDir(u)
+	local, err := readLocalState(localDir)
+	if err != nil {
+		return fmt.Errorf("ucm state: read local %s: %w", UcmStateFileName, err)
+	}
+
+	if err := assertRemoteNotAhead(ctx, b.StateFiler, local); err != nil {
+		return err
+	}
+
+	// Bump Seq before serialising so the on-remote record matches the
+	// intent of this Push. A crash after writeRemote but before the
+	// bookkeeping below leaves the remote ahead of local; the next Pull
+	// catches up.
+	next := *local
+	next.Version = StateVersion
+	next.Seq = local.Seq + 1
+	if next.ID == uuid.Nil {
+		next.ID = uuid.New()
+	}
+	next.Timestamp = time.Now().UTC()
+
+	if err := writeRemote(ctx, b.StateFiler, localDir, &next); err != nil {
+		return err
+	}
+
+	// Mirror the bumped Seq into the local cache so the next Push starts
+	// from an accurate baseline without requiring an intervening Pull.
+	if err := writeLocalState(localDir, &next); err != nil {
+		return fmt.Errorf("ucm state: refresh local %s: %w", UcmStateFileName, err)
+	}
+	log.Infof(ctx, "ucm state: pushed state (seq %d -> %d) for target %s", local.Seq, next.Seq, u.Config.Ucm.Target)
+	return nil
+}
+
+// assertRemoteNotAhead fails with ErrStaleState when the remote Seq exceeds
+// the local Seq. Missing remote state counts as Seq=-1 for comparison so a
+// first Push always succeeds.
+func assertRemoteNotAhead(ctx context.Context, f filer.StateFiler, local *State) error {
+	remote, err := readRemoteUcmState(ctx, f)
+	if err != nil {
+		return fmt.Errorf("ucm state: inspect remote: %w", err)
+	}
+	if remote == nil {
+		return nil
+	}
+	if remote.Seq > local.Seq {
+		return &ErrStaleState{LocalSeq: local.Seq, RemoteSeq: remote.Seq}
+	}
+	return nil
+}
+
+// writeRemote uploads the local terraform.tfstate (if any) first, then
+// ucm-state.json. ucm-state.json is written last so a crash between the two
+// leaves the remote in a shape the next Pull can still interpret as
+// "remote ahead of us, need to advance" rather than "blank slate".
+func writeRemote(ctx context.Context, f filer.StateFiler, localDir string, next *State) error {
+	tfPath := filepath.Join(localDir, TfStateFileName)
+	if data, err := os.ReadFile(tfPath); err == nil {
+		if err := f.Write(ctx, TfStateFileName, bytes.NewReader(data), filer.WriteModeOverwrite|filer.WriteModeCreateParents); err != nil {
+			return fmt.Errorf("ucm state: write remote %s: %w", TfStateFileName, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("ucm state: read local %s: %w", TfStateFileName, err)
+	}
+
+	blob, err := json.MarshalIndent(next, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := f.Write(ctx, UcmStateFileName, bytes.NewReader(blob), filer.WriteModeOverwrite|filer.WriteModeCreateParents); err != nil {
+		return fmt.Errorf("ucm state: write remote %s: %w", UcmStateFileName, err)
+	}
+	return nil
+}

--- a/ucm/deploy/state_push_test.go
+++ b/ucm/deploy/state_push_test.go
@@ -1,0 +1,210 @@
+package deploy_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readRemoteState round-trips the remote ucm-state.json for assertion
+// purposes. Returns nil if the remote hasn't been written yet.
+func readRemoteState(t *testing.T, f libsfiler.Filer) *deploy.State {
+	t.Helper()
+	rc, err := f.Read(t.Context(), deploy.UcmStateFileName)
+	if err != nil {
+		return nil
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	var s deploy.State
+	require.NoError(t, json.Unmarshal(data, &s))
+	return &s
+}
+
+func TestPushFirstWriteAfterPull(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// First Pull on an empty remote establishes a Seq=0 local.
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	// Drop a tfstate blob locally so Push has something to upload.
+	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), []byte(`{"tf":"v1"}`), 0o600))
+
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	remote := readRemoteState(t, f.remote)
+	require.NotNil(t, remote)
+	assert.Equal(t, 1, remote.Seq)
+
+	// Local should have been refreshed to match the new Seq.
+	localData, err := os.ReadFile(filepath.Join(f.localDir, deploy.UcmStateFileName))
+	require.NoError(t, err)
+	var local deploy.State
+	require.NoError(t, json.Unmarshal(localData, &local))
+	assert.Equal(t, 1, local.Seq)
+}
+
+func TestPushPullRoundTripIsIdentical(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+	tfBlob := []byte(`{"tf":"roundtrip"}`)
+	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), tfBlob, 0o600))
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	// Simulate a second clone of the project: wipe the local cache and
+	// re-Pull. The pulled tfstate must byte-for-byte match what was Pushed.
+	require.NoError(t, os.RemoveAll(f.localDir))
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	got, err := os.ReadFile(filepath.Join(f.localDir, deploy.TfStateFileName))
+	require.NoError(t, err)
+	assert.Equal(t, tfBlob, got)
+
+	// Seq must round-trip too.
+	state, err := os.ReadFile(filepath.Join(f.localDir, deploy.UcmStateFileName))
+	require.NoError(t, err)
+	var s deploy.State
+	require.NoError(t, json.Unmarshal(state, &s))
+	assert.Equal(t, 1, s.Seq)
+}
+
+func TestPushDetectsStaleState(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// Client A pulls and prepares to push.
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	// Meanwhile, client B advances the remote Seq out from under A.
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion, Seq: 5})
+
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+
+	var stale *deploy.ErrStaleState
+	require.ErrorAs(t, err, &stale)
+	assert.Equal(t, 0, stale.LocalSeq)
+	assert.Equal(t, 5, stale.RemoteSeq)
+}
+
+func TestPushSecondPushAfterRemoteBumpFails(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	// Peer bumps remote Seq.
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion, Seq: 99})
+
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+	var stale *deploy.ErrStaleState
+	require.ErrorAs(t, err, &stale)
+	assert.Equal(t, 99, stale.RemoteSeq)
+}
+
+func TestPushWithoutPriorPullFails(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	// No Pull before Push → no local ucm-state.json → read error.
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read local")
+}
+
+func TestPushReleasesLockOnStaleError(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	// Force a stale-state failure.
+	seedRemoteUcmState(t, ctx, f.remote, deploy.State{Version: deploy.StateVersion, Seq: 5})
+
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+
+	// Lock must be released after the failure.
+	contender := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, contender.Acquire(ctx, false))
+	require.NoError(t, contender.Release(ctx, lock.GoalDeploy))
+}
+
+func TestPushReleasesLockOnSuccess(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	contender := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, contender.Acquire(ctx, false))
+	require.NoError(t, contender.Release(ctx, lock.GoalDeploy))
+}
+
+func TestPushFailsWhenLockHeldByPeer(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+
+	peer := lock.NewLockerWithFiler("bob@example.com", ".", f.remote)
+	require.NoError(t, peer.Acquire(ctx, false))
+	defer peer.Release(ctx, lock.GoalDeploy)
+
+	err := deploy.Push(ctx, f.u, f.backend)
+	require.Error(t, err)
+	var held *lock.ErrLockHeld
+	require.ErrorAs(t, err, &held)
+}
+
+func TestPushMirrorsTfstateBytesExactly(t *testing.T) {
+	ctx := t.Context()
+	f := newFixture(t)
+
+	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
+	tfBlob := bytes.Repeat([]byte{0xAB}, 2048)
+	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), tfBlob, 0o600))
+
+	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
+
+	rc, err := f.remote.Read(ctx, deploy.TfStateFileName)
+	require.NoError(t, err)
+	defer rc.Close()
+	remoteTf, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, tfBlob, remoteTf)
+}
+
+func TestPushNilUcmRequiresBackend(t *testing.T) {
+	ctx := t.Context()
+	err := deploy.Push(ctx, nil, deploy.Backend{})
+	require.Error(t, err)
+
+	f := newFixture(t)
+	err = deploy.Push(ctx, f.u, deploy.Backend{})
+	require.Error(t, err)
+}
+
+func TestPushErrStaleStateIsAssignableToPointer(t *testing.T) {
+	// Guards against regressions in ErrStaleState pointer receiver.
+	var stale *deploy.ErrStaleState
+	var e error = &deploy.ErrStaleState{LocalSeq: 1, RemoteSeq: 2}
+	require.True(t, errors.As(e, &stale))
+}

--- a/ucm/deploy/state_test.go
+++ b/ucm/deploy/state_test.go
@@ -1,0 +1,75 @@
+package deploy_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateJSONRoundTrip(t *testing.T) {
+	src := deploy.State{
+		Version:   deploy.StateVersion,
+		Seq:       7,
+		ID:        uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+		Timestamp: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+	}
+	buf, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	var got deploy.State
+	require.NoError(t, json.Unmarshal(buf, &got))
+	assert.Equal(t, src, got)
+}
+
+func TestErrStaleStateMessage(t *testing.T) {
+	err := &deploy.ErrStaleState{LocalSeq: 3, RemoteSeq: 5}
+	msg := err.Error()
+	assert.Contains(t, msg, "local seq 3")
+	assert.Contains(t, msg, "remote seq 5")
+	assert.Contains(t, msg, "pull before pushing")
+}
+
+func TestErrStaleStateErrorsAs(t *testing.T) {
+	err := error(&deploy.ErrStaleState{LocalSeq: 1, RemoteSeq: 2})
+	var target *deploy.ErrStaleState
+	require.True(t, errors.As(err, &target))
+	assert.Equal(t, 1, target.LocalSeq)
+	assert.Equal(t, 2, target.RemoteSeq)
+}
+
+func TestErrStaleStateIsReflexive(t *testing.T) {
+	// errors.Is on a typed error falls back to == identity via the pointer;
+	// this guards against anyone adding a custom Is that breaks that.
+	err := &deploy.ErrStaleState{LocalSeq: 1, RemoteSeq: 2}
+	assert.True(t, errors.Is(err, err))
+}
+
+func TestStateUnmarshalEmptyTimestamp(t *testing.T) {
+	// Tolerate blobs written by tests or future CLIs that omit Timestamp.
+	var s deploy.State
+	require.NoError(t, json.Unmarshal([]byte(`{"version":1,"seq":0,"id":"00000000-0000-0000-0000-000000000000","timestamp":"0001-01-01T00:00:00Z"}`), &s))
+	assert.Equal(t, 1, s.Version)
+	assert.Equal(t, 0, s.Seq)
+	assert.True(t, s.Timestamp.IsZero())
+}
+
+func TestStateMarshalIndented(t *testing.T) {
+	// Sanity-check that an indented marshal reads back identical. This is
+	// the exact shape writeLocalState persists.
+	src := deploy.State{Version: 1, Seq: 2, ID: uuid.New(), Timestamp: time.Now().UTC()}
+	buf, err := json.MarshalIndent(src, "", "  ")
+	require.NoError(t, err)
+
+	var got deploy.State
+	require.NoError(t, json.NewDecoder(bytes.NewReader(buf)).Decode(&got))
+	assert.Equal(t, src.Seq, got.Seq)
+	assert.Equal(t, src.Version, got.Version)
+	assert.Equal(t, src.ID, got.ID)
+}

--- a/ucm/deploy/terraform/apply.go
+++ b/ucm/deploy/terraform/apply.go
@@ -1,0 +1,58 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// Apply acquires the U2 deployment lock and runs `terraform apply`.
+// If a plan artefact from a previous Plan call is available, Apply consumes
+// it via tfexec.DirOrPlan; otherwise it falls back to an auto-approved
+// `terraform apply` that computes its own plan inline.
+//
+// The lock is released on defer with the GoalDeploy value regardless of
+// whether Apply succeeded. Contention on the lock surfaces as a
+// *lock.ErrLockHeld so callers can errors.As on it and present a helpful
+// "--force-lock to override" message to the user.
+func (t *Terraform) Apply(ctx context.Context, u *ucm.Ucm) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Init(ctx, u); err != nil {
+		return err
+	}
+
+	factory := t.lockerFactory
+	if factory == nil {
+		factory = defaultLockerFactory
+	}
+	locker, err := factory(ctx, u, t.user)
+	if err != nil {
+		return fmt.Errorf("create deployment locker: %w", err)
+	}
+	if err := locker.Acquire(ctx, false); err != nil {
+		return err
+	}
+	defer func() {
+		if relErr := locker.Release(ctx, lock.GoalDeploy); relErr != nil {
+			log.Warnf(ctx, "terraform apply: release lock: %v", relErr)
+		}
+	}()
+
+	opts := []tfexec.ApplyOption{}
+	if t.lastPlanExists && t.lastPlanPath != "" {
+		opts = append(opts, tfexec.DirOrPlan(t.lastPlanPath))
+	}
+	if err := t.runner.Apply(ctx, opts...); err != nil {
+		return fmt.Errorf("terraform apply: %w", err)
+	}
+
+	log.Infof(ctx, "terraform apply completed")
+	return nil
+}

--- a/ucm/deploy/terraform/apply_test.go
+++ b/ucm/deploy/terraform/apply_test.go
@@ -1,0 +1,115 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sharedLockerFactory produces Lockers that all share the same underlying
+// filer.Filer. The shared filer is what makes the two Apply calls race on
+// the same lock file — required for the contention test below.
+func sharedLockerFactory(t *testing.T, user string) (lockerFactory, libsfiler.Filer) {
+	t.Helper()
+	f, err := libsfiler.NewLocalClient(t.TempDir())
+	require.NoError(t, err)
+	factory := func(_ context.Context, _ *ucm.Ucm, who string) (*lock.Locker, error) {
+		holder := who
+		if holder == "" {
+			holder = user
+		}
+		return lock.NewLockerWithFiler(holder, "/state", f), nil
+	}
+	return factory, f
+}
+
+func newApplyTerraform(t *testing.T, u *ucm.Ucm, runner *fakeRunner, lf lockerFactory, user string) *Terraform {
+	t.Helper()
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+	return &Terraform{
+		ExecPath:      "/stub/terraform",
+		WorkingDir:    workingDir,
+		Env:           map[string]string{"DATABRICKS_HOST": "https://example.cloud.databricks.com"},
+		runnerFactory: newFakeRunnerFactory(runner),
+		lockerFactory: lf,
+		user:          user,
+	}
+}
+
+func TestApplyRunsUnderLock(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newApplyTerraform(t, u, runner, factory, "alice")
+
+	require.NoError(t, tf.Apply(t.Context(), u))
+	assert.Equal(t, 1, runner.ApplyCalls)
+	// Lock is released on defer — next Apply should succeed too.
+	require.NoError(t, tf.Apply(t.Context(), u))
+	assert.Equal(t, 2, runner.ApplyCalls)
+}
+
+func TestApplyLockContentionReturnsErrLockHeld(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	factory, _ := sharedLockerFactory(t, "shared")
+
+	// First Apply holds the lock via an ApplyHook that blocks on a channel.
+	// While it is blocked, a second Apply runs and should surface *ErrLockHeld.
+	hold := make(chan struct{})
+	release := make(chan struct{})
+	firstRunner := &fakeRunner{
+		ApplyHook: func(_ context.Context) {
+			close(hold)
+			<-release
+		},
+	}
+	firstTf := newApplyTerraform(t, u, firstRunner, factory, "alice")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- firstTf.Apply(t.Context(), u)
+	}()
+
+	// Wait until the first Apply is holding the lock.
+	<-hold
+
+	secondRunner := &fakeRunner{}
+	secondTf := newApplyTerraform(t, u, secondRunner, factory, "bob")
+
+	err := secondTf.Apply(t.Context(), u)
+	require.Error(t, err)
+	var held *lock.ErrLockHeld
+	require.True(t, errors.As(err, &held), "expected ErrLockHeld, got %T: %v", err, err)
+	assert.Equal(t, "alice", held.Holder)
+	assert.Equal(t, 0, secondRunner.ApplyCalls, "second Apply must not invoke the runner")
+
+	// Let the first Apply finish.
+	close(release)
+	require.NoError(t, <-errCh)
+}
+
+func TestApplyUsesPlanPathWhenAvailable(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{PlanHasChanges: true}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newApplyTerraform(t, u, runner, factory, "alice")
+
+	planResult, err := tf.Plan(t.Context(), u)
+	require.NoError(t, err)
+	require.NotNil(t, planResult)
+	assert.True(t, planResult.HasChanges)
+
+	require.NoError(t, tf.Apply(t.Context(), u))
+	require.Len(t, runner.LastApplyOpts, 1, "Apply should have received the plan-path option")
+
+	// The plan path should be the one returned by Plan.
+	assert.Equal(t, filepath.Join(tf.WorkingDir, PlanFileName), planResult.PlanPath)
+}

--- a/ucm/deploy/terraform/destroy.go
+++ b/ucm/deploy/terraform/destroy.go
@@ -1,0 +1,51 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+)
+
+// Destroy acquires the U2 deployment lock and runs `terraform destroy
+// -auto-approve` in the working directory. Init is called first to make
+// sure main.tf.json is up to date (destroy still needs the config to know
+// the resource graph) and the provider is installed.
+//
+// The lock is released on defer with GoalDestroy, which tolerates a
+// missing lock file (destroy may have wiped the state dir before Release
+// runs — see ucm/deploy/lock.Release).
+func (t *Terraform) Destroy(ctx context.Context, u *ucm.Ucm) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Init(ctx, u); err != nil {
+		return err
+	}
+
+	factory := t.lockerFactory
+	if factory == nil {
+		factory = defaultLockerFactory
+	}
+	locker, err := factory(ctx, u, t.user)
+	if err != nil {
+		return fmt.Errorf("create deployment locker: %w", err)
+	}
+	if err := locker.Acquire(ctx, false); err != nil {
+		return err
+	}
+	defer func() {
+		if relErr := locker.Release(ctx, lock.GoalDestroy); relErr != nil {
+			log.Warnf(ctx, "terraform destroy: release lock: %v", relErr)
+		}
+	}()
+
+	if err := t.runner.Destroy(ctx); err != nil {
+		return fmt.Errorf("terraform destroy: %w", err)
+	}
+	log.Infof(ctx, "terraform destroy completed")
+	return nil
+}

--- a/ucm/deploy/terraform/destroy_test.go
+++ b/ucm/deploy/terraform/destroy_test.go
@@ -1,0 +1,33 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDestroyRunsUnderLock(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newApplyTerraform(t, u, runner, factory, "alice")
+
+	require.NoError(t, tf.Destroy(t.Context(), u))
+	assert.Equal(t, 1, runner.DestroyCalls)
+
+	// Lock released on defer: a second Destroy should succeed and re-run.
+	require.NoError(t, tf.Destroy(t.Context(), u))
+	assert.Equal(t, 2, runner.DestroyCalls)
+}
+
+func TestDestroyPropagatesRunnerError(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{DestroyErr: assert.AnError}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newApplyTerraform(t, u, runner, factory, "alice")
+
+	err := tf.Destroy(t.Context(), u)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/ucm/deploy/terraform/dir.go
+++ b/ucm/deploy/terraform/dir.go
@@ -1,0 +1,38 @@
+package terraform
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/databricks/cli/ucm"
+)
+
+// cacheDirName is the per-root directory where ucm keeps its generated
+// terraform config, plan artefacts, and (on M1+) a downloaded terraform
+// binary. Mirrors bundle/deploy/terraform's `.databricks/bundle/<target>`
+// layout but under a ucm-owned subtree so the two subcommands don't
+// accidentally share state.
+const cacheDirName = ".databricks/ucm"
+
+// WorkingDir returns the absolute path of the terraform working directory
+// for the currently selected target: `<root>/.databricks/ucm/<target>/terraform`.
+// The directory is created on demand with 0o700 permissions.
+//
+// Errors if no target has been selected — the caller should have run
+// SelectTarget (or SelectDefaultTarget) before reaching here.
+func WorkingDir(u *ucm.Ucm) (string, error) {
+	if u == nil {
+		return "", errors.New("ucm is nil")
+	}
+	target := u.Config.Ucm.Target
+	if target == "" {
+		return "", errors.New("target not set; run SelectTarget before terraform operations")
+	}
+	dir := filepath.Join(u.RootPath, filepath.FromSlash(cacheDirName), target, "terraform")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create terraform working directory %s: %w", dir, err)
+	}
+	return dir, nil
+}

--- a/ucm/deploy/terraform/fakerunner_test.go
+++ b/ucm/deploy/terraform/fakerunner_test.go
@@ -1,0 +1,98 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// fakeRunner is a stand-in for *tfexec.Terraform used by the init/plan/apply
+// /destroy tests. It records call counts per method and lets tests inject
+// return values for Plan.HasChanges and errors.
+type fakeRunner struct {
+	mu sync.Mutex
+
+	InitCalls    int
+	PlanCalls    int
+	ApplyCalls   int
+	DestroyCalls int
+	SetEnvCalls  int
+
+	// LastEnv captures the map passed to the most recent SetEnv call.
+	LastEnv map[string]string
+	// LastApplyOpts captures the options passed to the most recent Apply call.
+	LastApplyOpts []tfexec.ApplyOption
+
+	// PlanHasChanges is returned by Plan.
+	PlanHasChanges bool
+	// ApplyErr, InitErr, DestroyErr, PlanErr make the next corresponding
+	// call return the given error.
+	InitErr    error
+	PlanErr    error
+	ApplyErr   error
+	DestroyErr error
+
+	// ApplyHook is invoked synchronously inside Apply before returning. Used
+	// by the lock contention test to hold the lock while a second goroutine
+	// tries to acquire it.
+	ApplyHook func(ctx context.Context)
+}
+
+func (f *fakeRunner) Init(_ context.Context, _ ...tfexec.InitOption) error {
+	f.mu.Lock()
+	f.InitCalls++
+	err := f.InitErr
+	f.mu.Unlock()
+	return err
+}
+
+func (f *fakeRunner) Plan(_ context.Context, _ ...tfexec.PlanOption) (bool, error) {
+	f.mu.Lock()
+	f.PlanCalls++
+	err := f.PlanErr
+	changes := f.PlanHasChanges
+	f.mu.Unlock()
+	return changes, err
+}
+
+func (f *fakeRunner) Apply(ctx context.Context, opts ...tfexec.ApplyOption) error {
+	f.mu.Lock()
+	f.ApplyCalls++
+	f.LastApplyOpts = opts
+	hook := f.ApplyHook
+	err := f.ApplyErr
+	f.mu.Unlock()
+	if hook != nil {
+		hook(ctx)
+	}
+	return err
+}
+
+func (f *fakeRunner) Destroy(_ context.Context, _ ...tfexec.DestroyOption) error {
+	f.mu.Lock()
+	f.DestroyCalls++
+	err := f.DestroyErr
+	f.mu.Unlock()
+	return err
+}
+
+func (f *fakeRunner) SetEnv(e map[string]string) error {
+	f.mu.Lock()
+	f.SetEnvCalls++
+	f.LastEnv = e
+	f.mu.Unlock()
+	return nil
+}
+
+// newFakeRunnerFactory returns a tfRunnerFactory that always hands back the
+// same fakeRunner — so tests can observe calls after the wrapper returns.
+func newFakeRunnerFactory(r *fakeRunner) tfRunnerFactory {
+	return func(_, _ string) (tfRunner, error) {
+		if r == nil {
+			return nil, errors.New("fakeRunner is nil")
+		}
+		return r, nil
+	}
+}

--- a/ucm/deploy/terraform/init.go
+++ b/ucm/deploy/terraform/init.go
@@ -1,0 +1,43 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// Init ensures main.tf.json is current (calls Render) and then runs
+// `terraform init` in the working directory.
+//
+// Init is idempotent: calling it twice on the same *Terraform will re-render
+// main.tf.json (cheap) but skip the underlying terraform init the second
+// time. Callers that want to force a re-init (e.g. after a provider version
+// bump) should construct a fresh *Terraform.
+func (t *Terraform) Init(ctx context.Context, u *ucm.Ucm) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Render(ctx, u); err != nil {
+		return err
+	}
+
+	if err := t.ensureRunner(ctx); err != nil {
+		return err
+	}
+
+	if t.initialized {
+		log.Debugf(ctx, "terraform init: already initialized, skipping")
+		return nil
+	}
+
+	if err := t.runner.Init(ctx, tfexec.Upgrade(true)); err != nil {
+		return fmt.Errorf("terraform init: %w", err)
+	}
+	t.initialized = true
+	log.Infof(ctx, "terraform init completed")
+	return nil
+}

--- a/ucm/deploy/terraform/init_test.go
+++ b/ucm/deploy/terraform/init_test.go
@@ -1,0 +1,66 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newInitTerraform builds a *Terraform wired to a fakeRunner so Init can be
+// exercised without a real terraform binary install.
+func newInitTerraform(t *testing.T) (*Terraform, *fakeRunner) {
+	t.Helper()
+	root := t.TempDir()
+	workingDir := filepath.Join(root, ".databricks", "ucm", "dev", "terraform")
+	require.NoError(t, os.MkdirAll(workingDir, 0o700))
+
+	runner := &fakeRunner{}
+	tf := &Terraform{
+		ExecPath:      "/stub/terraform",
+		WorkingDir:    workingDir,
+		Env:           map[string]string{"DATABRICKS_HOST": "https://example.cloud.databricks.com"},
+		runnerFactory: newFakeRunnerFactory(runner),
+	}
+	return tf, runner
+}
+
+func TestInitRendersMainTfJson(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	tf, runner := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+
+	require.NoError(t, tf.Init(t.Context(), u))
+
+	_, err := os.Stat(filepath.Join(tf.WorkingDir, MainConfigFileName))
+	require.NoError(t, err, "main.tf.json should exist after Init")
+	assert.Equal(t, 1, runner.InitCalls)
+	assert.Equal(t, 1, runner.SetEnvCalls)
+	assert.Equal(t, tf.Env, runner.LastEnv)
+}
+
+func TestInitIsIdempotent(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	tf, runner := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+
+	require.NoError(t, tf.Init(t.Context(), u))
+	require.NoError(t, tf.Init(t.Context(), u))
+
+	assert.Equal(t, 1, runner.InitCalls, "second Init should skip the underlying terraform init")
+	// SetEnv is called once, when the runner is first bound.
+	assert.Equal(t, 1, runner.SetEnvCalls)
+}
+
+func TestInitPropagatesRunnerError(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	tf, runner := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+	runner.InitErr = assert.AnError
+
+	err := tf.Init(t.Context(), u)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/ucm/deploy/terraform/install.go
+++ b/ucm/deploy/terraform/install.go
@@ -1,0 +1,48 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/hc-install/releases"
+)
+
+// Installer resolves a Terraform binary on disk. Split out behind an
+// interface so tests can stub the download step.
+type Installer interface {
+	// Install downloads terraform v into dir and returns the absolute path
+	// of the installed binary.
+	Install(ctx context.Context, dir string, v *version.Version) (string, error)
+}
+
+// hcInstaller is the production Installer — delegates to hashicorp/hc-install.
+type hcInstaller struct{}
+
+// Install downloads terraform via hashicorp/hc-install.
+func (hcInstaller) Install(ctx context.Context, dir string, v *version.Version) (string, error) {
+	installer := &releases.ExactVersion{
+		Product:    product.Terraform,
+		Version:    v,
+		InstallDir: dir,
+		Timeout:    1 * time.Minute,
+	}
+	return installer.Install(ctx)
+}
+
+// lookupVersionFromEnv returns the terraform version configured via
+// DATABRICKS_TF_VERSION, or (nil, false, nil) if unset.
+func lookupVersionFromEnv(ctx context.Context) (*version.Version, bool, error) {
+	raw, ok := env.Lookup(ctx, VersionEnv)
+	if !ok || raw == "" {
+		return nil, false, nil
+	}
+	v, err := version.NewVersion(raw)
+	if err != nil {
+		return nil, false, fmt.Errorf("parse %s=%q: %w", VersionEnv, raw, err)
+	}
+	return v, true, nil
+}

--- a/ucm/deploy/terraform/lock.go
+++ b/ucm/deploy/terraform/lock.go
@@ -1,0 +1,24 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+)
+
+// defaultLockerFactory is the production factory — builds a Locker backed by
+// a local-disk filer under <root>/.databricks/ucm/<target>/state. Using the
+// local-disk filer for M1 keeps U5 landable ahead of U4 (which brings the
+// workspace-files state backend). When U4 lands, callers wanting remote
+// locking can override lockerFactory to point at a workspace-files filer.
+func defaultLockerFactory(ctx context.Context, u *ucm.Ucm, user string) (*lock.Locker, error) {
+	_, lockDir := lockIdentity(ctx, u)
+	f, err := libsfiler.NewLocalClient(lockDir)
+	if err != nil {
+		return nil, fmt.Errorf("init local-disk filer at %s: %w", lockDir, err)
+	}
+	return lock.NewLockerWithFiler(user, lockDir, f), nil
+}

--- a/ucm/deploy/terraform/pkg.go
+++ b/ucm/deploy/terraform/pkg.go
@@ -1,0 +1,53 @@
+// Package terraform is the terraform-engine wrapper for ucm. It sits on top
+// of the ucm/deploy/terraform/tfdyn converter (U3) and the ucm/deploy/lock
+// Locker (U2), mirroring the shape of bundle/deploy/terraform without
+// importing from bundle.
+//
+// Production code drives hashicorp/terraform-exec directly; tests inject a
+// fake tfRunner so the full init/plan/apply/destroy surface is exercised
+// without installing a real terraform binary.
+package terraform
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-version"
+)
+
+// MainConfigFileName is the on-disk name of the generated Terraform JSON
+// configuration written by Render. Mirrors bundle/deploy/terraform's
+// TerraformConfigFileName (bundle.tf.json) — the "main.tf.json" name is
+// chosen to match terraform's own convention for auto-loaded JSON config.
+const MainConfigFileName = "main.tf.json"
+
+// PlanFileName is the on-disk name of the plan artefact produced by Plan and
+// consumed by Apply. Kept identical to bundle/deploy/terraform so reviewers
+// have one fewer divergence to remember.
+const PlanFileName = "plan"
+
+// Terraform CLI override env vars. Same wire names as bundle/deploy/terraform
+// so a user's DATABRICKS_TF_EXEC_PATH works for both subcommands.
+const (
+	ExecPathEnv        = "DATABRICKS_TF_EXEC_PATH"
+	VersionEnv         = "DATABRICKS_TF_VERSION"
+	CliConfigPathEnv   = "DATABRICKS_TF_CLI_CONFIG_FILE"
+	ProviderVersionEnv = "DATABRICKS_TF_PROVIDER_VERSION"
+)
+
+// defaultTerraformVersion is the Terraform CLI version we download when the
+// user does not override it. Kept in lockstep with bundle/deploy/terraform so
+// the two subcommands use a single binary on disk.
+var defaultTerraformVersion = version.Must(version.NewVersion("1.5.5"))
+
+// GetTerraformVersion returns the terraform version to use, honouring
+// DATABRICKS_TF_VERSION when set.
+func GetTerraformVersion(ctx context.Context) (*version.Version, bool, error) {
+	v, ok, err := lookupVersionFromEnv(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if ok {
+		return v, false, nil
+	}
+	return defaultTerraformVersion, true, nil
+}

--- a/ucm/deploy/terraform/plan.go
+++ b/ucm/deploy/terraform/plan.go
@@ -1,0 +1,62 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// PlanResult is the outcome of a Plan call. PlanPath points at the on-disk
+// plan artefact Apply will consume; HasChanges is false when the plan is
+// empty (terraform exits 0 with no diffs) so callers can short-circuit.
+type PlanResult struct {
+	// PlanPath is the absolute on-disk path of the saved plan (-out).
+	PlanPath string
+	// HasChanges is true when terraform plan detected at least one change.
+	HasChanges bool
+	// Summary is a one-line human-readable summary ("plan: N change(s)" or
+	// "no changes").
+	Summary string
+}
+
+// Plan runs `terraform plan -out=<planfile>` in the working directory after
+// ensuring init has happened. The returned *PlanResult is kept on the
+// *Terraform as well, so a later Apply can pick up the plan artefact
+// without the caller having to thread it through.
+func (t *Terraform) Plan(ctx context.Context, u *ucm.Ucm) (*PlanResult, error) {
+	if t == nil {
+		return nil, fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Init(ctx, u); err != nil {
+		return nil, err
+	}
+
+	planPath := filepath.Join(t.WorkingDir, PlanFileName)
+	hasChanges, err := t.runner.Plan(ctx, tfexec.Out(planPath))
+	if err != nil {
+		return nil, fmt.Errorf("terraform plan: %w", err)
+	}
+
+	t.lastPlanPath = planPath
+	t.lastPlanExists = true
+
+	result := &PlanResult{
+		PlanPath:   planPath,
+		HasChanges: hasChanges,
+		Summary:    planSummary(hasChanges),
+	}
+	log.Infof(ctx, "terraform plan: %s (at %s)", result.Summary, filepath.ToSlash(planPath))
+	return result, nil
+}
+
+func planSummary(hasChanges bool) string {
+	if hasChanges {
+		return "plan has changes"
+	}
+	return "no changes"
+}

--- a/ucm/deploy/terraform/plan_test.go
+++ b/ucm/deploy/terraform/plan_test.go
@@ -1,0 +1,49 @@
+package terraform
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanReturnsResultWithChanges(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{PlanHasChanges: true}
+	tf, _ := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+	tf.runnerFactory = newFakeRunnerFactory(runner)
+
+	result, err := tf.Plan(t.Context(), u)
+	require.NoError(t, err)
+	assert.True(t, result.HasChanges)
+	assert.Equal(t, filepath.Join(tf.WorkingDir, PlanFileName), result.PlanPath)
+	assert.Equal(t, "plan has changes", result.Summary)
+	assert.Equal(t, 1, runner.PlanCalls)
+}
+
+func TestPlanReturnsResultWithoutChanges(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{PlanHasChanges: false}
+	tf, _ := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+	tf.runnerFactory = newFakeRunnerFactory(runner)
+
+	result, err := tf.Plan(t.Context(), u)
+	require.NoError(t, err)
+	assert.False(t, result.HasChanges)
+	assert.Equal(t, "no changes", result.Summary)
+}
+
+func TestPlanInitsFirst(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{}
+	tf, _ := newInitTerraform(t)
+	tf.WorkingDir, _ = WorkingDir(u)
+	tf.runnerFactory = newFakeRunnerFactory(runner)
+
+	_, err := tf.Plan(t.Context(), u)
+	require.NoError(t, err)
+	assert.Equal(t, 1, runner.InitCalls, "Plan must call Init first")
+}

--- a/ucm/deploy/terraform/render.go
+++ b/ucm/deploy/terraform/render.go
@@ -1,0 +1,44 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/databricks/cli/libs/dyn/jsonsaver"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/terraform/tfdyn"
+)
+
+// Render converts the ucm config tree into a Terraform JSON resource map
+// and writes it to <workingDir>/main.tf.json. The conversion itself lives
+// in tfdyn (U3); Render is the thin filesystem adapter.
+//
+// The output is indented JSON for readability. Keys appear in insertion
+// order — libs/dyn/jsonsaver preserves the dyn.Value key order set by the
+// tfdyn walkers so diffs between Render runs are minimal.
+func (t *Terraform) Render(ctx context.Context, u *ucm.Ucm) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	tree, err := tfdyn.Convert(ctx, u)
+	if err != nil {
+		return fmt.Errorf("convert ucm to terraform: %w", err)
+	}
+
+	data, err := jsonsaver.MarshalIndent(tree, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal terraform json: %w", err)
+	}
+
+	outPath := filepath.Join(t.WorkingDir, MainConfigFileName)
+	if err := os.WriteFile(outPath, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+
+	log.Infof(ctx, "Rendered terraform config at %s", filepath.ToSlash(outPath))
+	return nil
+}

--- a/ucm/deploy/terraform/render_test.go
+++ b/ucm/deploy/terraform/render_test.go
@@ -1,0 +1,120 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// golden is the expected main.tf.json body for a 1-catalog + 1-schema +
+// 1-grant input. Indentation and key order must match jsonsaver's output
+// exactly — converters emit keys in insertion order and jsonsaver preserves
+// that order.
+const golden = `{
+  "resource": {
+    "databricks_catalog": {
+      "sales": {
+        "name": "sales_prod",
+        "comment": "sales data",
+        "force_destroy": true
+      }
+    },
+    "databricks_schema": {
+      "raw": {
+        "name": "raw",
+        "catalog_name": "sales",
+        "force_destroy": true,
+        "depends_on": [
+          "databricks_catalog.sales"
+        ]
+      }
+    },
+    "databricks_grants": {
+      "sales_admins": {
+        "catalog": "${databricks_catalog.sales.name}",
+        "grant": [
+          {
+            "principal": "sales-admins",
+            "privileges": [
+              "USE_CATALOG"
+            ]
+          }
+        ],
+        "depends_on": [
+          "databricks_catalog.sales"
+        ]
+      }
+    }
+  }
+}
+`
+
+func newRenderUcm(t *testing.T) (*ucm.Ucm, string) {
+	t.Helper()
+	root := t.TempDir()
+
+	cfg, diags := config.LoadFromBytes(filepath.Join(root, "ucm.yml"), []byte(`
+ucm:
+  name: render-test
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+      comment: sales data
+  schemas:
+    raw:
+      name: raw
+      catalog: sales
+  grants:
+    sales_admins:
+      securable:
+        type: catalog
+        name: sales
+      principal: sales-admins
+      privileges: [USE_CATALOG]
+`))
+	require.False(t, diags.HasError(), "load diagnostics: %v", diags)
+	cfg.Ucm.Target = "dev"
+
+	return &ucm.Ucm{RootPath: root, Config: *cfg}, root
+}
+
+func TestRenderWritesExpectedMainTfJson(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+
+	tf := &Terraform{
+		WorkingDir:    workingDir,
+		runnerFactory: defaultRunnerFactory,
+	}
+
+	require.NoError(t, tf.Render(t.Context(), u))
+
+	body, err := os.ReadFile(filepath.Join(workingDir, MainConfigFileName))
+	require.NoError(t, err)
+	assert.Equal(t, golden, string(body))
+}
+
+func TestRenderIsIdempotent(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+
+	tf := &Terraform{WorkingDir: workingDir}
+
+	require.NoError(t, tf.Render(t.Context(), u))
+	first, err := os.ReadFile(filepath.Join(workingDir, MainConfigFileName))
+	require.NoError(t, err)
+
+	require.NoError(t, tf.Render(t.Context(), u))
+	second, err := os.ReadFile(filepath.Join(workingDir, MainConfigFileName))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}

--- a/ucm/deploy/terraform/terraform.go
+++ b/ucm/deploy/terraform/terraform.go
@@ -1,0 +1,279 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// tfRunner is the minimal terraform-exec surface used by the wrapper.
+// Having an explicit interface keeps tests independent of a real terraform
+// binary — the production impl is *tfexec.Terraform; tests inject a fake.
+type tfRunner interface {
+	Init(ctx context.Context, opts ...tfexec.InitOption) error
+	Plan(ctx context.Context, opts ...tfexec.PlanOption) (bool, error)
+	Apply(ctx context.Context, opts ...tfexec.ApplyOption) error
+	Destroy(ctx context.Context, opts ...tfexec.DestroyOption) error
+	SetEnv(env map[string]string) error
+}
+
+// tfRunnerFactory builds a tfRunner given a working dir and exec path. Split
+// so tests can swap out the real binary for a fake.
+type tfRunnerFactory func(workingDir, execPath string) (tfRunner, error)
+
+// defaultRunnerFactory is the production factory — returns a real
+// *tfexec.Terraform bound to the given workingDir+execPath.
+func defaultRunnerFactory(workingDir, execPath string) (tfRunner, error) {
+	return tfexec.NewTerraform(workingDir, execPath)
+}
+
+// lockerFactory constructs a Locker scoped to the target-specific state
+// directory. Overridable by tests (so Apply/Destroy can hand a contending
+// Locker a shared in-memory filer).
+type lockerFactory func(ctx context.Context, u *ucm.Ucm, user string) (*lock.Locker, error)
+
+// Terraform is the top-level terraform-engine wrapper. One instance per
+// ucm.Ucm; calls to Render/Init/Plan/Apply/Destroy drive the underlying
+// tfRunner in sequence. The Terraform value itself is safe to reuse across
+// calls — Init is idempotent.
+type Terraform struct {
+	// ExecPath is the absolute path of the terraform binary.
+	ExecPath string
+	// WorkingDir is where main.tf.json, the plan artefact, and the state
+	// backend config live.
+	WorkingDir string
+	// Env is the environment map passed to terraform-exec. Populated by New;
+	// includes DATABRICKS_HOST/CLIENT_ID/CLIENT_SECRET + cloud-cred passthrough.
+	Env map[string]string
+
+	runner         tfRunner
+	runnerFactory  tfRunnerFactory
+	installer      Installer
+	lockerFactory  lockerFactory
+	user           string
+	lockTargetDir  string
+	initialized    bool
+	lastPlanPath   string
+	lastPlanExists bool
+}
+
+// New wires up a Terraform for the given ucm. It resolves (and if necessary
+// downloads via hc-install) the terraform binary, computes the working
+// directory, and assembles the env-var map used for auth and cloud-cred
+// passthrough. The caller is expected to have run SelectTarget first.
+func New(ctx context.Context, u *ucm.Ucm) (*Terraform, error) {
+	workingDir, err := WorkingDir(u)
+	if err != nil {
+		return nil, err
+	}
+
+	execPath, err := resolveExecPath(ctx, workingDir, hcInstaller{})
+	if err != nil {
+		return nil, err
+	}
+
+	envMap := buildEnv(ctx)
+
+	user, lockDir := lockIdentity(ctx, u)
+
+	return &Terraform{
+		ExecPath:      execPath,
+		WorkingDir:    workingDir,
+		Env:           envMap,
+		runnerFactory: defaultRunnerFactory,
+		installer:     hcInstaller{},
+		lockerFactory: defaultLockerFactory,
+		user:          user,
+		lockTargetDir: lockDir,
+	}, nil
+}
+
+// resolveExecPath returns an absolute path to a usable terraform binary.
+// Preference order:
+//  1. DATABRICKS_TF_EXEC_PATH (validated by exec.LookPath).
+//  2. <workingDir>/bin/<terraform binary> if already present.
+//  3. Download via hc-install into <workingDir>/bin.
+func resolveExecPath(ctx context.Context, workingDir string, installer Installer) (string, error) {
+	if p, ok := env.Lookup(ctx, ExecPathEnv); ok && p != "" {
+		abs, err := exec.LookPath(p)
+		if err != nil {
+			return "", fmt.Errorf("locate %s=%q: %w", ExecPathEnv, p, err)
+		}
+		log.Debugf(ctx, "Using terraform at %s (from %s)", filepath.ToSlash(abs), ExecPathEnv)
+		return abs, nil
+	}
+
+	binDir := filepath.Join(workingDir, "bin")
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		return "", fmt.Errorf("create terraform bin dir %s: %w", binDir, err)
+	}
+
+	existing := filepath.Join(binDir, product.Terraform.BinaryName())
+	if _, err := os.Stat(existing); err == nil {
+		log.Debugf(ctx, "Using terraform at %s", filepath.ToSlash(existing))
+		return existing, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("stat %s: %w", existing, err)
+	}
+
+	tv, _, err := GetTerraformVersion(ctx)
+	if err != nil {
+		return "", err
+	}
+	log.Infof(ctx, "Downloading terraform %s to %s", tv.String(), filepath.ToSlash(binDir))
+	path, err := installer.Install(ctx, binDir, tv)
+	if err != nil {
+		return "", fmt.Errorf("install terraform: %w", err)
+	}
+	return path, nil
+}
+
+// buildEnv assembles the env map passed to terraform-exec.
+//
+// It starts with the auth variables the databricks terraform provider reads
+// natively (DATABRICKS_HOST / DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET
+// / DATABRICKS_TOKEN / DATABRICKS_CONFIG_PROFILE), then layers on the cloud
+// credentials that the underlay resources will eventually need (AWS, Azure,
+// GCP), then PATH/HOME/TMPDIR/proxy variables so the subprocess inherits a
+// sane environment. Everything flows from the current process env — there is
+// no `--profile` resolution here; that is the CLI layer's job.
+func buildEnv(ctx context.Context) map[string]string {
+	out := map[string]string{}
+
+	passthroughKeys := []string{
+		// Databricks auth — consumed by the terraform-provider-databricks.
+		// See https://registry.terraform.io/providers/databricks/databricks/latest/docs
+		"DATABRICKS_HOST",
+		"DATABRICKS_CLIENT_ID",
+		"DATABRICKS_CLIENT_SECRET",
+		"DATABRICKS_TOKEN",
+		"DATABRICKS_CONFIG_PROFILE",
+		"DATABRICKS_CONFIG_FILE",
+		"DATABRICKS_ACCOUNT_ID",
+		"DATABRICKS_AUTH_TYPE",
+		"DATABRICKS_METADATA_SERVICE_URL",
+
+		// AWS cloud-underlay credentials. Out-of-scope for M1, but passing
+		// them through now keeps the wrapper from re-shaping once AWS
+		// resources land.
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_REGION",
+		"AWS_DEFAULT_REGION",
+		"AWS_PROFILE",
+		"AWS_WEB_IDENTITY_TOKEN_FILE",
+		"AWS_ROLE_ARN",
+		"AWS_ROLE_SESSION_NAME",
+
+		// Azure cloud-underlay credentials.
+		"AZURE_TENANT_ID",
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET",
+		"AZURE_SUBSCRIPTION_ID",
+		"AZURE_FEDERATED_TOKEN_FILE",
+
+		// GCP cloud-underlay credentials.
+		"GOOGLE_CREDENTIALS",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"GOOGLE_PROJECT",
+		"GOOGLE_REGION",
+
+		// Process plumbing.
+		"HOME",
+		"USERPROFILE",
+		"PATH",
+		"TF_CLI_CONFIG_FILE",
+	}
+	for _, k := range passthroughKeys {
+		if v, ok := env.Lookup(ctx, k); ok {
+			out[k] = v
+		}
+	}
+
+	// $DATABRICKS_TF_CLI_CONFIG_FILE maps to $TF_CLI_CONFIG_FILE so the
+	// VSCode extension's filesystem-mirror config is picked up when it lines
+	// up with the provider version we actually use.
+	if v, ok := env.Lookup(ctx, CliConfigPathEnv); ok && v != "" {
+		if _, err := os.Stat(v); err == nil {
+			out["TF_CLI_CONFIG_FILE"] = v
+		}
+	}
+
+	// Proxy variables — both upper and lower case; terraform-exec is fine
+	// with either, but downstream tools on macOS/Linux commonly read the
+	// uppercase form.
+	for _, v := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+		for _, key := range []string{v, strings.ToLower(v)} {
+			if val, ok := env.Lookup(ctx, key); ok {
+				out[strings.ToUpper(v)] = val
+			}
+		}
+	}
+
+	// TMPDIR / TMP — let terraform create temp files in a place it can write.
+	if runtime.GOOS == "windows" {
+		for _, k := range []string{"TMP", "TEMP"} {
+			if v, ok := env.Lookup(ctx, k); ok {
+				out[k] = v
+			}
+		}
+	} else if v, ok := env.Lookup(ctx, "TMPDIR"); ok {
+		out["TMPDIR"] = v
+	}
+
+	return out
+}
+
+// lockIdentity returns the (user, lockTargetDir) pair used to construct a
+// Locker for Apply/Destroy. user identifies the holder in the on-the-wire
+// lock record; lockTargetDir is the state dir whose race we are resolving.
+//
+// The lock dir follows the same `.databricks/ucm/<target>/state` convention
+// U4 will use for terraform state. Keeping the path client-derived (rather
+// than pulling it from a not-yet-wired Ucm field) lets U5 ship ahead of U4.
+func lockIdentity(ctx context.Context, u *ucm.Ucm) (string, string) {
+	user := env.Get(ctx, "USER")
+	if user == "" {
+		user = env.Get(ctx, "USERNAME")
+	}
+	if user == "" {
+		user = "ucm"
+	}
+	lockDir := filepath.Join(u.RootPath, filepath.FromSlash(cacheDirName), u.Config.Ucm.Target, "state")
+	return user, lockDir
+}
+
+// ensureRunner lazily binds a tfRunner to the Terraform wrapper. Split so
+// Init can re-use it and tests can bypass the factory by pre-populating the
+// runner field.
+func (t *Terraform) ensureRunner(_ context.Context) error {
+	if t.runner != nil {
+		return nil
+	}
+	factory := t.runnerFactory
+	if factory == nil {
+		factory = defaultRunnerFactory
+	}
+	r, err := factory(t.WorkingDir, t.ExecPath)
+	if err != nil {
+		return fmt.Errorf("init terraform-exec: %w", err)
+	}
+	if err := r.SetEnv(t.Env); err != nil {
+		return fmt.Errorf("set terraform env: %w", err)
+	}
+	t.runner = r
+	return nil
+}

--- a/ucm/deploy/terraform/terraform_test.go
+++ b/ucm/deploy/terraform/terraform_test.go
@@ -1,0 +1,70 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildEnvPassesAuthAndCloudVars pins the wire-level auth and cloud-cred
+// env variables we expect to forward to the terraform subprocess. The test
+// uses libs/env's context-backed environment so it doesn't pollute the
+// process-wide os.Environ.
+func TestBuildEnvPassesAuthAndCloudVars(t *testing.T) {
+	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://example.cloud.databricks.com")
+	ctx = env.Set(ctx, "DATABRICKS_CLIENT_ID", "sp-client-id")
+	ctx = env.Set(ctx, "DATABRICKS_CLIENT_SECRET", "sp-client-secret")
+	ctx = env.Set(ctx, "AWS_ACCESS_KEY_ID", "AKIA...")
+	ctx = env.Set(ctx, "AWS_SECRET_ACCESS_KEY", "secret")
+	ctx = env.Set(ctx, "AZURE_TENANT_ID", "azure-tenant")
+	ctx = env.Set(ctx, "GOOGLE_CREDENTIALS", `{"type":"service_account"}`)
+
+	got := buildEnv(ctx)
+
+	for _, key := range []string{
+		"DATABRICKS_HOST",
+		"DATABRICKS_CLIENT_ID",
+		"DATABRICKS_CLIENT_SECRET",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AZURE_TENANT_ID",
+		"GOOGLE_CREDENTIALS",
+	} {
+		_, ok := got[key]
+		assert.Truef(t, ok, "expected %s to be passed through", key)
+	}
+
+	assert.Equal(t, "https://example.cloud.databricks.com", got["DATABRICKS_HOST"])
+	assert.Equal(t, "sp-client-id", got["DATABRICKS_CLIENT_ID"])
+}
+
+func TestBuildEnvOmitsUnsetVars(t *testing.T) {
+	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://example.cloud.databricks.com")
+	got := buildEnv(ctx)
+
+	_, ok := got["DATABRICKS_CLIENT_ID"]
+	assert.False(t, ok, "unset var should not leak into env map")
+	_, ok = got["AWS_ACCESS_KEY_ID"]
+	assert.False(t, ok)
+}
+
+func TestBuildEnvMapsProxyVarsUppercase(t *testing.T) {
+	ctx := env.Set(t.Context(), "http_proxy", "http://proxy.example:3128")
+	ctx = env.Set(ctx, "HTTPS_PROXY", "http://proxy.example:3129")
+
+	got := buildEnv(ctx)
+	assert.Equal(t, "http://proxy.example:3128", got["HTTP_PROXY"])
+	assert.Equal(t, "http://proxy.example:3129", got["HTTPS_PROXY"])
+}
+
+func TestLockIdentityDerivesPathFromTarget(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	user, dir := lockIdentity(t.Context(), u)
+	require.NotEmpty(t, user)
+	assert.Contains(t, dir, ".databricks")
+	assert.Contains(t, dir, "ucm")
+	assert.Contains(t, dir, "dev")
+	assert.Contains(t, dir, "state")
+}

--- a/ucm/phases/build.go
+++ b/ucm/phases/build.go
@@ -1,0 +1,36 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+)
+
+// Build renders the ucm configuration tree into the working directory's
+// main.tf.json via the terraform wrapper's Render step. The underlying
+// conversion is done by ucm/deploy/terraform/tfdyn.Convert and driven from
+// (*terraform.Terraform).Render; Build is the phase-level veneer so cmd layer
+// progress messages have a single pivot.
+//
+// Build returns the wrapper so callers can thread it into Plan/Deploy/Destroy
+// without recreating it (important: terraform.New resolves the binary on
+// disk, which is expensive). A nil return value means logdiag.HasError is
+// set and the caller should bail.
+func Build(ctx context.Context, u *ucm.Ucm, opts Options) TerraformWrapper {
+	log.Info(ctx, "Phase: build")
+
+	factory := opts.terraformFactoryOrDefault()
+	tf, err := factory(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("build terraform wrapper: %w", err))
+		return nil
+	}
+	if err := tf.Render(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("render terraform config: %w", err))
+		return nil
+	}
+	return tf
+}

--- a/ucm/phases/build_test.go
+++ b/ucm/phases/build_test.go
@@ -1,0 +1,65 @@
+package phases_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fakeTfFactory(f *fakeTf) phases.TerraformFactory {
+	return func(_ context.Context, _ *ucm.Ucm) (phases.TerraformWrapper, error) {
+		return f, nil
+	}
+}
+
+func TestBuildHappyPath(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	tf := phases.Build(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	require.False(t, logdiag.HasError(ctx))
+	require.NotNil(t, tf)
+	assert.Equal(t, 1, f.tf.RenderCalls)
+	assert.Equal(t, 0, f.tf.InitCalls, "Build must not call terraform init itself")
+}
+
+func TestBuildFactoryError(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	factory := func(_ context.Context, _ *ucm.Ucm) (phases.TerraformWrapper, error) {
+		return nil, errSentinel
+	}
+
+	tf := phases.Build(ctx, f.u, phases.Options{TerraformFactory: factory})
+
+	assert.Nil(t, tf)
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, errSentinel.Error())
+}
+
+func TestBuildRenderError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.RenderErr = errSentinel
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	tf := phases.Build(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	assert.Nil(t, tf)
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "render terraform config")
+}

--- a/ucm/phases/deploy.go
+++ b/ucm/phases/deploy.go
@@ -1,0 +1,50 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+)
+
+// Deploy runs the initialize → build → terraform-init → terraform-apply →
+// state-push sequence. Errors are reported via logdiag; state.Push is only
+// called when the apply succeeds, so a mid-apply failure leaves the remote
+// state on the previous Seq and the local cache updated but un-acknowledged.
+//
+// The terraform apply acquires its own deploy lock for the write window; the
+// preceding Pull (in Initialize) and the subsequent Push each acquire and
+// release the lock independently. Between those two lock windows the lock is
+// released — intentional, because holding a remote lock across a long
+// terraform apply would create availability problems for other targets.
+func Deploy(ctx context.Context, u *ucm.Ucm, opts Options) {
+	log.Info(ctx, "Phase: deploy")
+
+	setting := Initialize(ctx, u, opts)
+	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+		return
+	}
+
+	tf := Build(ctx, u, opts)
+	if tf == nil || logdiag.HasError(ctx) {
+		return
+	}
+
+	if err := tf.Init(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform init: %w", err))
+		return
+	}
+
+	if err := tf.Apply(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform apply: %w", err))
+		return
+	}
+
+	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
+		return
+	}
+}

--- a/ucm/phases/deploy_test.go
+++ b/ucm/phases/deploy_test.go
@@ -1,0 +1,108 @@
+package phases_test
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readRemoteSeq returns the Seq of the remote ucm-state.json, or -1 when the
+// file has not been written yet. Used to assert Push advanced the remote.
+func readRemoteSeq(t *testing.T, f *fixture) int {
+	t.Helper()
+	rc, err := f.remote.Read(t.Context(), deploy.UcmStateFileName)
+	if err != nil {
+		return -1
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	var s deploy.State
+	require.NoError(t, json.Unmarshal(data, &s))
+	return s.Seq
+}
+
+func TestDeployHappyPath(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	assert.Equal(t, 1, f.tf.RenderCalls)
+	assert.Equal(t, 1, f.tf.InitCalls)
+	assert.Equal(t, 1, f.tf.ApplyCalls)
+	// Post-apply Push must advance the remote Seq from 0 to 1.
+	assert.Equal(t, 1, readRemoteSeq(t, f))
+}
+
+func TestDeployShortCircuitsOnDirectEngine(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.ApplyCalls)
+	assert.Equal(t, -1, readRemoteSeq(t, f), "remote state must not advance when apply is skipped")
+}
+
+func TestDeployBailsOnApplyError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.ApplyErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	// Apply failed → Push must NOT run; remote ucm-state.json must stay
+	// absent because Pull only writes locally on first-run.
+	assert.Equal(t, -1, readRemoteSeq(t, f))
+}
+
+func TestDeployBailsOnInitializeError(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	// Zero Backend → Pull fails → the rest of Deploy short-circuits.
+	phases.Deploy(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.ApplyCalls)
+}
+
+func TestDeployBailsOnBuildError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.RenderErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.ApplyCalls)
+}

--- a/ucm/phases/destroy.go
+++ b/ucm/phases/destroy.go
@@ -1,0 +1,48 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+)
+
+// Destroy runs the initialize → terraform-init → terraform-destroy →
+// state-push sequence. The Build phase is skipped — destroy operates on the
+// already-rendered terraform config cached from the last apply (tf.Init
+// re-renders from current ucm.yml which is still necessary for the resource
+// graph). The final Push uploads the post-destroy terraform.tfstate so peers
+// observe the emptied state.
+func Destroy(ctx context.Context, u *ucm.Ucm, opts Options) {
+	log.Info(ctx, "Phase: destroy")
+
+	setting := Initialize(ctx, u, opts)
+	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+		return
+	}
+
+	factory := opts.terraformFactoryOrDefault()
+	tf, err := factory(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("build terraform wrapper: %w", err))
+		return
+	}
+
+	if err := tf.Init(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform init: %w", err))
+		return
+	}
+
+	if err := tf.Destroy(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform destroy: %w", err))
+		return
+	}
+
+	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
+		return
+	}
+}

--- a/ucm/phases/destroy_test.go
+++ b/ucm/phases/destroy_test.go
@@ -1,0 +1,89 @@
+package phases_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDestroyHappyPath(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	// Destroy does NOT call Render via Build — Init re-renders.
+	assert.Equal(t, 0, f.tf.RenderCalls)
+	assert.Equal(t, 1, f.tf.InitCalls)
+	assert.Equal(t, 1, f.tf.DestroyCalls)
+	assert.Equal(t, 0, f.tf.ApplyCalls)
+	// Post-destroy Push must advance the remote Seq.
+	assert.Equal(t, 1, readRemoteSeq(t, f))
+}
+
+func TestDestroyShortCircuitsOnDirectEngine(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.DestroyCalls)
+}
+
+func TestDestroyBailsOnDestroyError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.DestroyErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	// Destroy failed before Push; remote state file must not have been
+	// written (Pull only writes locally on first-run).
+	assert.Equal(t, -1, readRemoteSeq(t, f))
+}
+
+func TestDestroyBailsOnInitializeError(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.DestroyCalls)
+}
+
+func TestDestroyBailsOnInitError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.InitErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.DestroyCalls)
+}

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -1,0 +1,114 @@
+package phases_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/deploy"
+	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTf satisfies phases.TerraformWrapper for tests. Each method bumps a
+// counter and returns the pre-seeded err/plan value so test cases can assert
+// on call order and inject failures mid-sequence.
+type fakeTf struct {
+	mu sync.Mutex
+
+	RenderCalls  int
+	InitCalls    int
+	PlanCalls    int
+	ApplyCalls   int
+	DestroyCalls int
+
+	RenderErr  error
+	InitErr    error
+	PlanErr    error
+	ApplyErr   error
+	DestroyErr error
+
+	PlanResult *terraform.PlanResult
+}
+
+func (f *fakeTf) Render(_ context.Context, _ *ucm.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.RenderCalls++
+	return f.RenderErr
+}
+
+func (f *fakeTf) Init(_ context.Context, _ *ucm.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.InitCalls++
+	return f.InitErr
+}
+
+func (f *fakeTf) Plan(_ context.Context, _ *ucm.Ucm) (*terraform.PlanResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.PlanCalls++
+	return f.PlanResult, f.PlanErr
+}
+
+func (f *fakeTf) Apply(_ context.Context, _ *ucm.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ApplyCalls++
+	return f.ApplyErr
+}
+
+func (f *fakeTf) Destroy(_ context.Context, _ *ucm.Ucm) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.DestroyCalls++
+	return f.DestroyErr
+}
+
+// fixture bundles the dependencies every phase test needs: a minimal Ucm with
+// a target selected, a local-filer-backed Backend that satisfies deploy.Pull
+// and deploy.Push, and the per-test fakeTf.
+type fixture struct {
+	t        *testing.T
+	u        *ucm.Ucm
+	backend  deploy.Backend
+	tf       *fakeTf
+	remote   libsfiler.Filer
+	localDir string
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	projDir := t.TempDir()
+	remoteDir := t.TempDir()
+
+	remote, err := libsfiler.NewLocalClient(remoteDir)
+	require.NoError(t, err)
+
+	u := &ucm.Ucm{RootPath: projDir}
+	u.Config.Ucm = config.Ucm{Name: "test", Target: "dev"}
+
+	return &fixture{
+		t:  t,
+		u:  u,
+		tf: &fakeTf{},
+		backend: deploy.Backend{
+			StateFiler: ucmfiler.NewStateFilerFromFiler(remote),
+			LockFiler:  remote,
+			User:       "alice@example.com",
+		},
+		remote:   remote,
+		localDir: filepath.Join(projDir, filepath.FromSlash(deploy.LocalCacheDir), "dev"),
+	}
+}
+
+// errSentinel is a stable error identity for tests that assert the wrapped
+// cause propagates through logdiag-formatted diagnostics.
+var errSentinel = errors.New("sentinel")

--- a/ucm/phases/initialize.go
+++ b/ucm/phases/initialize.go
@@ -1,0 +1,95 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/deploy"
+)
+
+// Engine-resolution source labels. Kept private and parallel to the labels
+// used by cmd/ucm/utils.ResolveEngineSetting so diagnostics remain consistent
+// with whichever entry point the caller exercised. Duplicated here (not
+// imported) because cmd/ucm/utils → phases makes utils → phases a cycle.
+const (
+	engineSourceConfig  = "config"
+	engineSourceEnv     = "env"
+	engineSourceDefault = "default"
+)
+
+// resolveEngine mirrors cmd/ucm/utils.ResolveEngineSetting. It lives here to
+// break the cmd/ucm/utils → phases import cycle that would otherwise form
+// when the CLI layer wants to compose both the load/validate phases and the
+// deploy phases from a single utils.ProcessUcm-style helper.
+func resolveEngine(ctx context.Context, u *ucm.Ucm) (engine.EngineSetting, error) {
+	configEngine := engine.EngineNotSet
+	if u != nil {
+		configEngine = u.Config.Ucm.Engine
+	}
+
+	if configEngine != engine.EngineNotSet {
+		return engine.EngineSetting{
+			Type:       configEngine,
+			Source:     engineSourceConfig,
+			ConfigType: configEngine,
+		}, nil
+	}
+
+	envEngine, err := engine.FromEnv(ctx)
+	if err != nil {
+		return engine.EngineSetting{}, err
+	}
+	if envEngine != engine.EngineNotSet {
+		return engine.EngineSetting{
+			Type:   envEngine,
+			Source: engineSourceEnv,
+		}, nil
+	}
+
+	return engine.EngineSetting{
+		Type:   engine.Default,
+		Source: engineSourceDefault,
+	}, nil
+}
+
+// Initialize resolves the deployment engine and pulls remote state into the
+// per-target local cache so downstream phases (build/plan/deploy/destroy) can
+// read a consistent baseline. Errors are reported via logdiag; callers must
+// check logdiag.HasError before proceeding.
+//
+// Initialize does NOT retain the deploy lock across phases — state.Pull
+// acquires and releases its own lock for the duration of the pull. The
+// subsequent terraform Apply/Destroy acquires a fresh lock covering the write
+// half of the deploy.
+func Initialize(ctx context.Context, u *ucm.Ucm, opts Options) engine.EngineSetting {
+	log.Info(ctx, "Phase: initialize")
+
+	setting, err := resolveEngine(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("resolve engine: %w", err))
+		return engine.EngineSetting{}
+	}
+	log.Debugf(ctx, "initialize: engine=%s source=%s", setting.Type, setting.Source)
+
+	if setting.Type.IsDirect() {
+		// Direct engine landed as a design goal but has no M1 implementation.
+		// Report via logdiag and bail — downstream phases will skip on
+		// logdiag.HasError.
+		logdiag.LogDiag(ctx, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "ucm direct engine is not yet implemented; set ucm.engine to terraform or unset DATABRICKS_UCM_ENGINE",
+		})
+		return setting
+	}
+
+	if err := deploy.Pull(ctx, u, opts.Backend); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("pull remote state: %w", err))
+		return setting
+	}
+	return setting
+}

--- a/ucm/phases/initialize_test.go
+++ b/ucm/phases/initialize_test.go
@@ -1,0 +1,81 @@
+package phases_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeHappyPath(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	setting := phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected error diagnostics: %v", logdiag.FlushCollected(ctx))
+	assert.Equal(t, engine.EngineTerraform, setting.Type)
+	assert.Equal(t, "default", setting.Source)
+}
+
+func TestInitializeDirectEngineIsStubbed(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	setting := phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+
+	assert.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, "direct engine is not yet implemented")
+	assert.Equal(t, engine.EngineDirect, setting.Type)
+}
+
+func TestInitializeDirectEngineViaEnv(t *testing.T) {
+	f := newFixture(t)
+	ctx := env.Set(t.Context(), engine.EnvVar, "direct")
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetCollect(ctx, true)
+
+	setting := phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, engine.EngineDirect, setting.Type)
+	assert.Equal(t, "env", setting.Source)
+}
+
+func TestInitializeInvalidEngineEnv(t *testing.T) {
+	f := newFixture(t)
+	ctx := env.Set(t.Context(), engine.EnvVar, "bogus")
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetCollect(ctx, true)
+
+	phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, engine.EnvVar)
+}
+
+func TestInitializeMissingBackendFails(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	// Zero-valued Backend — Pull refuses to run.
+	phases.Initialize(ctx, f.u, phases.Options{})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "pull remote state")
+}

--- a/ucm/phases/load.go
+++ b/ucm/phases/load.go
@@ -13,6 +13,8 @@ import (
 // the user did not pass --target.
 func LoadDefaultTarget(ctx context.Context, u *ucm.Ucm) {
 	ucm.ApplySeqContext(ctx, u,
+		mutator.FlattenNestedResources(),
+		mutator.InheritCatalogTags(),
 		mutator.DefineDefaultTarget(),
 		mutator.SelectDefaultTarget(),
 	)
@@ -22,6 +24,8 @@ func LoadDefaultTarget(ctx context.Context, u *ucm.Ucm) {
 // --target <name>.
 func LoadNamedTarget(ctx context.Context, u *ucm.Ucm, name string) {
 	ucm.ApplySeqContext(ctx, u,
+		mutator.FlattenNestedResources(),
+		mutator.InheritCatalogTags(),
 		mutator.DefineDefaultTarget(),
 		mutator.SelectTarget(name),
 	)

--- a/ucm/phases/options.go
+++ b/ucm/phases/options.go
@@ -1,0 +1,65 @@
+package phases
+
+import (
+	"context"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+)
+
+// TerraformWrapper is the slice of *terraform.Terraform that phases depend on.
+// Keeping the surface minimal lets tests inject a fake without standing up a
+// real terraform binary. *terraform.Terraform satisfies this interface so the
+// production factory does not need an adapter.
+type TerraformWrapper interface {
+	Render(ctx context.Context, u *ucm.Ucm) error
+	Init(ctx context.Context, u *ucm.Ucm) error
+	Plan(ctx context.Context, u *ucm.Ucm) (*terraform.PlanResult, error)
+	Apply(ctx context.Context, u *ucm.Ucm) error
+	Destroy(ctx context.Context, u *ucm.Ucm) error
+}
+
+// TerraformFactory constructs a terraform-engine wrapper scoped to u.
+// Production callers pass DefaultTerraformFactory; tests hand in a factory
+// that returns a fake.
+type TerraformFactory func(ctx context.Context, u *ucm.Ucm) (TerraformWrapper, error)
+
+// Compile-time assertion that *terraform.Terraform satisfies TerraformWrapper.
+// Keeps the interface honest when the underlying wrapper gains new methods;
+// a broken assertion catches the drift at build time rather than at the
+// DefaultTerraformFactory call site.
+var _ TerraformWrapper = (*terraform.Terraform)(nil)
+
+// DefaultTerraformFactory builds a real *terraform.Terraform via terraform.New,
+// resolving (and if necessary downloading) the terraform binary on first use.
+// Production callers pass this directly; tests never should.
+func DefaultTerraformFactory(ctx context.Context, u *ucm.Ucm) (TerraformWrapper, error) {
+	return terraform.New(ctx, u)
+}
+
+// Options bundles the externally-supplied dependencies a phase needs at
+// runtime. Zero-valued Options is never meaningful in production — the CLI
+// layer (U7) will always populate Backend + TerraformFactory before invoking
+// plan/deploy/destroy. Tests may omit Backend when exercising the
+// engine-direct stub or the no-op initialize error paths.
+type Options struct {
+	// Backend is the pull/push state-storage pair used by Initialize and
+	// the post-apply/destroy Push. Required for Plan/Deploy/Destroy in the
+	// terraform engine; callers that set the engine to direct (and thus
+	// short-circuit) may leave it nil.
+	Backend deploy.Backend
+
+	// TerraformFactory produces the terraform wrapper bound to u. When nil,
+	// phases fall back to DefaultTerraformFactory.
+	TerraformFactory TerraformFactory
+}
+
+// terraformFactoryOrDefault returns o.TerraformFactory or the production
+// factory when unset.
+func (o Options) terraformFactoryOrDefault() TerraformFactory {
+	if o.TerraformFactory != nil {
+		return o.TerraformFactory
+	}
+	return DefaultTerraformFactory
+}

--- a/ucm/phases/plan.go
+++ b/ucm/phases/plan.go
@@ -1,0 +1,45 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+)
+
+// Plan runs the initialize → build → terraform-init → terraform-plan sequence
+// and returns the resulting *terraform.PlanResult. Errors are reported via
+// logdiag; on error Plan returns nil and the caller should check
+// logdiag.HasError before rendering any output.
+//
+// Plan does NOT call state.Push — a plan never advances remote state. The
+// deploy-side lock is held only for the state.Pull in Initialize and
+// released; planning itself runs lock-free because it never writes.
+func Plan(ctx context.Context, u *ucm.Ucm, opts Options) *terraform.PlanResult {
+	log.Info(ctx, "Phase: plan")
+
+	setting := Initialize(ctx, u, opts)
+	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+		return nil
+	}
+
+	tf := Build(ctx, u, opts)
+	if tf == nil || logdiag.HasError(ctx) {
+		return nil
+	}
+
+	if err := tf.Init(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform init: %w", err))
+		return nil
+	}
+
+	result, err := tf.Plan(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform plan: %w", err))
+		return nil
+	}
+	return result
+}

--- a/ucm/phases/plan_test.go
+++ b/ucm/phases/plan_test.go
@@ -1,0 +1,96 @@
+package phases_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanHappyPath(t *testing.T) {
+	f := newFixture(t)
+	f.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "plan has changes"}
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	require.False(t, logdiag.HasError(ctx))
+	require.NotNil(t, result)
+	assert.True(t, result.HasChanges)
+	assert.Equal(t, 1, f.tf.RenderCalls)
+	assert.Equal(t, 1, f.tf.InitCalls)
+	assert.Equal(t, 1, f.tf.PlanCalls)
+}
+
+func TestPlanBailsOnInitializeError(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	// Missing Backend — Initialize.Pull fails, Plan should short-circuit.
+	result := phases.Plan(ctx, f.u, phases.Options{TerraformFactory: fakeTfFactory(f.tf)})
+
+	assert.Nil(t, result)
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.RenderCalls, "Build must not run when Initialize failed")
+}
+
+func TestPlanShortCircuitsOnDirectEngine(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	assert.Nil(t, result)
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.RenderCalls)
+	assert.Equal(t, 0, f.tf.InitCalls)
+	assert.Equal(t, 0, f.tf.PlanCalls)
+}
+
+func TestPlanBailsOnInitError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.InitErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	assert.Nil(t, result)
+	assert.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.PlanCalls, "Plan should not run when Init fails")
+}
+
+func TestPlanPropagatesPlanError(t *testing.T) {
+	f := newFixture(t)
+	f.tf.PlanErr = errSentinel
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	})
+
+	assert.Nil(t, result)
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "terraform plan")
+}


### PR DESCRIPTION
## Summary

Consolidation PR to bring all of M1 onto main. Individual stacked PRs (#15, #18, #19, #21, #24, #25) were marked MERGED by GitHub because their heads became ancestors of their `ci/waveN-integration` base branches — but their content is not yet on main. This PR lands all of it atomically.

Includes:
- **#5** — Nested schemas/grants under catalog with tag inheritance (already-in-flight pre-M1)
- **#15 (U0)** — `bundle.engine` → `ucm.engine` mirror with `DATABRICKS_UCM_ENGINE` env var
- **#18 (U4)** — State pull/push with Locker + StateFiler
- **#19 (U5)** — Terraform binary wrapper (init/render/plan/apply/destroy)
- **#21 (U6)** — Phase orchestration (initialize/build/plan/deploy/destroy)
- **#24 (U7)** — M1 verbs (plan/deploy/destroy/summary/policy-check) + BackendFromUcm
- **#25 (U8)** — End-to-end smoke fixture + runtime auth wiring (`PersistentPreRunE: root.MustWorkspaceClient`)

Already on main (via sequential merge): #4 (M0), #11 (U1 filer), #13 (U2 lock), #14 (U3 tfdyn).

## Why

M1 takes ucm from "config-only" to "can deploy end-to-end". After this lands, `databricks ucm {validate,plan,deploy,destroy,summary,policy-check}` works against a real workspace with terraform engine.

## Test plan

- [x] `go build ./...` clean on `ci/m1-integration`
- [x] `go vet ./cmd/ucm/... ./ucm/...` clean
- [x] `go test ./cmd/ucm/... ./ucm/...` green (13 packages)
- [x] Smoke test `TestCmd_PlanSmoke_EndToEnd` validates ucm.yml → rendered tf.json against golden
- [ ] Manual: `DATABRICKS_HOST=... ./databricks ucm plan --target default` from `cmd/ucm/testdata/deploy_smoke`

## Follow-ups (already filed)

- #26 — sort tfdyn `properties` map keys for deterministic output
- #27 — clean error when `buildPhaseOptions` sees nil workspace client