### PR TITLE
Fix #30: Restore ProcessUcm and Ucm.Target dropped during PR #29

### DIFF
--- a/cmd/ucm/utils/utils.go
+++ b/cmd/ucm/utils/utils.go
@@ -1,11 +1,18 @@
-// Package utils contains helpers shared across cmd/ucm verbs.
+// Package utils contains helpers shared by `databricks ucm` subcommand
+// implementations — primarily ProcessUcm, which mirrors the role of
+// cmd/bundle/utils.ProcessBundle for the ucm verbs, and ResolveEngineSetting,
+// which picks the effective deployment engine.
 package utils
 
 import (
 	"context"
 
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config"
 	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -13,6 +20,47 @@ const (
 	sourceEnv     = "env"
 	sourceDefault = "default"
 )
+
+// ProcessOptions controls optional behavior in ProcessUcm. M0 only exposes
+// the `Validate` switch; more knobs will join as additional verbs land.
+type ProcessOptions struct {
+	// Validate runs phases.Validate after loading the target. Set this when
+	// implementing the `validate` or `policy-check` verbs.
+	Validate bool
+}
+
+// ProcessUcm loads the ucm.yml rooted at the working directory (or
+// DATABRICKS_UCM_ROOT), selects the target indicated by --target (or the
+// default target), and — if opts.Validate — runs the validation phase.
+//
+// Errors are reported via logdiag. The caller should check
+// logdiag.HasError(cmd.Context()) and render diagnostics before returning.
+func ProcessUcm(cmd *cobra.Command, opts ProcessOptions) *ucm.Ucm {
+	ctx := cmd.Context()
+	if !logdiag.IsSetup(ctx) {
+		ctx = logdiag.InitContext(ctx)
+		cmd.SetContext(ctx)
+	}
+
+	u := ucm.MustLoad(ctx)
+	if u == nil || logdiag.HasError(ctx) {
+		return u
+	}
+
+	if target := getTargetFromCmd(cmd); target == "" {
+		phases.LoadDefaultTarget(ctx, u)
+	} else {
+		phases.LoadNamedTarget(ctx, u, target)
+	}
+	if logdiag.HasError(ctx) {
+		return u
+	}
+
+	if opts.Validate {
+		phases.Validate(ctx, u)
+	}
+	return u
+}
 
 // ResolveEngineSetting determines the effective engine for a ucm project.
 //
@@ -48,4 +96,11 @@ func ResolveEngineSetting(ctx context.Context, u *config.Ucm) (engine.EngineSett
 		Type:   engine.Default,
 		Source: sourceDefault,
 	}, nil
+}
+
+func getTargetFromCmd(cmd *cobra.Command) string {
+	if flag := cmd.Flag("target"); flag != nil {
+		return flag.Value.String()
+	}
+	return ""
 }

--- a/ucm/config/ucm.go
+++ b/ucm/config/ucm.go
@@ -11,4 +11,8 @@ type Ucm struct {
 	// Engine selects the deployment engine ("terraform" or "direct").
 	// Can be overridden with the DATABRICKS_UCM_ENGINE environment variable.
 	Engine engine.EngineType `json:"engine,omitempty"`
+
+	// Target records which target is currently selected. It is populated
+	// by the SelectTarget mutator; users do not set it in ucm.yml.
+	Target string `json:"target,omitempty" bundle:"readonly"`
 }


### PR DESCRIPTION
Closes #30

## Summary
- Restores `ProcessOptions`, `ProcessUcm`, `getTargetFromCmd` in `cmd/ucm/utils/utils.go`
- Restores `Target string` field on `ucm/config/ucm.go:Ucm`

## Why
PR #29's conflict resolution dropped these symbols. Main has been failing to build since #29 merged:

```
ucm/config/mutator/select_target.go:44:15: u.Config.Ucm.Target undefined
cmd/ucm/validate.go:32:9: undefined: utils.ProcessUcm
cmd/ucm/validate.go:32:31: undefined: utils.ProcessOptions
```

Must land before the M1 consolidation PR.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...` clean
- [x] `go test ./cmd/ucm/... ./ucm/...` green
- [x] `go vet ./cmd/ucm/... ./ucm/...` clean