### PR TITLE
Fix #45: Resolve workspace client from ucm.yml workspace.host

### DIFF
--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -24,7 +24,7 @@ Common invocations:
   databricks ucm deploy                  # Deploy the default target
   databricks ucm deploy --target prod    # Deploy a specific target`,
 		Args:    root.NoArgs,
-		PreRunE: root.MustWorkspaceClient,
+		PreRunE: utils.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -26,7 +26,7 @@ Common invocations:
   databricks ucm destroy --auto-approve                # Destroy default target
   databricks ucm destroy --target dev --auto-approve   # Destroy a specific target`,
 		Args:    root.NoArgs,
-		PreRunE: root.MustWorkspaceClient,
+		PreRunE: utils.MustWorkspaceClient,
 	}
 
 	var autoApprove bool

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -24,7 +24,7 @@ Common invocations:
   databricks ucm plan                   # Plan against the default target
   databricks ucm plan --target prod     # Plan against a specific target`,
 		Args:    root.NoArgs,
-		PreRunE: root.MustWorkspaceClient,
+		PreRunE: utils.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/pre_run_hooks_test.go
+++ b/cmd/ucm/pre_run_hooks_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 // TestAuthVerbs_UsePreRunE guards against re-introducing the cmdIO panic caused
-// by overriding PersistentPreRunE. Auth-requiring verbs must wire
-// root.MustWorkspaceClient as PreRunE so the root's PersistentPreRunE (which
-// installs cmdio) still executes. See https://github.com/micheledaddetta-databricks/cli/issues/TBD.
+// by overriding PersistentPreRunE. Auth-requiring verbs must wire the UCM
+// workspace-client hook (utils.MustWorkspaceClient) as PreRunE so the root's
+// PersistentPreRunE (which installs cmdio) still executes. See
+// https://github.com/micheledaddetta-databricks/cli/issues/41 and /issues/45.
 func TestAuthVerbs_UsePreRunE(t *testing.T) {
 	root := New()
 	authVerbs := map[string]bool{

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -36,7 +36,7 @@ Reads the local terraform state cached under .databricks/ucm/<target>/ and
 prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
 ` + "`ucm plan`" + `) first; without a local state the table is empty.`,
 		Args:    root.NoArgs,
-		PreRunE: root.MustWorkspaceClient,
+		PreRunE: utils.MustWorkspaceClient,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/ucm/utils/auth.go
+++ b/cmd/ucm/utils/auth.go
@@ -1,0 +1,128 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/databrickscfg"
+	"github.com/databricks/cli/libs/databrickscfg/profile"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/spf13/cobra"
+)
+
+// MustWorkspaceClient is the UCM analogue of root.MustWorkspaceClient. It
+// loads ucm.yml, selects the target, resolves a workspace client from
+// workspace.host (matching against ~/.databrickscfg) and installs it on the
+// command context. Ambiguous matches are resolved interactively, mirroring
+// DAB's configureBundle + resolveProfileAmbiguity flow in cmd/root/bundle.go.
+func MustWorkspaceClient(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if !logdiag.IsSetup(ctx) {
+		ctx = logdiag.InitContext(ctx)
+		cmd.SetContext(ctx)
+	}
+
+	u := ProcessUcm(cmd, ProcessOptions{})
+	ctx = cmd.Context()
+	if u == nil || logdiag.HasError(ctx) {
+		return root.ErrAlreadyPrinted
+	}
+
+	client, err := u.WorkspaceClientE()
+	if err != nil {
+		names, isMulti := databrickscfg.AsMultipleProfiles(err)
+		if !isMulti {
+			logdiag.LogError(ctx, err)
+			return root.ErrAlreadyPrinted
+		}
+
+		selected, resolveErr := resolveProfileAmbiguity(cmd, u.Config.Workspace.Host, err, names)
+		if resolveErr != nil {
+			logdiag.LogError(ctx, resolveErr)
+			return root.ErrAlreadyPrinted
+		}
+
+		u.Config.Workspace.Profile = selected
+		u.ClearWorkspaceClient()
+		client, err = u.WorkspaceClientE()
+		if err != nil {
+			logdiag.LogError(ctx, err)
+			return root.ErrAlreadyPrinted
+		}
+	}
+
+	ctx = cmdctx.SetConfigUsed(ctx, client.Config)
+	ctx = cmdctx.SetWorkspaceClient(ctx, client)
+	cmd.SetContext(ctx)
+	return nil
+}
+
+// resolveProfileAmbiguity is the UCM copy of cmd/root/bundle.go:resolveProfileAmbiguity.
+// The DAB version takes a *bundle.Bundle which we can't import here, so we
+// pass the host URL directly — it's the only Bundle field the upstream
+// function actually reads.
+func resolveProfileAmbiguity(cmd *cobra.Command, host string, originalErr error, names []string) (string, error) {
+	ctx := cmd.Context()
+
+	namesMatcher := profile.MatchProfileNames(names...)
+	profiler := profile.GetProfiler(ctx)
+	profiles, err := profiler.LoadProfiles(ctx, func(p profile.Profile) bool {
+		return namesMatcher(p) && profile.MatchWorkspaceProfiles(p)
+	})
+	if err != nil {
+		if errors.Is(err, profile.ErrNoConfiguration) {
+			return "", originalErr
+		}
+		return "", err
+	}
+
+	switch len(profiles) {
+	case 0:
+		return "", originalErr
+	case 1:
+		return profiles[0].Name, nil
+	}
+
+	_, hasProfileFlag := profileFlagValue(cmd)
+	if hasProfileFlag || !cmdio.IsPromptSupported(ctx) {
+		return "", fmt.Errorf(
+			"%w\n\nMatching workspace profiles: %s\n\n"+
+				"Fix (pick one):\n"+
+				"  1. Set profile in ucm.yml:\n"+
+				"       workspace:\n"+
+				"         profile: %s\n"+
+				"  2. Pass a flag:\n"+
+				"       %s --profile %s\n"+
+				"  3. Set env var:\n"+
+				"       DATABRICKS_CONFIG_PROFILE=%s",
+			originalErr,
+			strings.Join(profiles.Names(), ", "),
+			profiles[0].Name,
+			cmd.CommandPath(),
+			profiles[0].Name,
+			profiles[0].Name,
+		)
+	}
+
+	return profile.SelectProfile(ctx, profile.SelectConfig{
+		Label:             "Multiple profiles match host " + host,
+		Profiles:          profiles,
+		StartInSearchMode: true,
+		ActiveTemplate:    `{{.Name | bold}}{{if .AccountID}} (account: {{.AccountID|faint}}){{end}}{{if .WorkspaceID}} (workspace: {{.WorkspaceID|faint}}){{end}}`,
+		InactiveTemplate:  `{{.Name}}{{if .AccountID}} (account: {{.AccountID}}){{end}}{{if .WorkspaceID}} (workspace: {{.WorkspaceID}}){{end}}`,
+		SelectedTemplate:  `{{ "Using profile" | faint }}: {{ .Name | bold }}`,
+	})
+}
+
+func profileFlagValue(cmd *cobra.Command) (string, bool) {
+	flag := cmd.Flag("profile")
+	if flag == nil {
+		return "", false
+	}
+	value := flag.Value.String()
+	return value, value != ""
+}

--- a/cmd/ucm/utils/auth_test.go
+++ b/cmd/ucm/utils/auth_test.go
@@ -1,0 +1,175 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDatabricksCfg mirrors the helper in ucm/workspace_client_test.go.
+func setupDatabricksCfg(t *testing.T) {
+	t.Helper()
+	tempHomeDir := t.TempDir()
+	homeEnvVar := "HOME"
+	if runtime.GOOS == "windows" {
+		homeEnvVar = "USERPROFILE"
+	}
+
+	cfg := []byte(strings.Join([]string{
+		"[PROFILE-UNIQUE]",
+		"host = https://unique.example.com",
+		"token = u",
+		"",
+		"[PROFILE-DUP-1]",
+		"host = https://dup.example.com",
+		"token = d1",
+		"",
+		"[PROFILE-DUP-2]",
+		"host = https://dup.example.com",
+		"token = d2",
+		"",
+	}, "\n"))
+	err := os.WriteFile(filepath.Join(tempHomeDir, ".databrickscfg"), cfg, 0o644)
+	require.NoError(t, err)
+
+	t.Setenv("DATABRICKS_CONFIG_FILE", "")
+	t.Setenv(homeEnvVar, tempHomeDir)
+}
+
+// setupUcmWithHost drops a ucm.yml with the given host into a fresh working
+// directory and returns a *cobra.Command wired for MustWorkspaceClient.
+func setupUcmWithHost(t *testing.T, host string) *cobra.Command {
+	t.Helper()
+	rootPath := t.TempDir()
+	t.Chdir(rootPath)
+
+	y := "ucm:\n  name: t\n\nworkspace:\n  host: " + host + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(rootPath, "ucm.yml"), []byte(y), 0o644))
+
+	cmd := &cobra.Command{Use: "plan"}
+	cmd.PersistentFlags().String("target", "", "")
+	cmd.PersistentFlags().String("profile", "", "")
+
+	ctx := t.Context()
+	ctx = cmdio.MockDiscard(ctx)
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetCollect(ctx, true)
+	cmd.SetContext(ctx)
+	return cmd
+}
+
+func TestMustWorkspaceClient_UniqueHostMatchResolvesProfile(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	// Restrict PATH so the SDK's auth resolution cannot invoke az/gcloud.
+	if runtime.GOOS == "windows" {
+		t.Setenv("PATH", `C:\Windows\System32`)
+	} else {
+		t.Setenv("PATH", "/usr/bin:/bin")
+	}
+	setupDatabricksCfg(t)
+
+	cmd := setupUcmWithHost(t, "https://unique.example.com")
+	err := MustWorkspaceClient(cmd, nil)
+	diags := logdiag.FlushCollected(cmd.Context())
+
+	require.NoError(t, err)
+	require.Empty(t, diags)
+	w := cmdctx.WorkspaceClient(cmd.Context())
+	assert.Equal(t, "PROFILE-UNIQUE", w.Config.Profile)
+	assert.Equal(t, "https://unique.example.com", w.Config.Host)
+}
+
+func TestMustWorkspaceClient_AmbiguousHostReturnsGuidanceError(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	if runtime.GOOS == "windows" {
+		t.Setenv("PATH", `C:\Windows\System32`)
+	} else {
+		t.Setenv("PATH", "/usr/bin:/bin")
+	}
+	setupDatabricksCfg(t)
+
+	cmd := setupUcmWithHost(t, "https://dup.example.com")
+	err := MustWorkspaceClient(cmd, nil)
+	diags := logdiag.FlushCollected(cmd.Context())
+
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, "multiple profiles matched")
+	assert.Contains(t, diags[0].Summary, "Matching workspace profiles")
+	assert.Contains(t, diags[0].Summary, "PROFILE-DUP-1")
+	assert.Contains(t, diags[0].Summary, "PROFILE-DUP-2")
+}
+
+func TestMustWorkspaceClient_NoMatchingProfileDoesNotPrompt(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	if runtime.GOOS == "windows" {
+		t.Setenv("PATH", `C:\Windows\System32`)
+	} else {
+		t.Setenv("PATH", "/usr/bin:/bin")
+	}
+	setupDatabricksCfg(t)
+
+	cmd := setupUcmWithHost(t, "https://nobody.example.com")
+	err := MustWorkspaceClient(cmd, nil)
+	diags := logdiag.FlushCollected(cmd.Context())
+
+	// DAB-parallel behavior: the ResolveProfileFromHost loader swallows
+	// "no matching profiles" so EnsureResolved may succeed with only the host.
+	// The critical invariant is that we never surface the "multi-match"
+	// ambiguity text and never drop into the interactive picker. Either a
+	// clean error or a clean success is acceptable.
+	if err != nil {
+		require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+		require.Len(t, diags, 1)
+		assert.Equal(t, diag.Error, diags[0].Severity)
+		assert.NotContains(t, diags[0].Summary, "Multiple profiles")
+		assert.NotContains(t, diags[0].Summary, "multiple profiles matched")
+		return
+	}
+	assert.Empty(t, diags)
+}
+
+func TestMustWorkspaceClient_ProfileInYamlUsedVerbatim(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	if runtime.GOOS == "windows" {
+		t.Setenv("PATH", `C:\Windows\System32`)
+	} else {
+		t.Setenv("PATH", "/usr/bin:/bin")
+	}
+	setupDatabricksCfg(t)
+
+	rootPath := t.TempDir()
+	t.Chdir(rootPath)
+
+	y := "ucm:\n  name: t\n\nworkspace:\n  host: https://unique.example.com\n  profile: PROFILE-UNIQUE\n"
+	require.NoError(t, os.WriteFile(filepath.Join(rootPath, "ucm.yml"), []byte(y), 0o644))
+
+	cmd := &cobra.Command{Use: "plan"}
+	cmd.PersistentFlags().String("target", "", "")
+	cmd.PersistentFlags().String("profile", "", "")
+	ctx := t.Context()
+	ctx = cmdio.MockDiscard(ctx)
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetCollect(ctx, true)
+	cmd.SetContext(ctx)
+
+	err := MustWorkspaceClient(cmd, nil)
+	diags := logdiag.FlushCollected(cmd.Context())
+
+	require.NoError(t, err)
+	require.Empty(t, diags)
+	w := cmdctx.WorkspaceClient(cmd.Context())
+	assert.Equal(t, "PROFILE-UNIQUE", w.Config.Profile)
+}

--- a/ucm/config/workspace.go
+++ b/ucm/config/workspace.go
@@ -2,9 +2,11 @@ package config
 
 // Workspace describes a Databricks workspace that ucm targets.
 //
-// M0 holds only the host URL. Auth wiring (OAuth M2M client id/secret,
-// account id, profile resolution) lands in M1 along with the real deploy
-// path.
+// M0 holds only the host URL. Profile was added to support the
+// databrickscfg-profile resolution flow mirroring DAB (see
+// ucm/workspace_client.go). Fuller auth wiring (OAuth M2M client id/secret,
+// account id) lands in M1 along with the real deploy path.
 type Workspace struct {
-	Host string `json:"host,omitempty"`
+	Host    string `json:"host,omitempty"`
+	Profile string `json:"profile,omitempty"`
 }

--- a/ucm/ucm.go
+++ b/ucm/ucm.go
@@ -17,6 +17,7 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/databricks-sdk-go"
 )
 
 // RootEnv is the environment variable that pins a ucm root directory,
@@ -34,6 +35,10 @@ type Ucm struct {
 	// Target is the snapshot of the selected target after SelectTarget runs.
 	// nil until a target has been selected.
 	Target *config.Target
+
+	// getClient memoizes the workspace client built from Config.Workspace.
+	// Initialized lazily by WorkspaceClientE via initClientOnce.
+	getClient func() (*databricks.WorkspaceClient, error)
 }
 
 // Load builds a Ucm for the given root path, reading the ucm.yml file

--- a/ucm/workspace_client.go
+++ b/ucm/workspace_client.go
@@ -1,0 +1,91 @@
+package ucm
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/databricks/cli/libs/databrickscfg"
+	"github.com/databricks/databricks-sdk-go"
+	sdkconfig "github.com/databricks/databricks-sdk-go/config"
+)
+
+// workspaceClientConfig builds the SDK config used to construct a workspace
+// client for this Ucm. Mirrors bundle/config.Workspace.Config + Client() with
+// only the subset of auth attributes UCM currently supports.
+func (u *Ucm) workspaceClientConfig() *sdkconfig.Config {
+	return &sdkconfig.Config{
+		Host:    u.Config.Workspace.Host,
+		Profile: u.Config.Workspace.Profile,
+	}
+}
+
+// buildWorkspaceClient resolves auth configuration and constructs a workspace
+// client. Mirrors bundle/config.Workspace.Client(): when only the host is set,
+// we install the ResolveProfileFromHost loader so the SDK picks up a unique
+// matching profile from ~/.databrickscfg. On ambiguity the loader returns the
+// errMultipleProfiles error detected by databrickscfg.AsMultipleProfiles.
+func (u *Ucm) buildWorkspaceClient() (*databricks.WorkspaceClient, error) {
+	cfg := u.workspaceClientConfig()
+
+	if cfg.Host != "" && cfg.Profile == "" {
+		cfg.Loaders = []sdkconfig.Loader{
+			sdkconfig.ConfigAttributes,
+			databrickscfg.ResolveProfileFromHost,
+		}
+	}
+
+	if err := cfg.EnsureResolved(); err != nil {
+		return nil, err
+	}
+
+	if cfg.Host != "" && cfg.Profile != "" {
+		if err := databrickscfg.ValidateConfigAndProfileHost(cfg, cfg.Profile); err != nil {
+			return nil, err
+		}
+	}
+
+	return databricks.NewWorkspaceClient((*databricks.Config)(cfg))
+}
+
+func (u *Ucm) initClientOnce() {
+	u.getClient = sync.OnceValues(func() (*databricks.WorkspaceClient, error) {
+		w, err := u.buildWorkspaceClient()
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve ucm auth configuration: %w", err)
+		}
+		return w, nil
+	})
+}
+
+// WorkspaceClientE returns the memoized workspace client, building it from
+// Config.Workspace on first call.
+func (u *Ucm) WorkspaceClientE() (*databricks.WorkspaceClient, error) {
+	if u.getClient == nil {
+		u.initClientOnce()
+	}
+	return u.getClient()
+}
+
+// WorkspaceClient is the panicking convenience wrapper around WorkspaceClientE.
+// Prefer WorkspaceClientE in new code so callers can surface auth errors.
+func (u *Ucm) WorkspaceClient() *databricks.WorkspaceClient {
+	client, err := u.WorkspaceClientE()
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// SetWorkspaceClient injects a pre-built client, primarily for tests.
+func (u *Ucm) SetWorkspaceClient(w *databricks.WorkspaceClient) {
+	u.getClient = func() (*databricks.WorkspaceClient, error) {
+		return w, nil
+	}
+}
+
+// ClearWorkspaceClient resets the memoized client so the next WorkspaceClientE
+// call rebuilds it. Used after Config.Workspace is mutated (e.g. when a
+// profile is selected via the ambiguity picker).
+func (u *Ucm) ClearWorkspaceClient() {
+	u.initClientOnce()
+}

--- a/ucm/workspace_client_test.go
+++ b/ucm/workspace_client_test.go
@@ -1,0 +1,152 @@
+package ucm
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/cli/libs/databrickscfg"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDatabricksCfg writes a .databrickscfg with a mix of profiles into a
+// temp HOME and points DATABRICKS_CONFIG_FILE at the default location so the
+// SDK's profile loader picks it up. Mirrors cmd/root/bundle_test.go.
+func setupDatabricksCfg(t *testing.T) {
+	t.Helper()
+	tempHomeDir := t.TempDir()
+	homeEnvVar := "HOME"
+	if runtime.GOOS == "windows" {
+		homeEnvVar = "USERPROFILE"
+	}
+
+	cfg := []byte(strings.Join([]string{
+		"[PROFILE-UNIQUE]",
+		"host = https://unique.example.com",
+		"token = u",
+		"",
+		"[PROFILE-DUP-1]",
+		"host = https://dup.example.com",
+		"token = d1",
+		"",
+		"[PROFILE-DUP-2]",
+		"host = https://dup.example.com",
+		"token = d2",
+		"",
+	}, "\n"))
+	err := os.WriteFile(filepath.Join(tempHomeDir, ".databrickscfg"), cfg, 0o644)
+	require.NoError(t, err)
+
+	t.Setenv("DATABRICKS_CONFIG_FILE", "")
+	t.Setenv(homeEnvVar, tempHomeDir)
+}
+
+func TestWorkspaceClientE_UniqueMatchResolvesProfile(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	setupDatabricksCfg(t)
+
+	u := &Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				Host: "https://unique.example.com",
+			},
+		},
+	}
+
+	client, err := u.WorkspaceClientE()
+	require.NoError(t, err)
+	assert.Equal(t, "PROFILE-UNIQUE", client.Config.Profile)
+	assert.Equal(t, "https://unique.example.com", client.Config.Host)
+}
+
+func TestWorkspaceClientE_MultipleMatchesReturnsAmbiguity(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	setupDatabricksCfg(t)
+
+	u := &Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				Host: "https://dup.example.com",
+			},
+		},
+	}
+
+	_, err := u.WorkspaceClientE()
+	require.Error(t, err)
+	names, ok := databrickscfg.AsMultipleProfiles(err)
+	require.True(t, ok, "expected AsMultipleProfiles to detect ambiguity in: %v", err)
+	assert.ElementsMatch(t, []string{"PROFILE-DUP-1", "PROFILE-DUP-2"}, names)
+}
+
+func TestWorkspaceClientE_NoMatchingHost(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	setupDatabricksCfg(t)
+
+	u := &Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				Host: "https://nobody.example.com",
+			},
+		},
+	}
+
+	client, err := u.WorkspaceClientE()
+	// The SDK's ResolveProfileFromHost loader swallows the "no matching
+	// profile" case and returns nil, so subsequent auth depends on env/default
+	// credential chain. What we assert here is that the result is NOT an
+	// ambiguity error — the user must not be dropped into a profile picker.
+	if err != nil {
+		_, isMulti := databrickscfg.AsMultipleProfiles(err)
+		assert.False(t, isMulti, "unexpected ambiguity error for no-match host: %v", err)
+		return
+	}
+	// If no error, the host should still match what we configured and profile
+	// must stay empty (no stealth selection).
+	assert.Equal(t, "https://nobody.example.com", client.Config.Host)
+	assert.Empty(t, client.Config.Profile)
+}
+
+func TestWorkspaceClientE_Memoizes(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	setupDatabricksCfg(t)
+
+	u := &Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				Host: "https://unique.example.com",
+			},
+		},
+	}
+
+	c1, err := u.WorkspaceClientE()
+	require.NoError(t, err)
+	c2, err := u.WorkspaceClientE()
+	require.NoError(t, err)
+	assert.Same(t, c1, c2, "expected WorkspaceClientE to memoize")
+}
+
+func TestWorkspaceClientE_ClearReResolves(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	setupDatabricksCfg(t)
+
+	u := &Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				Host: "https://unique.example.com",
+			},
+		},
+	}
+
+	c1, err := u.WorkspaceClientE()
+	require.NoError(t, err)
+
+	u.ClearWorkspaceClient()
+	c2, err := u.WorkspaceClientE()
+	require.NoError(t, err)
+	assert.NotSame(t, c1, c2, "expected ClearWorkspaceClient to reset memoization")
+}


### PR DESCRIPTION
Closes #45

## Summary

- Add `WorkspaceClientE()` / `WorkspaceClient()` / `ClearWorkspaceClient()` on `*ucm.Ucm` (new `ucm/workspace_client.go`). Mirrors `bundle.Bundle.WorkspaceClient{,E}()` and `bundle/config.Workspace.Client()`, but lives under `ucm/` so we stay clear of the `bundle/**` fork-divergence line.
- Add `Profile` field on `ucm.Workspace` so users (or the ambiguity resolver) can override the host-derived profile.
- Add a UCM-specific `utils.MustWorkspaceClient` PreRunE (new `cmd/ucm/utils/auth.go`) that loads ucm.yml via `ProcessUcm`, builds the workspace client, handles multi-profile ambiguity (via a forked `resolveProfileAmbiguity`), and installs the resolved `*WorkspaceClient` on the command context.
- Rewire `plan` / `deploy` / `destroy` / `summary` to use the new PreRunE. PreRunE (not PersistentPreRunE) is preserved per the regression guard added in #41 / PR #43.

## Why

`root.MustWorkspaceClient` calls `TryConfigureBundle`, which only understands `databricks.yml`. With no bundle loaded, the helper falls through to `workspaceClientOrPrompt` → `AskForWorkspaceProfile`, which is the interactive picker. DAB avoids this because `TryConfigureBundle` both loads the bundle and builds the client from `workspace.host` matched against `~/.databrickscfg`. UCM has its own config and had no equivalent path, so every `ucm plan` with a host-only fixture dropped straight into a profile prompt.

This PR mirrors DAB's `configureBundle` + `resolveProfileAmbiguity` code path inside ucm-owned paths (no imports from `bundle/**`), matching DAB's UX exactly: unique host match → silent; ambiguous host match → guidance error (or picker when attached to a tty); no match → clean error; explicit `workspace.profile` → honored.

## Test plan

- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] New unit tests — `ucm/workspace_client_test.go` covers unique-match / ambiguous-match / no-match / memoize / clear; `cmd/ucm/utils/auth_test.go` covers the end-to-end PreRunE behavior and asserts no profile-picker drops.
- [x] Regression guard — `TestAuthVerbs_UsePreRunE` and `TestUcmSubtree_NoPersistentPreRunE` still pass.
- [x] Binary smoke — `databricks ucm plan` against `cmd/ucm/testdata/valid`:
  - Empty databrickscfg → clean "default auth: cannot configure default credentials" (no picker).
  - databrickscfg with a single matching profile → resolved silently, downstream network error.
  - databrickscfg with multiple matching profiles → user-facing guidance error listing the candidates (no picker).
- [x] No touch to `bundle/**`; only `cmd/ucm/**` + `ucm/**` edited.

This pull request and its description were written by Isaac.