### PR TITLE
Fix #41: Swap PersistentPreRunE→PreRunE on ucm auth verbs

### DIFF
--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -23,8 +23,8 @@ the previous seq; re-running the command will re-attempt from a fresh pull.
 Common invocations:
   databricks ucm deploy                  # Deploy the default target
   databricks ucm deploy --target prod    # Deploy a specific target`,
-		Args:              root.NoArgs,
-		PersistentPreRunE: root.MustWorkspaceClient,
+		Args:    root.NoArgs,
+		PreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -25,8 +25,8 @@ cached from the last apply.
 Common invocations:
   databricks ucm destroy --auto-approve                # Destroy default target
   databricks ucm destroy --target dev --auto-approve   # Destroy a specific target`,
-		Args:              root.NoArgs,
-		PersistentPreRunE: root.MustWorkspaceClient,
+		Args:    root.NoArgs,
+		PreRunE: root.MustWorkspaceClient,
 	}
 
 	var autoApprove bool

--- a/cmd/ucm/helpers_test.go
+++ b/cmd/ucm/helpers_test.go
@@ -140,10 +140,10 @@ func runVerbInDir(t *testing.T, workDir string, args ...string) (string, string,
 	t.Cleanup(func() { _ = os.Chdir(prev) })
 
 	cmd := New()
-	// plan/deploy/destroy/summary attach PersistentPreRunE: root.MustWorkspaceClient
+	// plan/deploy/destroy/summary attach PreRunE: root.MustWorkspaceClient
 	// for real-world auth. Tests fake the workspace client via buildPhaseOptions,
 	// so strip the hook on every subcommand before invoking cobra.
-	stripPersistentPreRunE(cmd)
+	stripAuthHooks(cmd)
 	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
@@ -191,15 +191,17 @@ func validFixtureDir(t *testing.T) string {
 // phases-package errSentinel without colliding.
 var assertSentinel = errors.New("ucm verb test sentinel")
 
-// stripPersistentPreRunE recursively clears PersistentPreRunE on cmd and all
-// of its subcommands. The ucm verbs that need live auth wire
-// root.MustWorkspaceClient there; tests stand in their own Backend via
+// stripAuthHooks recursively clears PersistentPreRunE and PreRunE on cmd and
+// all of its subcommands. The ucm verbs that need live auth wire
+// root.MustWorkspaceClient as PreRunE; tests stand in their own Backend via
 // buildPhaseOptions so the real auth hook would just fail on a missing
 // ~/.databrickscfg.
-func stripPersistentPreRunE(cmd *cobra.Command) {
+func stripAuthHooks(cmd *cobra.Command) {
 	cmd.PersistentPreRunE = nil
 	cmd.PersistentPreRun = nil
+	cmd.PreRunE = nil
+	cmd.PreRun = nil
 	for _, sub := range cmd.Commands() {
-		stripPersistentPreRunE(sub)
+		stripAuthHooks(sub)
 	}
 }

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -23,8 +23,8 @@ touched.
 Common invocations:
   databricks ucm plan                   # Plan against the default target
   databricks ucm plan --target prod     # Plan against a specific target`,
-		Args:              root.NoArgs,
-		PersistentPreRunE: root.MustWorkspaceClient,
+		Args:    root.NoArgs,
+		PreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/plan_smoke_test.go
+++ b/cmd/ucm/plan_smoke_test.go
@@ -78,7 +78,7 @@ func assertSmokeGolden(t *testing.T, ctx context.Context, u *ucmpkg.Ucm) {
 // TestCmd_PlanSmoke_VerbHappyPath drives the cobra plan verb against the same
 // smoke fixture with the fake-tf harness. Complements TestCmd_PlanSmoke_EndToEnd
 // by proving the full CLI pivot (ucm plan → phases.Plan → TerraformWrapper)
-// stays wired once PersistentPreRunE auth is stripped out for tests.
+// stays wired once PreRunE auth is stripped out for tests.
 func TestCmd_PlanSmoke_VerbHappyPath(t *testing.T) {
 	h := newVerbHarness(t)
 	h.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "smoke plan ready"}

--- a/cmd/ucm/pre_run_hooks_test.go
+++ b/cmd/ucm/pre_run_hooks_test.go
@@ -1,0 +1,52 @@
+package ucm
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAuthVerbs_UsePreRunE guards against re-introducing the cmdIO panic caused
+// by overriding PersistentPreRunE. Auth-requiring verbs must wire
+// root.MustWorkspaceClient as PreRunE so the root's PersistentPreRunE (which
+// installs cmdio) still executes. See https://github.com/micheledaddetta-databricks/cli/issues/TBD.
+func TestAuthVerbs_UsePreRunE(t *testing.T) {
+	root := New()
+	authVerbs := map[string]bool{
+		"plan":    true,
+		"deploy":  true,
+		"destroy": true,
+		"summary": true,
+	}
+
+	seen := map[string]bool{}
+	for _, sub := range root.Commands() {
+		name := sub.Name()
+		if !authVerbs[name] {
+			continue
+		}
+		seen[name] = true
+		assert.Nil(t, sub.PersistentPreRunE, "%s must not set PersistentPreRunE (would bypass root cmdio install)", name)
+		assert.NotNil(t, sub.PreRunE, "%s must set PreRunE for workspace-client auth", name)
+	}
+
+	for verb := range authVerbs {
+		assert.True(t, seen[verb], "verb %q not found under ucm root; test needs updating", verb)
+	}
+}
+
+// assertNoSubtreeHasPersistentPreRunE walks the tree and fails if any descendant
+// of `root` (except root itself) declares PersistentPreRunE. Kept exported for
+// symmetry with stripAuthHooks.
+func assertNoSubtreeHasPersistentPreRunE(t *testing.T, c *cobra.Command) {
+	t.Helper()
+	for _, sub := range c.Commands() {
+		assert.Nil(t, sub.PersistentPreRunE, "%s has PersistentPreRunE which would shadow the root's cmdio setup", sub.CommandPath())
+		assertNoSubtreeHasPersistentPreRunE(t, sub)
+	}
+}
+
+func TestUcmSubtree_NoPersistentPreRunE(t *testing.T) {
+	assertNoSubtreeHasPersistentPreRunE(t, New())
+}

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -35,8 +35,8 @@ func newSummaryCommand() *cobra.Command {
 Reads the local terraform state cached under .databricks/ucm/<target>/ and
 prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
 ` + "`ucm plan`" + `) first; without a local state the table is empty.`,
-		Args:              root.NoArgs,
-		PersistentPreRunE: root.MustWorkspaceClient,
+		Args:    root.NoArgs,
+		PreRunE: root.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- Fixes #41 — \`ucm plan/deploy/destroy/summary\` no longer panic with "no cmdIO found in the context" when invoked without DATABRICKS_HOST/TOKEN.
- Root cause: cobra runs only the **nearest** PersistentPreRunE; the root's hook at \`cmd/root/root.go:61\` (which installs cmdio) was being shadowed by the verbs' own PersistentPreRunE. Fix: use PreRunE, which runs **after** the inherited PersistentPreRunE.
- Regression guard: new \`cmd/ucm/pre_run_hooks_test.go\` asserts auth verbs have PreRunE set and no ucm subcommand anywhere declares PersistentPreRunE.

## Test plan
- [x] \`go test ./cmd/ucm/... ./ucm/...\` passes
- [x] \`./cli ucm validate\`, \`./cli ucm schema\`, \`./cli ucm policy-check\` still work (happy paths on testdata/valid)
- [x] \`./cli ucm plan\` without auth → clean auth error, no panic
- [x] New \`TestAuthVerbs_UsePreRunE\` + \`TestUcmSubtree_NoPersistentPreRunE\` pass and catch the bad shape

This pull request and its description were written by Isaac.