### PR TITLE
Feat #50: Align ucm plan with bundle, direct engine for catalogs/schemas/grants, resolved-auth env

### DIFF
--- a/acceptance/ucm/plan/happy/script
+++ b/acceptance/ucm/plan/happy/script
@@ -1,0 +1,1 @@
+trace $CLI ucm plan

--- a/acceptance/ucm/plan/happy/test.toml
+++ b/acceptance/ucm/plan/happy/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/plan/happy/ucm.yml
+++ b/acceptance/ucm/plan/happy/ucm.yml
@@ -1,0 +1,20 @@
+ucm:
+  name: plan-happy
+  engine: direct
+
+resources:
+  catalogs:
+    main:
+      name: main
+      comment: plan-happy catalog
+
+  schemas:
+    raw:
+      name: raw
+      catalog: main
+
+  grants:
+    analysts:
+      securable: { type: schema, name: main.raw }
+      principal: analysts
+      privileges: [USE_SCHEMA, SELECT]

--- a/acceptance/ucm/plan/json/script
+++ b/acceptance/ucm/plan/json/script
@@ -1,0 +1,1 @@
+trace $CLI ucm plan -o json

--- a/acceptance/ucm/plan/json/test.toml
+++ b/acceptance/ucm/plan/json/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/plan/json/ucm.yml
+++ b/acceptance/ucm/plan/json/ucm.yml
@@ -1,0 +1,8 @@
+ucm:
+  name: plan-json
+  engine: direct
+
+resources:
+  catalogs:
+    main:
+      name: main

--- a/acceptance/ucm/plan/no_changes/script
+++ b/acceptance/ucm/plan/no_changes/script
@@ -1,0 +1,17 @@
+# Seed the direct-engine state file so the upcoming plan sees the catalog as
+# already-applied. The target matches the default that phases.LoadDefaultTarget
+# picks when ucm.yml has no targets section.
+mkdir -p .databricks/ucm/default
+cat > .databricks/ucm/default/resources.json <<'EOF'
+{
+  "version": 1,
+  "catalogs": {
+    "main": {
+      "name": "main",
+      "comment": "plan-no-changes catalog"
+    }
+  }
+}
+EOF
+
+trace $CLI ucm plan

--- a/acceptance/ucm/plan/no_changes/test.toml
+++ b/acceptance/ucm/plan/no_changes/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/plan/no_changes/ucm.yml
+++ b/acceptance/ucm/plan/no_changes/ucm.yml
@@ -1,0 +1,9 @@
+ucm:
+  name: plan-no-changes
+  engine: direct
+
+resources:
+  catalogs:
+    main:
+      name: main
+      comment: plan-no-changes catalog

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -45,15 +45,15 @@ Common invocations:
 			return fmt.Errorf("resolve deploy options: %w", err)
 		}
 
-		result := phases.Plan(ctx, u, opts)
+		outcome := phases.Plan(ctx, u, opts)
 		if logdiag.HasError(ctx) {
 			return root.ErrAlreadyPrinted
 		}
-		if result == nil {
+		if outcome == nil {
 			return root.ErrAlreadyPrinted
 		}
 
-		plan := result.Plan
+		plan := outcome.Plan
 		if plan == nil {
 			plan = deployplan.NewPlanTerraform()
 		}

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -1,11 +1,16 @@
 package ucm
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/deployplan"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/spf13/cobra"
 )
@@ -17,12 +22,13 @@ func newPlanCommand() *cobra.Command {
 		Long: `Preview the changes ucm deploy would make.
 
 Runs the initialize → build → terraform init → terraform plan sequence and
-prints a one-line summary. No state is mutated and no remote resources are
-touched.
+prints a DAB-style action list plus the add/change/delete/unchanged tally.
+No state is mutated and no remote resources are touched.
 
 Common invocations:
   databricks ucm plan                   # Plan against the default target
-  databricks ucm plan --target prod     # Plan against a specific target`,
+  databricks ucm plan --target prod     # Plan against a specific target
+  databricks ucm plan -o json           # Emit the structured plan as JSON`,
 		Args:    root.NoArgs,
 		PreRunE: utils.MustWorkspaceClient,
 	}
@@ -47,9 +53,70 @@ Common invocations:
 			return root.ErrAlreadyPrinted
 		}
 
-		fmt.Fprintln(cmd.OutOrStdout(), result.Summary)
-		return nil
+		plan := result.Plan
+		if plan == nil {
+			plan = deployplan.NewPlanTerraform()
+		}
+
+		out := cmd.OutOrStdout()
+		switch planOutputType(cmd) {
+		case flags.OutputJSON:
+			buf, err := json.MarshalIndent(plan, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(out, string(buf))
+			return nil
+		default:
+			renderPlanText(out, plan)
+			return nil
+		}
 	}
 
 	return cmd
+}
+
+// planOutputType returns the configured -o value, defaulting to OutputText
+// when the flag is not wired (e.g. in standalone unit tests that don't go
+// through root.New). root.OutputType would panic in that case.
+func planOutputType(cmd *cobra.Command) flags.Output {
+	if cmd.Flag("output") == nil {
+		return flags.OutputText
+	}
+	return root.OutputType(cmd)
+}
+
+// renderPlanText prints the DAB-style per-resource action list followed by
+// the `Plan: N to add, ...` tally. Mirrors cmd/bundle/plan.go so ucm plan
+// output is byte-identical to bundle plan for the resources ucm models.
+func renderPlanText(out io.Writer, plan *deployplan.Plan) {
+	createCount, updateCount, deleteCount, unchangedCount := 0, 0, 0, 0
+	for _, change := range plan.GetActions() {
+		switch change.ActionType {
+		case deployplan.Create:
+			createCount++
+		case deployplan.Update, deployplan.UpdateWithID, deployplan.Resize:
+			updateCount++
+		case deployplan.Delete:
+			deleteCount++
+		case deployplan.Recreate:
+			deleteCount++
+			createCount++
+		case deployplan.Skip, deployplan.Undefined:
+			unchangedCount++
+		}
+	}
+
+	totalChanges := createCount + updateCount + deleteCount
+	if totalChanges > 0 {
+		for _, action := range plan.GetActions() {
+			if action.ActionType == deployplan.Skip {
+				continue
+			}
+			key := strings.TrimPrefix(action.ResourceKey, "resources.")
+			fmt.Fprintf(out, "%s %s\n", action.ActionType.StringShort(), key)
+		}
+		fmt.Fprintln(out)
+	}
+	fmt.Fprintf(out, "Plan: %d to add, %d to change, %d to delete, %d unchanged\n", createCount, updateCount, deleteCount, unchangedCount)
 }

--- a/cmd/ucm/plan_smoke_test.go
+++ b/cmd/ucm/plan_smoke_test.go
@@ -12,6 +12,7 @@ import (
 	ucmpkg "github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/deploy/terraform"
 	"github.com/databricks/cli/ucm/deploy/terraform/tfdyn"
+	"github.com/databricks/cli/ucm/deployplan"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,13 +82,25 @@ func assertSmokeGolden(t *testing.T, ctx context.Context, u *ucmpkg.Ucm) {
 // stays wired once PreRunE auth is stripped out for tests.
 func TestCmd_PlanSmoke_VerbHappyPath(t *testing.T) {
 	h := newVerbHarness(t)
-	h.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "smoke plan ready"}
+	h.tf.PlanResult = &terraform.PlanResult{
+		HasChanges: true,
+		Summary:    "smoke plan ready",
+		Plan: &deployplan.Plan{
+			Plan: map[string]*deployplan.PlanEntry{
+				"resources.catalogs.main":    {Action: deployplan.Create},
+				"resources.schemas.main.raw": {Action: deployplan.Create},
+				"resources.grants.analysts":  {Action: deployplan.Update},
+			},
+		},
+	}
 
 	stdout, stderr, err := runVerb(t, filepath.Join("testdata", "deploy_smoke"), "plan")
 	t.Logf("stdout=%q stderr=%q", stdout, stderr)
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "smoke plan ready")
+	assert.Contains(t, stdout, "create catalogs.main")
+	assert.Contains(t, stdout, "update grants.analysts")
+	assert.Contains(t, stdout, "Plan: 2 to add, 1 to change, 0 to delete, 0 unchanged")
 	assert.Equal(t, 1, h.tf.RenderCalls)
 	assert.Equal(t, 1, h.tf.InitCalls)
 	assert.Equal(t, 1, h.tf.PlanCalls)

--- a/cmd/ucm/plan_test.go
+++ b/cmd/ucm/plan_test.go
@@ -1,33 +1,153 @@
 package ucm
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/deployplan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmd_Plan_HappyPathPrintsSummary(t *testing.T) {
+func TestCmd_Plan_HappyPathPrintsDabStyleTally(t *testing.T) {
 	h := newVerbHarness(t)
-	h.tf.PlanResult = &terraform.PlanResult{HasChanges: true, Summary: "plan has changes"}
+	h.tf.PlanResult = &terraform.PlanResult{
+		HasChanges: true,
+		Summary:    "plan has changes",
+		Plan: &deployplan.Plan{
+			Plan: map[string]*deployplan.PlanEntry{
+				"resources.catalogs.main":     {Action: deployplan.Create},
+				"resources.schemas.main.raw":  {Action: deployplan.Create},
+				"resources.grants.analysts":   {Action: deployplan.Update},
+			},
+		},
+	}
 
 	stdout, stderr, err := runVerb(t, validFixtureDir(t), "plan")
 	t.Logf("stdout=%q stderr=%q", stdout, stderr)
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "plan has changes")
+	assert.Contains(t, stdout, "create catalogs.main")
+	assert.Contains(t, stdout, "create schemas.main.raw")
+	assert.Contains(t, stdout, "update grants.analysts")
+	assert.Contains(t, stdout, "Plan: 2 to add, 1 to change, 0 to delete, 0 unchanged")
 	assert.Equal(t, 1, h.tf.RenderCalls)
 	assert.Equal(t, 1, h.tf.InitCalls)
 	assert.Equal(t, 1, h.tf.PlanCalls)
 }
 
-func TestCmd_Plan_NoChangesPrintsSummary(t *testing.T) {
+func TestCmd_Plan_NoChangesPrintsZeroTally(t *testing.T) {
 	h := newVerbHarness(t)
-	h.tf.PlanResult = &terraform.PlanResult{HasChanges: false, Summary: "no changes"}
+	h.tf.PlanResult = &terraform.PlanResult{
+		HasChanges: false,
+		Summary:    "no changes",
+		Plan:       deployplan.NewPlanTerraform(),
+	}
 
 	stdout, _, err := runVerb(t, validFixtureDir(t), "plan")
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "no changes")
+	assert.Contains(t, stdout, "Plan: 0 to add, 0 to change, 0 to delete, 0 unchanged")
+	assert.NotContains(t, stdout, "create")
 }
+
+// TestCmd_Plan_RecreateCountsAsAddAndDelete mirrors DAB's tally accounting
+// where a Recreate contributes to both add and delete counts.
+func TestCmd_Plan_RecreateCountsAsAddAndDelete(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.PlanResult = &terraform.PlanResult{
+		HasChanges: true,
+		Plan: &deployplan.Plan{
+			Plan: map[string]*deployplan.PlanEntry{
+				"resources.catalogs.main": {Action: deployplan.Recreate},
+			},
+		},
+	}
+
+	stdout, _, err := runVerb(t, validFixtureDir(t), "plan")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "recreate catalogs.main")
+	assert.Contains(t, stdout, "Plan: 1 to add, 0 to change, 1 to delete, 0 unchanged")
+}
+
+// TestCmd_Plan_SkipCountsUnchanged verifies Skip/Undefined entries are counted
+// as unchanged and not emitted as action lines.
+func TestCmd_Plan_SkipCountsUnchanged(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.PlanResult = &terraform.PlanResult{
+		HasChanges: false,
+		Plan: &deployplan.Plan{
+			Plan: map[string]*deployplan.PlanEntry{
+				"resources.catalogs.main":    {Action: deployplan.Skip},
+				"resources.schemas.main.raw": {Action: deployplan.Undefined},
+			},
+		},
+	}
+
+	stdout, _, err := runVerb(t, validFixtureDir(t), "plan")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Plan: 0 to add, 0 to change, 0 to delete, 2 unchanged")
+	assert.NotContains(t, stdout, "skip catalogs.main")
+}
+
+func TestRenderPlanText_BucketsAllActionKinds(t *testing.T) {
+	cases := []struct {
+		name    string
+		actions map[string]deployplan.ActionType
+		want    string
+	}{
+		{
+			"update_with_id counts as change",
+			map[string]deployplan.ActionType{"resources.catalogs.a": deployplan.UpdateWithID},
+			"Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged",
+		},
+		{
+			"resize counts as change",
+			map[string]deployplan.ActionType{"resources.catalogs.a": deployplan.Resize},
+			"Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged",
+		},
+		{
+			"delete only",
+			map[string]deployplan.ActionType{"resources.catalogs.a": deployplan.Delete},
+			"Plan: 0 to add, 0 to change, 1 to delete, 0 unchanged",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			plan := deployplan.NewPlanTerraform()
+			for k, a := range c.actions {
+				plan.Plan[k] = &deployplan.PlanEntry{Action: a}
+			}
+			var buf stringBuf
+			renderPlanText(&buf, plan)
+			assert.Contains(t, buf.String(), c.want)
+		})
+	}
+}
+
+// TestCmd_Plan_RoundTripsThroughJSONStructure verifies the structured plan
+// survives the Plan→json.Marshal→json.Unmarshal trip with the same resource
+// keys and action values — the contract tooling consumers depend on.
+func TestCmd_Plan_RoundTripsThroughJSONStructure(t *testing.T) {
+	plan := &deployplan.Plan{
+		Plan: map[string]*deployplan.PlanEntry{
+			"resources.catalogs.main": {Action: deployplan.Create},
+		},
+	}
+	buf, err := json.Marshal(plan)
+	require.NoError(t, err)
+
+	var round deployplan.Plan
+	require.NoError(t, json.Unmarshal(buf, &round))
+	assert.Equal(t, deployplan.Create, round.Plan["resources.catalogs.main"].Action)
+}
+
+// stringBuf is a tiny io.Writer sink used by renderPlanText tests — avoids
+// pulling in bytes.Buffer just for a string accumulator.
+type stringBuf struct{ b []byte }
+
+func (s *stringBuf) Write(p []byte) (int, error) { s.b = append(s.b, p...); return len(p), nil }
+func (s *stringBuf) String() string               { return string(s.b) }

--- a/cmd/ucm/testdata/deploy_smoke/expected.tf.json.golden
+++ b/cmd/ucm/testdata/deploy_smoke/expected.tf.json.golden
@@ -1,4 +1,15 @@
 {
+  "terraform": {
+    "required_providers": {
+      "databricks": {
+        "source": "databricks/databricks",
+        "version": "1.112.0"
+      }
+    }
+  },
+  "provider": {
+    "databricks": {}
+  },
   "resource": {
     "databricks_catalog": {
       "main": {

--- a/ucm/deploy/direct/apply.go
+++ b/ucm/deploy/direct/apply.go
@@ -1,0 +1,374 @@
+package direct
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/deployplan"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+)
+
+// Apply executes the given plan against the provided client, updating state
+// in place as each action succeeds. On a mid-plan error the already-applied
+// state is preserved — the caller is expected to persist state afterwards so
+// a retry sees the partial progress.
+//
+// Execution order is the natural UC dependency order:
+//
+//	catalogs creates+updates → schemas creates+updates → grants reconcile
+//	→ schema deletes → catalog deletes
+//
+// Grants are reconciled per securable in a single pass (Create, Update, and
+// Delete share the code path) because the UC API treats grants as a full
+// replacement of the (principal, privileges) set on a given securable. A
+// per-grant-key plan shape still makes individual additions/removals
+// observable to users in the plan output.
+func Apply(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	if err := applyCatalogCreates(ctx, u, client, plan, state); err != nil {
+		return err
+	}
+	if err := applySchemaCreates(ctx, u, client, plan, state); err != nil {
+		return err
+	}
+	if err := applyGrantChanges(ctx, u, client, plan, state); err != nil {
+		return err
+	}
+	if err := applySchemaDeletes(ctx, client, plan, state); err != nil {
+		return err
+	}
+	if err := applyCatalogDeletes(ctx, client, plan, state); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Destroy builds a plan where every recorded resource gets a Delete action
+// and runs it through Apply. The resulting plan is returned for rendering by
+// the caller.
+func Destroy(ctx context.Context, u *ucm.Ucm, client Client, state *State) (*deployplan.Plan, error) {
+	plan := deployplan.NewPlanTerraform()
+	for key := range state.Grants {
+		plan.Plan["resources.grants."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
+	}
+	for key := range state.Schemas {
+		plan.Plan["resources.schemas."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
+	}
+	for key := range state.Catalogs {
+		plan.Plan["resources.catalogs."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
+	}
+	if err := Apply(ctx, u, client, plan, state); err != nil {
+		return plan, err
+	}
+	return plan, nil
+}
+
+func applyCatalogCreates(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range sortedPlanKeysByGroup(plan, "catalogs") {
+		entry := plan.Plan[key]
+		name := strings.TrimPrefix(key, "resources.catalogs.")
+		cfg := u.Config.Resources.Catalogs[name]
+		switch entry.Action {
+		case deployplan.Create:
+			log.Infof(ctx, "direct: creating catalog %s", name)
+			if _, err := client.CreateCatalog(ctx, catalogCreateInput(cfg)); err != nil {
+				return fmt.Errorf("create catalog %s: %w", name, err)
+			}
+			state.Catalogs[name] = ptrCatalog(catalogStateFromConfig(cfg))
+		case deployplan.Update:
+			log.Infof(ctx, "direct: updating catalog %s", name)
+			if _, err := client.UpdateCatalog(ctx, catalogUpdateInput(cfg)); err != nil {
+				return fmt.Errorf("update catalog %s: %w", name, err)
+			}
+			state.Catalogs[name] = ptrCatalog(catalogStateFromConfig(cfg))
+		}
+	}
+	return nil
+}
+
+func applySchemaCreates(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range sortedPlanKeysByGroup(plan, "schemas") {
+		entry := plan.Plan[key]
+		name := strings.TrimPrefix(key, "resources.schemas.")
+		cfg := u.Config.Resources.Schemas[name]
+		switch entry.Action {
+		case deployplan.Create:
+			log.Infof(ctx, "direct: creating schema %s.%s", cfg.Catalog, cfg.Name)
+			if _, err := client.CreateSchema(ctx, schemaCreateInput(cfg)); err != nil {
+				return fmt.Errorf("create schema %s.%s: %w", cfg.Catalog, cfg.Name, err)
+			}
+			state.Schemas[name] = ptrSchema(schemaStateFromConfig(cfg))
+		case deployplan.Update:
+			log.Infof(ctx, "direct: updating schema %s.%s", cfg.Catalog, cfg.Name)
+			if _, err := client.UpdateSchema(ctx, schemaUpdateInput(cfg)); err != nil {
+				return fmt.Errorf("update schema %s.%s: %w", cfg.Catalog, cfg.Name, err)
+			}
+			state.Schemas[name] = ptrSchema(schemaStateFromConfig(cfg))
+		}
+	}
+	return nil
+}
+
+// applyGrantChanges coalesces every grant Create/Update/Delete by securable
+// and issues one UpdatePermissions call per affected securable carrying the
+// full desired assignment set. The per-key plan entries are preserved in
+// state so the next run can diff individual grants; the batching only
+// affects the apply wire call.
+//
+// All three action kinds go through the same code path: any plan entry on a
+// grant means "reconcile that securable". For a Delete we look up the
+// previously-recorded state to learn which securable the removed key was
+// attached to; for a Create/Update we read it from config.
+func applyGrantChanges(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	touched := touchedGrantSecurables(plan, u.Config.Resources.Grants, state)
+	if len(touched) == 0 {
+		return nil
+	}
+	desired := grantsBySecurable(u.Config.Resources.Grants)
+	for _, sec := range sortSecurables(touched) {
+		log.Infof(ctx, "direct: reconciling grants on %s %s", sec.Type, sec.Name)
+		in := buildUpdatePermissions(sec, desired[sec])
+		in.Changes = append(in.Changes, revocationsForRemovedPrincipals(state, sec, desired[sec])...)
+		if err := client.UpdatePermissions(ctx, in); err != nil {
+			return fmt.Errorf("update grants on %s %s: %w", sec.Type, sec.Name, err)
+		}
+	}
+	for _, key := range sortedPlanKeysByGroup(plan, "grants") {
+		entry := plan.Plan[key]
+		name := strings.TrimPrefix(key, "resources.grants.")
+		switch entry.Action {
+		case deployplan.Create, deployplan.Update:
+			cfg := u.Config.Resources.Grants[name]
+			state.Grants[name] = ptrGrant(grantStateFromConfig(cfg))
+		case deployplan.Delete:
+			delete(state.Grants, name)
+		}
+	}
+	return nil
+}
+
+func applySchemaDeletes(ctx context.Context, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range reverseSortedPlanKeysByGroup(plan, "schemas") {
+		entry := plan.Plan[key]
+		if entry.Action != deployplan.Delete {
+			continue
+		}
+		name := strings.TrimPrefix(key, "resources.schemas.")
+		rec, ok := state.Schemas[name]
+		if !ok {
+			continue
+		}
+		fullName := rec.Catalog + "." + rec.Name
+		log.Infof(ctx, "direct: deleting schema %s", fullName)
+		if err := client.DeleteSchema(ctx, fullName); err != nil {
+			return fmt.Errorf("delete schema %s: %w", fullName, err)
+		}
+		delete(state.Schemas, name)
+	}
+	return nil
+}
+
+func applyCatalogDeletes(ctx context.Context, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range reverseSortedPlanKeysByGroup(plan, "catalogs") {
+		entry := plan.Plan[key]
+		if entry.Action != deployplan.Delete {
+			continue
+		}
+		name := strings.TrimPrefix(key, "resources.catalogs.")
+		rec, ok := state.Catalogs[name]
+		if !ok {
+			continue
+		}
+		log.Infof(ctx, "direct: deleting catalog %s", rec.Name)
+		if err := client.DeleteCatalog(ctx, rec.Name); err != nil {
+			return fmt.Errorf("delete catalog %s: %w", rec.Name, err)
+		}
+		delete(state.Catalogs, name)
+	}
+	return nil
+}
+
+// ---- SDK input builders ----
+
+func catalogCreateInput(c *resources.Catalog) catalog.CreateCatalog {
+	return catalog.CreateCatalog{
+		Name:        c.Name,
+		Comment:     c.Comment,
+		StorageRoot: c.StorageRoot,
+		Properties:  copyTags(c.Tags),
+	}
+}
+
+func catalogUpdateInput(c *resources.Catalog) catalog.UpdateCatalog {
+	return catalog.UpdateCatalog{
+		Name:       c.Name,
+		Comment:    c.Comment,
+		Properties: copyTags(c.Tags),
+	}
+}
+
+func schemaCreateInput(s *resources.Schema) catalog.CreateSchema {
+	return catalog.CreateSchema{
+		Name:        s.Name,
+		CatalogName: s.Catalog,
+		Comment:     s.Comment,
+		Properties:  copyTags(s.Tags),
+	}
+}
+
+func schemaUpdateInput(s *resources.Schema) catalog.UpdateSchema {
+	return catalog.UpdateSchema{
+		FullName:   s.Catalog + "." + s.Name,
+		Comment:    s.Comment,
+		Properties: copyTags(s.Tags),
+	}
+}
+
+func buildUpdatePermissions(sec securable, grants []*resources.Grant) catalog.UpdatePermissions {
+	changes := make([]catalog.PermissionsChange, 0, len(grants))
+	for _, g := range grants {
+		privs := make([]catalog.Privilege, 0, len(g.Privileges))
+		for _, p := range g.Privileges {
+			privs = append(privs, catalog.Privilege(p))
+		}
+		change := catalog.PermissionsChange{
+			Principal: g.Principal,
+			Add:       privs,
+		}
+		if !containsAllPrivileges(privs) {
+			change.Remove = []catalog.Privilege{catalog.PrivilegeAllPrivileges}
+		}
+		changes = append(changes, change)
+	}
+	return catalog.UpdatePermissions{
+		SecurableType: sec.Type,
+		FullName:      sec.Name,
+		Changes:       changes,
+	}
+}
+
+func revocationsForRemovedPrincipals(state *State, sec securable, desiredGrants []*resources.Grant) []catalog.PermissionsChange {
+	desiredPrincipals := make(map[string]struct{}, len(desiredGrants))
+	for _, g := range desiredGrants {
+		desiredPrincipals[g.Principal] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+	var revs []catalog.PermissionsChange
+	for _, g := range state.Grants {
+		if g.SecurableType != sec.Type || g.SecurableName != sec.Name {
+			continue
+		}
+		if _, keep := desiredPrincipals[g.Principal]; keep {
+			continue
+		}
+		if _, dup := seen[g.Principal]; dup {
+			continue
+		}
+		seen[g.Principal] = struct{}{}
+		revs = append(revs, catalog.PermissionsChange{
+			Principal: g.Principal,
+			Remove:    []catalog.Privilege{catalog.PrivilegeAllPrivileges},
+		})
+	}
+	return revs
+}
+
+func containsAllPrivileges(privs []catalog.Privilege) bool {
+	for _, p := range privs {
+		if p == catalog.PrivilegeAllPrivileges {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- helpers ----
+
+// securable is the (type, name) tuple the grants API keys by. The UCM
+// config's Securable carries the same fields — re-defined here to keep the
+// apply-side types in one place.
+type securable struct {
+	Type string
+	Name string
+}
+
+// touchedGrantSecurables returns the set of securables that have at least
+// one grant plan entry whose action requires a reconcile (Create/Update
+// /Delete). The reader resolves key → securable out of config first, falling
+// back to state when the key was only present there (i.e. a Delete).
+func touchedGrantSecurables(plan *deployplan.Plan, desired map[string]*resources.Grant, state *State) map[securable]struct{} {
+	out := map[securable]struct{}{}
+	for _, key := range sortedPlanKeysByGroup(plan, "grants") {
+		entry := plan.Plan[key]
+		switch entry.Action {
+		case deployplan.Create, deployplan.Update, deployplan.Delete:
+		default:
+			continue
+		}
+		name := strings.TrimPrefix(key, "resources.grants.")
+		if cfg, ok := desired[name]; ok {
+			out[securable{Type: cfg.Securable.Type, Name: cfg.Securable.Name}] = struct{}{}
+			continue
+		}
+		if rec, ok := state.Grants[name]; ok {
+			out[securable{Type: rec.SecurableType, Name: rec.SecurableName}] = struct{}{}
+		}
+	}
+	return out
+}
+
+// sortedPlanKeysByGroup returns the plan keys under "resources.<group>." in
+// lexical order. Used to make apply ordering deterministic within a step.
+func sortedPlanKeysByGroup(plan *deployplan.Plan, group string) []string {
+	prefix := "resources." + group + "."
+	var keys []string
+	for k := range plan.Plan {
+		if strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// reverseSortedPlanKeysByGroup returns the same set in reverse order.
+// Used by delete passes so nested resources are torn down before parents.
+func reverseSortedPlanKeysByGroup(plan *deployplan.Plan, group string) []string {
+	keys := sortedPlanKeysByGroup(plan, group)
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+	return keys
+}
+
+// grantsBySecurable indexes config grants by (securable type, name). Used by
+// both the change and the delete pass to compute the full desired assignment
+// set for any touched securable.
+func grantsBySecurable(grants map[string]*resources.Grant) map[securable][]*resources.Grant {
+	out := make(map[securable][]*resources.Grant)
+	for _, g := range grants {
+		sec := securable{Type: g.Securable.Type, Name: g.Securable.Name}
+		out[sec] = append(out[sec], g)
+	}
+	return out
+}
+
+func sortSecurables(set map[securable]struct{}) []securable {
+	out := make([]securable, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Type != out[j].Type {
+			return out[i].Type < out[j].Type
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func ptrCatalog(s CatalogState) *CatalogState { return &s }
+func ptrSchema(s SchemaState) *SchemaState    { return &s }
+func ptrGrant(s GrantState) *GrantState       { return &s }

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -1,0 +1,241 @@
+package direct_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingClient captures every SDK call in order so tests can assert both
+// the set of calls and their sequencing without mocking the wire protocol.
+type recordingClient struct {
+	Calls []string
+
+	CreatedCatalogs []catalog.CreateCatalog
+	UpdatedCatalogs []catalog.UpdateCatalog
+	DeletedCatalogs []string
+
+	CreatedSchemas []catalog.CreateSchema
+	UpdatedSchemas []catalog.UpdateSchema
+	DeletedSchemas []string
+
+	Permissions []catalog.UpdatePermissions
+
+	FailOn string
+}
+
+func (r *recordingClient) trip(op string) error {
+	r.Calls = append(r.Calls, op)
+	if r.FailOn == op {
+		return errors.New("forced")
+	}
+	return nil
+}
+
+func (r *recordingClient) GetCatalog(_ context.Context, _ string) (*catalog.CatalogInfo, error) {
+	return nil, nil
+}
+
+func (r *recordingClient) CreateCatalog(_ context.Context, in catalog.CreateCatalog) (*catalog.CatalogInfo, error) {
+	if err := r.trip("CreateCatalog:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.CreatedCatalogs = append(r.CreatedCatalogs, in)
+	return &catalog.CatalogInfo{Name: in.Name}, nil
+}
+
+func (r *recordingClient) UpdateCatalog(_ context.Context, in catalog.UpdateCatalog) (*catalog.CatalogInfo, error) {
+	if err := r.trip("UpdateCatalog:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.UpdatedCatalogs = append(r.UpdatedCatalogs, in)
+	return &catalog.CatalogInfo{Name: in.Name}, nil
+}
+
+func (r *recordingClient) DeleteCatalog(_ context.Context, name string) error {
+	if err := r.trip("DeleteCatalog:" + name); err != nil {
+		return err
+	}
+	r.DeletedCatalogs = append(r.DeletedCatalogs, name)
+	return nil
+}
+
+func (r *recordingClient) GetSchema(_ context.Context, _ string) (*catalog.SchemaInfo, error) {
+	return nil, nil
+}
+
+func (r *recordingClient) CreateSchema(_ context.Context, in catalog.CreateSchema) (*catalog.SchemaInfo, error) {
+	if err := r.trip("CreateSchema:" + in.CatalogName + "." + in.Name); err != nil {
+		return nil, err
+	}
+	r.CreatedSchemas = append(r.CreatedSchemas, in)
+	return &catalog.SchemaInfo{Name: in.Name, CatalogName: in.CatalogName}, nil
+}
+
+func (r *recordingClient) UpdateSchema(_ context.Context, in catalog.UpdateSchema) (*catalog.SchemaInfo, error) {
+	if err := r.trip("UpdateSchema:" + in.FullName); err != nil {
+		return nil, err
+	}
+	r.UpdatedSchemas = append(r.UpdatedSchemas, in)
+	return &catalog.SchemaInfo{FullName: in.FullName}, nil
+}
+
+func (r *recordingClient) DeleteSchema(_ context.Context, fullName string) error {
+	if err := r.trip("DeleteSchema:" + fullName); err != nil {
+		return err
+	}
+	r.DeletedSchemas = append(r.DeletedSchemas, fullName)
+	return nil
+}
+
+func (r *recordingClient) UpdatePermissions(_ context.Context, in catalog.UpdatePermissions) error {
+	if err := r.trip("UpdatePermissions:" + string(in.SecurableType) + ":" + in.FullName); err != nil {
+		return err
+	}
+	r.Permissions = append(r.Permissions, in)
+	return nil
+}
+
+func TestApply_CreateHappyPath(t *testing.T) {
+	u := ucmWith(
+		map[string]*resources.Catalog{"main": {Name: "main", Comment: "prod"}},
+		map[string]*resources.Schema{"raw": {Name: "raw", Catalog: "main"}},
+		map[string]*resources.Grant{
+			"analysts": {
+				Securable:  resources.Securable{Type: "schema", Name: "main.raw"},
+				Principal:  "analysts",
+				Privileges: []string{"SELECT", "USE_SCHEMA"},
+			},
+		},
+	)
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{
+		"CreateCatalog:main",
+		"CreateSchema:main.raw",
+		"UpdatePermissions:schema:main.raw",
+	}, client.Calls)
+
+	assert.Equal(t, "prod", state.Catalogs["main"].Comment)
+	assert.Equal(t, "main", state.Schemas["raw"].Catalog)
+	require.NotNil(t, state.Grants["analysts"])
+	assert.ElementsMatch(t, []string{"SELECT", "USE_SCHEMA"}, state.Grants["analysts"].Privileges)
+}
+
+func TestApply_GrantCoalescingPerSecurable(t *testing.T) {
+	u := ucmWith(nil, nil, map[string]*resources.Grant{
+		"a_select": {
+			Securable:  resources.Securable{Type: "schema", Name: "main.raw"},
+			Principal:  "analysts",
+			Privileges: []string{"SELECT"},
+		},
+		"b_use": {
+			Securable:  resources.Securable{Type: "schema", Name: "main.raw"},
+			Principal:  "developers",
+			Privileges: []string{"USE_SCHEMA"},
+		},
+	})
+
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	require.Len(t, client.Permissions, 1, "two grants on the same securable must collapse to one call")
+	call := client.Permissions[0]
+	assert.Equal(t, "schema", call.SecurableType)
+	assert.Equal(t, "main.raw", call.FullName)
+	assert.Len(t, call.Changes, 2)
+}
+
+func TestApply_DeleteReversesOrder(t *testing.T) {
+	u := &ucm.Ucm{}
+	state := direct.NewState()
+	state.Catalogs["main"] = &direct.CatalogState{Name: "main"}
+	state.Schemas["raw"] = &direct.SchemaState{Name: "raw", Catalog: "main"}
+	state.Grants["analysts"] = &direct.GrantState{
+		SecurableType: "schema",
+		SecurableName: "main.raw",
+		Principal:     "analysts",
+		Privileges:    []string{"SELECT"},
+	}
+
+	client := &recordingClient{}
+	plan, err := direct.Destroy(t.Context(), u, client, state)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	assert.Equal(t, []string{
+		"UpdatePermissions:schema:main.raw",
+		"DeleteSchema:main.raw",
+		"DeleteCatalog:main",
+	}, client.Calls)
+
+	assert.Empty(t, state.Catalogs)
+	assert.Empty(t, state.Schemas)
+	assert.Empty(t, state.Grants)
+}
+
+func TestApply_PreservesStateOnMidApplyError(t *testing.T) {
+	u := ucmWith(
+		map[string]*resources.Catalog{"main": {Name: "main"}},
+		map[string]*resources.Schema{"raw": {Name: "raw", Catalog: "main"}},
+		nil,
+	)
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{FailOn: "CreateSchema:main.raw"}
+	err := direct.Apply(t.Context(), u, client, plan, state)
+	require.Error(t, err)
+
+	// Catalog create committed before the schema create failed — its state
+	// is kept so the next retry sees the partial progress.
+	assert.NotNil(t, state.Catalogs["main"])
+	assert.Nil(t, state.Schemas["raw"])
+}
+
+func TestApply_RevokesPrincipalsNotInConfig(t *testing.T) {
+	u := ucmWith(nil, nil, map[string]*resources.Grant{
+		"analysts": {
+			Securable:  resources.Securable{Type: "schema", Name: "main.raw"},
+			Principal:  "analysts",
+			Privileges: []string{"SELECT"},
+		},
+	})
+
+	state := direct.NewState()
+	state.Grants["legacy"] = &direct.GrantState{
+		SecurableType: "schema",
+		SecurableName: "main.raw",
+		Principal:     "contractors",
+		Privileges:    []string{"MODIFY"},
+	}
+
+	plan := direct.CalculatePlan(u, state)
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	require.Len(t, client.Permissions, 1)
+	changes := client.Permissions[0].Changes
+
+	var sawRevocation bool
+	for _, c := range changes {
+		if c.Principal == "contractors" && len(c.Remove) > 0 {
+			sawRevocation = true
+		}
+	}
+	assert.True(t, sawRevocation, "removed principals must be revoked in the reconcile call")
+}

--- a/ucm/deploy/direct/client.go
+++ b/ucm/deploy/direct/client.go
@@ -1,0 +1,70 @@
+package direct
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+)
+
+// Client is the narrow SDK surface the direct engine actually exercises.
+// Expressed as an interface so tests can substitute an in-memory fake without
+// standing up the full *databricks.WorkspaceClient.
+type Client interface {
+	GetCatalog(ctx context.Context, name string) (*catalog.CatalogInfo, error)
+	CreateCatalog(ctx context.Context, in catalog.CreateCatalog) (*catalog.CatalogInfo, error)
+	UpdateCatalog(ctx context.Context, in catalog.UpdateCatalog) (*catalog.CatalogInfo, error)
+	DeleteCatalog(ctx context.Context, name string) error
+
+	GetSchema(ctx context.Context, fullName string) (*catalog.SchemaInfo, error)
+	CreateSchema(ctx context.Context, in catalog.CreateSchema) (*catalog.SchemaInfo, error)
+	UpdateSchema(ctx context.Context, in catalog.UpdateSchema) (*catalog.SchemaInfo, error)
+	DeleteSchema(ctx context.Context, fullName string) error
+
+	UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error
+}
+
+// sdkClient adapts *databricks.WorkspaceClient to the Client interface.
+type sdkClient struct{ w *databricks.WorkspaceClient }
+
+// NewClient wraps a workspace client in the narrower Client interface.
+func NewClient(w *databricks.WorkspaceClient) Client {
+	return &sdkClient{w: w}
+}
+
+func (c *sdkClient) GetCatalog(ctx context.Context, name string) (*catalog.CatalogInfo, error) {
+	return c.w.Catalogs.GetByName(ctx, name)
+}
+
+func (c *sdkClient) CreateCatalog(ctx context.Context, in catalog.CreateCatalog) (*catalog.CatalogInfo, error) {
+	return c.w.Catalogs.Create(ctx, in)
+}
+
+func (c *sdkClient) UpdateCatalog(ctx context.Context, in catalog.UpdateCatalog) (*catalog.CatalogInfo, error) {
+	return c.w.Catalogs.Update(ctx, in)
+}
+
+func (c *sdkClient) DeleteCatalog(ctx context.Context, name string) error {
+	return c.w.Catalogs.Delete(ctx, catalog.DeleteCatalogRequest{Name: name, Force: true})
+}
+
+func (c *sdkClient) GetSchema(ctx context.Context, fullName string) (*catalog.SchemaInfo, error) {
+	return c.w.Schemas.GetByFullName(ctx, fullName)
+}
+
+func (c *sdkClient) CreateSchema(ctx context.Context, in catalog.CreateSchema) (*catalog.SchemaInfo, error) {
+	return c.w.Schemas.Create(ctx, in)
+}
+
+func (c *sdkClient) UpdateSchema(ctx context.Context, in catalog.UpdateSchema) (*catalog.SchemaInfo, error) {
+	return c.w.Schemas.Update(ctx, in)
+}
+
+func (c *sdkClient) DeleteSchema(ctx context.Context, fullName string) error {
+	return c.w.Schemas.Delete(ctx, catalog.DeleteSchemaRequest{FullName: fullName, Force: true})
+}
+
+func (c *sdkClient) UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error {
+	_, err := c.w.Grants.Update(ctx, in)
+	return err
+}

--- a/ucm/deploy/direct/path.go
+++ b/ucm/deploy/direct/path.go
@@ -1,0 +1,15 @@
+package direct
+
+import (
+	"path/filepath"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+)
+
+// StatePath returns the canonical on-disk location of the direct-engine
+// state file for u's currently-selected target. Sits beside the terraform
+// engine's own artefacts under `.databricks/ucm/<target>/`.
+func StatePath(u *ucm.Ucm) string {
+	return filepath.Join(u.RootPath, filepath.FromSlash(deploy.LocalCacheDir), u.Config.Ucm.Target, StateFileName)
+}

--- a/ucm/deploy/direct/plan.go
+++ b/ucm/deploy/direct/plan.go
@@ -1,0 +1,160 @@
+// Package direct is the ucm direct-deployment engine. It applies catalogs,
+// schemas, and grants by calling the Databricks SDK directly — no terraform.
+//
+// The package is a ground-up implementation scoped to UCM's three-resource
+// model. It deliberately does not port bundle/direct/** since cmd/ucm/CLAUDE.md
+// forbids bundle imports from ucm/** and the UCM shape is simple enough
+// (three concrete types, linear dependency order, no reference resolution)
+// that a full Adapter/DAG framework would be overkill.
+package direct
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deployplan"
+)
+
+// CalculatePlan produces a deployplan.Plan for the given Ucm and state. The
+// plan compares desired config against the recorded State, emitting:
+//   - Create for keys present in config but absent from state
+//   - Delete for keys present in state but absent from config
+//   - Update for keys present in both when field values differ
+//   - Skip  for keys present in both with identical field values
+//
+// Drift against remote UC objects is intentionally not detected here;
+// double-checking remote state costs O(n) API calls per plan which is
+// disproportionate for the M2 scope. The follow-up task is to layer a
+// remote-read pass on top when we ship volumes/external_locations.
+func CalculatePlan(u *ucm.Ucm, state *State) *deployplan.Plan {
+	plan := deployplan.NewPlanTerraform()
+
+	planCatalogs(u, state, plan)
+	planSchemas(u, state, plan)
+	planGrants(u, state, plan)
+
+	return plan
+}
+
+func planCatalogs(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
+	desired := u.Config.Resources.Catalogs
+	recorded := state.Catalogs
+
+	keys := mergedKeys(desired, recorded)
+	for _, key := range keys {
+		planKey := "resources.catalogs." + key
+
+		cfg, haveCfg := desired[key]
+		rec, haveRec := recorded[key]
+		switch {
+		case haveCfg && !haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Create}
+		case !haveCfg && haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Delete}
+		case catalogStateFromConfig(cfg).equal(rec):
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Skip}
+		default:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Update}
+		}
+	}
+}
+
+func planSchemas(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
+	desired := u.Config.Resources.Schemas
+	recorded := state.Schemas
+
+	keys := mergedKeys(desired, recorded)
+	for _, key := range keys {
+		planKey := "resources.schemas." + key
+
+		cfg, haveCfg := desired[key]
+		rec, haveRec := recorded[key]
+		switch {
+		case haveCfg && !haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Create}
+		case !haveCfg && haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Delete}
+		case schemaStateFromConfig(cfg).equal(rec):
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Skip}
+		default:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Update}
+		}
+	}
+}
+
+func planGrants(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
+	desired := u.Config.Resources.Grants
+	recorded := state.Grants
+
+	keys := mergedKeys(desired, recorded)
+	for _, key := range keys {
+		planKey := "resources.grants." + key
+
+		cfg, haveCfg := desired[key]
+		rec, haveRec := recorded[key]
+		switch {
+		case haveCfg && !haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Create}
+		case !haveCfg && haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Delete}
+		case grantStateFromConfig(cfg).equal(rec):
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Skip}
+		default:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Update}
+		}
+	}
+}
+
+// mergedKeys returns a sorted list of keys present in either map. Sorting
+// keeps plan output stable across runs and matches the deployplan.GetActions
+// discipline of emitting actions in lexical order.
+func mergedKeys[V any, W any](a map[string]V, b map[string]W) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// equal is provided as methods on the state types so the planner stays
+// declarative (one line per comparison) and the notion of equality for each
+// resource type lives next to the state struct rather than scattered across
+// the planner.
+func (s CatalogState) equal(other *CatalogState) bool {
+	return other != nil && reflect.DeepEqual(s, *other)
+}
+
+func (s SchemaState) equal(other *SchemaState) bool {
+	return other != nil && reflect.DeepEqual(s, *other)
+}
+
+func (s GrantState) equal(other *GrantState) bool {
+	if other == nil {
+		return false
+	}
+	left := normalizedGrant(s)
+	right := normalizedGrant(*other)
+	return reflect.DeepEqual(left, right)
+}
+
+// normalizedGrant returns a copy of g with privileges sorted. The SDK sorts
+// privileges server-side; normalizing before comparison avoids spurious
+// Updates when the user reorders the config entries.
+func normalizedGrant(g GrantState) GrantState {
+	if len(g.Privileges) > 0 {
+		privs := make([]string, len(g.Privileges))
+		copy(privs, g.Privileges)
+		sort.Strings(privs)
+		g.Privileges = privs
+	}
+	return g
+}

--- a/ucm/deploy/direct/plan_test.go
+++ b/ucm/deploy/direct/plan_test.go
@@ -1,0 +1,146 @@
+package direct_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/deployplan"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculatePlan_EmptyConfigAndState(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	plan := direct.CalculatePlan(u, direct.NewState())
+	assert.Empty(t, plan.Plan)
+}
+
+func TestCalculatePlan_CreatesWhenStateEmpty(t *testing.T) {
+	u := ucmWith(
+		map[string]*resources.Catalog{"main": {Name: "main"}},
+		map[string]*resources.Schema{"raw": {Name: "raw", Catalog: "main"}},
+		map[string]*resources.Grant{
+			"analysts": {
+				Securable:  resources.Securable{Type: "schema", Name: "main.raw"},
+				Principal:  "analysts",
+				Privileges: []string{"USE_SCHEMA", "SELECT"},
+			},
+		},
+	)
+
+	plan := direct.CalculatePlan(u, direct.NewState())
+
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.catalogs.main"].Action)
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.schemas.raw"].Action)
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.grants.analysts"].Action)
+}
+
+func TestCalculatePlan_DeletesWhenConfigEmpty(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	state := direct.NewState()
+	state.Catalogs["main"] = &direct.CatalogState{Name: "main"}
+	state.Schemas["raw"] = &direct.SchemaState{Name: "raw", Catalog: "main"}
+	state.Grants["analysts"] = &direct.GrantState{
+		SecurableType: "schema",
+		SecurableName: "main.raw",
+		Principal:     "analysts",
+		Privileges:    []string{"SELECT"},
+	}
+
+	plan := direct.CalculatePlan(u, state)
+
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.catalogs.main"].Action)
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.schemas.raw"].Action)
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.grants.analysts"].Action)
+}
+
+func TestCalculatePlan_SkipsUnchangedEntries(t *testing.T) {
+	u := ucmWith(
+		map[string]*resources.Catalog{"main": {Name: "main", Comment: "prod"}},
+		map[string]*resources.Schema{"raw": {Name: "raw", Catalog: "main"}},
+		map[string]*resources.Grant{
+			"analysts": {
+				Securable:  resources.Securable{Type: "schema", Name: "main.raw"},
+				Principal:  "analysts",
+				Privileges: []string{"SELECT"},
+			},
+		},
+	)
+
+	state := direct.NewState()
+	state.Catalogs["main"] = &direct.CatalogState{Name: "main", Comment: "prod"}
+	state.Schemas["raw"] = &direct.SchemaState{Name: "raw", Catalog: "main"}
+	state.Grants["analysts"] = &direct.GrantState{
+		SecurableType: "schema",
+		SecurableName: "main.raw",
+		Principal:     "analysts",
+		Privileges:    []string{"SELECT"},
+	}
+
+	plan := direct.CalculatePlan(u, state)
+
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.catalogs.main"].Action)
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.schemas.raw"].Action)
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.grants.analysts"].Action)
+}
+
+func TestCalculatePlan_UpdatesOnFieldDrift(t *testing.T) {
+	u := ucmWith(
+		map[string]*resources.Catalog{"main": {Name: "main", Comment: "new"}},
+		map[string]*resources.Schema{"raw": {Name: "raw", Catalog: "main", Comment: "new"}},
+		map[string]*resources.Grant{
+			"analysts": {
+				Securable:  resources.Securable{Type: "schema", Name: "main.raw"},
+				Principal:  "analysts",
+				Privileges: []string{"SELECT", "MODIFY"},
+			},
+		},
+	)
+
+	state := direct.NewState()
+	state.Catalogs["main"] = &direct.CatalogState{Name: "main", Comment: "old"}
+	state.Schemas["raw"] = &direct.SchemaState{Name: "raw", Catalog: "main", Comment: "old"}
+	state.Grants["analysts"] = &direct.GrantState{
+		SecurableType: "schema",
+		SecurableName: "main.raw",
+		Principal:     "analysts",
+		Privileges:    []string{"SELECT"},
+	}
+
+	plan := direct.CalculatePlan(u, state)
+
+	assert.Equal(t, deployplan.Update, plan.Plan["resources.catalogs.main"].Action)
+	assert.Equal(t, deployplan.Update, plan.Plan["resources.schemas.raw"].Action)
+	assert.Equal(t, deployplan.Update, plan.Plan["resources.grants.analysts"].Action)
+}
+
+func TestCalculatePlan_PrivilegeReorderIsSkip(t *testing.T) {
+	u := ucmWith(nil, nil, map[string]*resources.Grant{
+		"analysts": {
+			Securable:  resources.Securable{Type: "schema", Name: "main.raw"},
+			Principal:  "analysts",
+			Privileges: []string{"MODIFY", "SELECT"},
+		},
+	})
+
+	state := direct.NewState()
+	state.Grants["analysts"] = &direct.GrantState{
+		SecurableType: "schema",
+		SecurableName: "main.raw",
+		Principal:     "analysts",
+		Privileges:    []string{"SELECT", "MODIFY"},
+	}
+
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.grants.analysts"].Action)
+}
+
+func ucmWith(catalogs map[string]*resources.Catalog, schemas map[string]*resources.Schema, grants map[string]*resources.Grant) *ucm.Ucm {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Catalogs = catalogs
+	u.Config.Resources.Schemas = schemas
+	u.Config.Resources.Grants = grants
+	return u
+}

--- a/ucm/deploy/direct/snapshot.go
+++ b/ucm/deploy/direct/snapshot.go
@@ -1,0 +1,59 @@
+package direct
+
+import (
+	"github.com/databricks/cli/ucm/config/resources"
+)
+
+// Snapshot-helpers live in their own file so plan.go (the diff logic) stays
+// focused on the Create/Update/Skip/Delete decision tree. Each helper takes
+// a pointer into the loaded ucm config and returns the comparable state
+// representation.
+
+func catalogStateFromConfig(c *resources.Catalog) CatalogState {
+	if c == nil {
+		return CatalogState{}
+	}
+	return CatalogState{
+		Name:        c.Name,
+		Comment:     c.Comment,
+		StorageRoot: c.StorageRoot,
+		Tags:        copyTags(c.Tags),
+	}
+}
+
+func schemaStateFromConfig(s *resources.Schema) SchemaState {
+	if s == nil {
+		return SchemaState{}
+	}
+	return SchemaState{
+		Name:    s.Name,
+		Catalog: s.Catalog,
+		Comment: s.Comment,
+		Tags:    copyTags(s.Tags),
+	}
+}
+
+func grantStateFromConfig(g *resources.Grant) GrantState {
+	if g == nil {
+		return GrantState{}
+	}
+	privs := make([]string, len(g.Privileges))
+	copy(privs, g.Privileges)
+	return GrantState{
+		SecurableType: g.Securable.Type,
+		SecurableName: g.Securable.Name,
+		Principal:     g.Principal,
+		Privileges:    privs,
+	}
+}
+
+func copyTags(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(tags))
+	for k, v := range tags {
+		out[k] = v
+	}
+	return out
+}

--- a/ucm/deploy/direct/state.go
+++ b/ucm/deploy/direct/state.go
@@ -1,0 +1,122 @@
+package direct
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// StateVersion is bumped on incompatible changes to the on-disk state shape.
+// Direct-engine state is strictly a local cache — there is no remote mirror,
+// unlike terraform state — but the versioning discipline is retained so that
+// an older CLI refuses to read a newer format.
+const StateVersion = 1
+
+// StateFileName is the per-target file where direct-engine recorded state is
+// persisted. Sits next to (but independent of) the terraform-engine artifacts
+// under `.databricks/ucm/<target>/`.
+const StateFileName = "resources.json"
+
+// State is the recorded snapshot of every resource the direct engine has
+// successfully applied. Keys match the plan's per-resource keys so the
+// next plan can diff desired vs recorded by a simple map lookup.
+type State struct {
+	Version  int                      `json:"version"`
+	Catalogs map[string]*CatalogState `json:"catalogs,omitempty"`
+	Schemas  map[string]*SchemaState  `json:"schemas,omitempty"`
+	Grants   map[string]*GrantState   `json:"grants,omitempty"`
+}
+
+// CatalogState is what the direct engine records for a catalog after a
+// successful apply. Shape mirrors the slice of fields the UCM catalog
+// resource currently models — expand only as the resource model grows.
+type CatalogState struct {
+	Name        string            `json:"name"`
+	Comment     string            `json:"comment,omitempty"`
+	StorageRoot string            `json:"storage_root,omitempty"`
+	Tags        map[string]string `json:"tags,omitempty"`
+}
+
+// SchemaState mirrors CatalogState's discipline for the schema resource.
+type SchemaState struct {
+	Name    string            `json:"name"`
+	Catalog string            `json:"catalog"`
+	Comment string            `json:"comment,omitempty"`
+	Tags    map[string]string `json:"tags,omitempty"`
+}
+
+// GrantState records a single grant's inputs. Grants are keyed in UCM config
+// by arbitrary user-chosen keys; the (securable, principal, privileges) triple
+// is the semantic identity we compare when planning.
+type GrantState struct {
+	SecurableType string   `json:"securable_type"`
+	SecurableName string   `json:"securable_name"`
+	Principal     string   `json:"principal"`
+	Privileges    []string `json:"privileges"`
+}
+
+// NewState returns an empty State ready to be populated by the planner.
+func NewState() *State {
+	return &State{
+		Version:  StateVersion,
+		Catalogs: make(map[string]*CatalogState),
+		Schemas:  make(map[string]*SchemaState),
+		Grants:   make(map[string]*GrantState),
+	}
+}
+
+// LoadState reads the recorded direct-engine state from the given path.
+// Returns (NewState(), nil) when the file is absent — first-run is not an
+// error for the direct engine (unlike terraform which requires init first).
+func LoadState(path string) (*State, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return NewState(), nil
+		}
+		return nil, fmt.Errorf("read direct state %s: %w", path, err)
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse direct state %s: %w", path, err)
+	}
+	if s.Version > StateVersion {
+		return nil, fmt.Errorf("direct state %s: version %d > supported %d; upgrade the CLI", path, s.Version, StateVersion)
+	}
+	if s.Catalogs == nil {
+		s.Catalogs = make(map[string]*CatalogState)
+	}
+	if s.Schemas == nil {
+		s.Schemas = make(map[string]*SchemaState)
+	}
+	if s.Grants == nil {
+		s.Grants = make(map[string]*GrantState)
+	}
+	return &s, nil
+}
+
+// SaveState writes state atomically (write to a sibling tmp file, then rename)
+// so a crash mid-write never leaves behind a truncated blob.
+func SaveState(path string, s *State) error {
+	if s.Version == 0 {
+		s.Version = StateVersion
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create dir for %s: %w", path, err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal direct state: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write direct state tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace direct state %s: %w", path, err)
+	}
+	return nil
+}

--- a/ucm/deploy/direct/state_test.go
+++ b/ucm/deploy/direct/state_test.go
@@ -1,0 +1,51 @@
+package direct_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadState_MissingFileReturnsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resources.json")
+	s, err := direct.LoadState(path)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Empty(t, s.Catalogs)
+	assert.Empty(t, s.Schemas)
+	assert.Empty(t, s.Grants)
+}
+
+func TestLoadState_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resources.json")
+	in := direct.NewState()
+	in.Catalogs["main"] = &direct.CatalogState{Name: "main", Comment: "prod"}
+	in.Schemas["raw"] = &direct.SchemaState{Name: "raw", Catalog: "main"}
+	in.Grants["analysts"] = &direct.GrantState{
+		SecurableType: "schema",
+		SecurableName: "main.raw",
+		Principal:     "analysts",
+		Privileges:    []string{"SELECT"},
+	}
+
+	require.NoError(t, direct.SaveState(path, in))
+
+	out, err := direct.LoadState(path)
+	require.NoError(t, err)
+	assert.Equal(t, in.Catalogs, out.Catalogs)
+	assert.Equal(t, in.Schemas, out.Schemas)
+	assert.Equal(t, in.Grants, out.Grants)
+}
+
+func TestLoadState_RejectsFutureVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resources.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"version":99}`), 0o644))
+
+	_, err := direct.LoadState(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version 99")
+}

--- a/ucm/deploy/terraform/fakerunner_test.go
+++ b/ucm/deploy/terraform/fakerunner_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
 // fakeRunner is a stand-in for *tfexec.Terraform used by the init/plan/apply
@@ -14,11 +15,12 @@ import (
 type fakeRunner struct {
 	mu sync.Mutex
 
-	InitCalls    int
-	PlanCalls    int
-	ApplyCalls   int
-	DestroyCalls int
-	SetEnvCalls  int
+	InitCalls         int
+	PlanCalls         int
+	ShowPlanFileCalls int
+	ApplyCalls        int
+	DestroyCalls      int
+	SetEnvCalls       int
 
 	// LastEnv captures the map passed to the most recent SetEnv call.
 	LastEnv map[string]string
@@ -27,12 +29,17 @@ type fakeRunner struct {
 
 	// PlanHasChanges is returned by Plan.
 	PlanHasChanges bool
-	// ApplyErr, InitErr, DestroyErr, PlanErr make the next corresponding
-	// call return the given error.
-	InitErr    error
-	PlanErr    error
-	ApplyErr   error
-	DestroyErr error
+	// ShowPlanResult is returned by ShowPlanFile. nil yields an empty plan
+	// (no resource changes) so callers don't need to set it for zero-diff
+	// tests.
+	ShowPlanResult *tfjson.Plan
+	// ApplyErr, InitErr, DestroyErr, PlanErr, ShowPlanFileErr make the next
+	// corresponding call return the given error.
+	InitErr          error
+	PlanErr          error
+	ShowPlanFileErr  error
+	ApplyErr         error
+	DestroyErr       error
 
 	// ApplyHook is invoked synchronously inside Apply before returning. Used
 	// by the lock contention test to hold the lock while a second goroutine
@@ -55,6 +62,18 @@ func (f *fakeRunner) Plan(_ context.Context, _ ...tfexec.PlanOption) (bool, erro
 	changes := f.PlanHasChanges
 	f.mu.Unlock()
 	return changes, err
+}
+
+func (f *fakeRunner) ShowPlanFile(_ context.Context, _ string, _ ...tfexec.ShowOption) (*tfjson.Plan, error) {
+	f.mu.Lock()
+	f.ShowPlanFileCalls++
+	err := f.ShowPlanFileErr
+	plan := f.ShowPlanResult
+	f.mu.Unlock()
+	if plan == nil {
+		plan = &tfjson.Plan{}
+	}
+	return plan, err
 }
 
 func (f *fakeRunner) Apply(ctx context.Context, opts ...tfexec.ApplyOption) error {

--- a/ucm/deploy/terraform/pkg.go
+++ b/ucm/deploy/terraform/pkg.go
@@ -25,6 +25,23 @@ const MainConfigFileName = "main.tf.json"
 // have one fewer divergence to remember.
 const PlanFileName = "plan"
 
+// ProviderSource is the fully-qualified source address of the databricks
+// terraform provider. Written into the `terraform.required_providers` block
+// so `terraform init` resolves the provider out of the databricks namespace
+// rather than the default hashicorp namespace (which has no databricks
+// provider). Kept in lockstep with bundle/internal/tf/schema.ProviderSource
+// but duplicated here to honour the ucm fork-divergence rule (no imports
+// from bundle/**).
+const ProviderSource = "databricks/databricks"
+
+// ProviderVersion pins the databricks terraform provider version ucm
+// renders into main.tf.json. Temporarily held one minor behind the DABs
+// pin (1.113.0) because the internal terraform-proxy.dev.databricks.com
+// mirror tops out at 1.112.0 at the time of writing. Bump back to match
+// bundle/internal/tf/schema.ProviderVersion once the internal mirror
+// catches up.
+const ProviderVersion = "1.112.0"
+
 // Terraform CLI override env vars. Same wire names as bundle/deploy/terraform
 // so a user's DATABRICKS_TF_EXEC_PATH works for both subcommands.
 const (

--- a/ucm/deploy/terraform/plan.go
+++ b/ucm/deploy/terraform/plan.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deployplan"
 	"github.com/hashicorp/terraform-exec/tfexec"
 )
 
@@ -18,9 +19,13 @@ type PlanResult struct {
 	PlanPath string
 	// HasChanges is true when terraform plan detected at least one change.
 	HasChanges bool
-	// Summary is a one-line human-readable summary ("plan: N change(s)" or
-	// "no changes").
+	// Summary is a one-line human-readable summary ("plan has changes" /
+	// "no changes"). Retained for callers/tests that only care about the
+	// legacy one-liner.
 	Summary string
+	// Plan is the DAB-parity structured plan, populated by translating the
+	// saved plan file. Empty when there are no changes.
+	Plan *deployplan.Plan
 }
 
 // Plan runs `terraform plan -out=<planfile>` in the working directory after
@@ -45,10 +50,16 @@ func (t *Terraform) Plan(ctx context.Context, u *ucm.Ucm) (*PlanResult, error) {
 	t.lastPlanPath = planPath
 	t.lastPlanExists = true
 
+	tfPlan, err := t.runner.ShowPlanFile(ctx, planPath)
+	if err != nil {
+		return nil, fmt.Errorf("terraform show plan: %w", err)
+	}
+
 	result := &PlanResult{
 		PlanPath:   planPath,
 		HasChanges: hasChanges,
 		Summary:    planSummary(hasChanges),
+		Plan:       translatePlan(ctx, tfPlan),
 	}
 	log.Infof(ctx, "terraform plan: %s (at %s)", result.Summary, filepath.ToSlash(planPath))
 	return result, nil

--- a/ucm/deploy/terraform/render_test.go
+++ b/ucm/deploy/terraform/render_test.go
@@ -16,6 +16,17 @@ import (
 // exactly — converters emit keys in insertion order and jsonsaver preserves
 // that order.
 const golden = `{
+  "terraform": {
+    "required_providers": {
+      "databricks": {
+        "source": "databricks/databricks",
+        "version": "1.112.0"
+      }
+    }
+  },
+  "provider": {
+    "databricks": {}
+  },
   "resource": {
     "databricks_catalog": {
       "sales": {

--- a/ucm/deploy/terraform/showplan.go
+++ b/ucm/deploy/terraform/showplan.go
@@ -1,0 +1,74 @@
+package terraform
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm/deployplan"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// terraformToGroupName maps a databricks_* terraform resource type back to the
+// ucm resource group key used under `resources.<group>.<name>`. ucm currently
+// emits only these three; extend here when new tfdyn converters land.
+//
+// Forked from bundle/deploy/terraform's TerraformToGroupName map rather than
+// imported — the DAB map covers jobs/pipelines/etc but not databricks_catalog,
+// and pinning to a bundle map will drift as upstream adds resources ucm does
+// not model. See cmd/ucm/CLAUDE.md on fork isolation.
+var terraformToGroupName = map[string]string{
+	"databricks_catalog": "catalogs",
+	"databricks_schema":  "schemas",
+	"databricks_grants":  "grants",
+}
+
+// populatePlan fills `plan` from terraform resource changes using the
+// ucm resource-key convention. Unknown resource types are logged and skipped
+// so a stray TF resource (e.g. a provider added a new type) doesn't hard-fail
+// the command.
+func populatePlan(ctx context.Context, plan *deployplan.Plan, changes []*tfjson.ResourceChange) {
+	for _, rc := range changes {
+		if rc.Change == nil {
+			continue
+		}
+
+		var actionType deployplan.ActionType
+		switch {
+		case rc.Change.Actions.Delete():
+			actionType = deployplan.Delete
+		case rc.Change.Actions.Replace():
+			actionType = deployplan.Recreate
+		case rc.Change.Actions.Create():
+			actionType = deployplan.Create
+		case rc.Change.Actions.Update():
+			actionType = deployplan.Update
+		case rc.Change.Actions.NoOp():
+			actionType = deployplan.Skip
+		default:
+			continue
+		}
+
+		group, ok := terraformToGroupName[rc.Type]
+		if !ok {
+			log.Warnf(ctx, "unknown resource type %q", rc.Type)
+			continue
+		}
+
+		key := "resources." + group + "." + rc.Name
+
+		if existing, ok := plan.Plan[key]; ok {
+			existing.Action = deployplan.GetHigherAction(existing.Action, actionType)
+		} else {
+			plan.Plan[key] = &deployplan.PlanEntry{Action: actionType}
+		}
+	}
+}
+
+// translatePlan turns a parsed terraform plan into a ucm deployplan.Plan.
+// Mirrors bundle/deploy/terraform.ShowPlanFile's tail half; the show-plan
+// read itself lives on the runner so tests can stub it.
+func translatePlan(ctx context.Context, tfPlan *tfjson.Plan) *deployplan.Plan {
+	plan := deployplan.NewPlanTerraform()
+	populatePlan(ctx, plan, tfPlan.ResourceChanges)
+	return plan
+}

--- a/ucm/deploy/terraform/showplan_test.go
+++ b/ucm/deploy/terraform/showplan_test.go
@@ -1,0 +1,92 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/deployplan"
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/stretchr/testify/assert"
+)
+
+func change(actions tfjson.Actions) *tfjson.Change {
+	return &tfjson.Change{Actions: actions}
+}
+
+func TestPopulatePlan_MapsActionsAndKeys(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	plan := deployplan.NewPlanTerraform()
+
+	populatePlan(ctx, plan, []*tfjson.ResourceChange{
+		{Type: "databricks_catalog", Name: "main", Change: change(tfjson.Actions{tfjson.ActionCreate})},
+		{Type: "databricks_schema", Name: "sales_raw", Change: change(tfjson.Actions{tfjson.ActionUpdate})},
+		{Type: "databricks_grants", Name: "analysts", Change: change(tfjson.Actions{tfjson.ActionDelete})},
+	})
+
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.catalogs.main"].Action)
+	assert.Equal(t, deployplan.Update, plan.Plan["resources.schemas.sales_raw"].Action)
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.grants.analysts"].Action)
+}
+
+func TestPopulatePlan_ReplaceBecomesRecreate(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	plan := deployplan.NewPlanTerraform()
+
+	populatePlan(ctx, plan, []*tfjson.ResourceChange{
+		{Type: "databricks_catalog", Name: "main", Change: change(tfjson.Actions{tfjson.ActionDelete, tfjson.ActionCreate})},
+	})
+
+	assert.Equal(t, deployplan.Recreate, plan.Plan["resources.catalogs.main"].Action)
+}
+
+func TestPopulatePlan_NoOpBecomesSkip(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	plan := deployplan.NewPlanTerraform()
+
+	populatePlan(ctx, plan, []*tfjson.ResourceChange{
+		{Type: "databricks_catalog", Name: "main", Change: change(tfjson.Actions{tfjson.ActionNoop})},
+	})
+
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.catalogs.main"].Action)
+}
+
+// TestPopulatePlan_UnknownTypeIsSkipped guards the "new TF resource type from
+// an upgraded provider" case — a warning is logged and the plan is unchanged
+// rather than hard-failing the verb.
+func TestPopulatePlan_UnknownTypeIsSkipped(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	plan := deployplan.NewPlanTerraform()
+
+	populatePlan(ctx, plan, []*tfjson.ResourceChange{
+		{Type: "databricks_nonexistent", Name: "x", Change: change(tfjson.Actions{tfjson.ActionCreate})},
+	})
+
+	assert.Empty(t, plan.Plan)
+}
+
+// TestPopulatePlan_MergesHigherSeverity mirrors bundle's GetHigherAction-based
+// merging for the edge case where a single resource key appears twice with
+// different actions (a defensive invariant — ucm tfdyn shouldn't emit dupes).
+func TestPopulatePlan_MergesHigherSeverity(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	plan := deployplan.NewPlanTerraform()
+
+	populatePlan(ctx, plan, []*tfjson.ResourceChange{
+		{Type: "databricks_catalog", Name: "main", Change: change(tfjson.Actions{tfjson.ActionUpdate})},
+		{Type: "databricks_catalog", Name: "main", Change: change(tfjson.Actions{tfjson.ActionDelete})},
+	})
+
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.catalogs.main"].Action)
+}
+
+func TestTranslatePlan_WrapsPopulate(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	tfPlan := &tfjson.Plan{
+		ResourceChanges: []*tfjson.ResourceChange{
+			{Type: "databricks_catalog", Name: "main", Change: change(tfjson.Actions{tfjson.ActionCreate})},
+		},
+	}
+
+	plan := translatePlan(ctx, tfPlan)
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.catalogs.main"].Action)
+}

--- a/ucm/deploy/terraform/terraform.go
+++ b/ucm/deploy/terraform/terraform.go
@@ -16,6 +16,7 @@ import (
 	"github.com/databricks/cli/ucm/deploy/lock"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
 // tfRunner is the minimal terraform-exec surface used by the wrapper.
@@ -24,6 +25,7 @@ import (
 type tfRunner interface {
 	Init(ctx context.Context, opts ...tfexec.InitOption) error
 	Plan(ctx context.Context, opts ...tfexec.PlanOption) (bool, error)
+	ShowPlanFile(ctx context.Context, planPath string, opts ...tfexec.ShowOption) (*tfjson.Plan, error)
 	Apply(ctx context.Context, opts ...tfexec.ApplyOption) error
 	Destroy(ctx context.Context, opts ...tfexec.DestroyOption) error
 	SetEnv(env map[string]string) error

--- a/ucm/deploy/terraform/terraform.go
+++ b/ucm/deploy/terraform/terraform.go
@@ -10,10 +10,12 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/databricks/cli/libs/auth"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
@@ -86,7 +88,11 @@ func New(ctx context.Context, u *ucm.Ucm) (*Terraform, error) {
 		return nil, err
 	}
 
-	envMap := buildEnv(ctx)
+	authCfg, err := resolveAuthConfig(u)
+	if err != nil {
+		return nil, err
+	}
+	envMap := buildEnv(ctx, authCfg)
 
 	user, lockDir := lockIdentity(ctx, u)
 
@@ -142,16 +148,36 @@ func resolveExecPath(ctx context.Context, workingDir string, installer Installer
 	return path, nil
 }
 
+// resolveAuthConfig resolves the workspace client for u and returns its SDK
+// config. The resolved config is the canonical snapshot of which auth method
+// fired (profile vs env vs OAuth cache) — buildEnv materializes it into
+// DATABRICKS_* env vars so the terraform subprocess inherits the same auth
+// regardless of how the parent CLI got there. Mirrors bundle.AuthEnv (see
+// bundle/bundle.go).
+func resolveAuthConfig(u *ucm.Ucm) (*config.Config, error) {
+	if u == nil {
+		return nil, nil
+	}
+	w, err := u.WorkspaceClientE()
+	if err != nil {
+		return nil, fmt.Errorf("resolve ucm auth for terraform: %w", err)
+	}
+	return w.Config, nil
+}
+
 // buildEnv assembles the env map passed to terraform-exec.
 //
-// It starts with the auth variables the databricks terraform provider reads
-// natively (DATABRICKS_HOST / DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET
-// / DATABRICKS_TOKEN / DATABRICKS_CONFIG_PROFILE), then layers on the cloud
-// credentials that the underlay resources will eventually need (AWS, Azure,
-// GCP), then PATH/HOME/TMPDIR/proxy variables so the subprocess inherits a
-// sane environment. Everything flows from the current process env — there is
-// no `--profile` resolution here; that is the CLI layer's job.
-func buildEnv(ctx context.Context) map[string]string {
+// It starts with the resolved SDK auth config (so `--profile` selections and
+// OAuth-cache resolutions are visible to the subprocess), then falls back to
+// passthrough of auth env vars set on the parent process. Cloud credentials
+// (AWS, Azure, GCP) flow through unchanged — the underlay resources will
+// need them once they land. PATH/HOME/TMPDIR/proxy are inherited so the
+// subprocess runs in a sane environment.
+//
+// Ordering matters: auth.Env wins over the passthrough fallback so a
+// --profile override materialised through the SDK cannot be clobbered by a
+// stale DATABRICKS_CONFIG_PROFILE lingering in the parent env.
+func buildEnv(ctx context.Context, authCfg *config.Config) map[string]string {
 	out := map[string]string{}
 
 	passthroughKeys := []string{
@@ -234,6 +260,15 @@ func buildEnv(ctx context.Context) map[string]string {
 		}
 	} else if v, ok := env.Lookup(ctx, "TMPDIR"); ok {
 		out["TMPDIR"] = v
+	}
+
+	// Overlay the resolved SDK auth on top so `--profile` or OAuth-cache
+	// selections survive into the subprocess even when the parent env has
+	// no DATABRICKS_* set.
+	if authCfg != nil {
+		for k, v := range auth.Env(authCfg) {
+			out[k] = v
+		}
 	}
 
 	return out

--- a/ucm/deploy/terraform/terraform_test.go
+++ b/ucm/deploy/terraform/terraform_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +22,7 @@ func TestBuildEnvPassesAuthAndCloudVars(t *testing.T) {
 	ctx = env.Set(ctx, "AZURE_TENANT_ID", "azure-tenant")
 	ctx = env.Set(ctx, "GOOGLE_CREDENTIALS", `{"type":"service_account"}`)
 
-	got := buildEnv(ctx)
+	got := buildEnv(ctx, nil)
 
 	for _, key := range []string{
 		"DATABRICKS_HOST",
@@ -42,7 +43,7 @@ func TestBuildEnvPassesAuthAndCloudVars(t *testing.T) {
 
 func TestBuildEnvOmitsUnsetVars(t *testing.T) {
 	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://example.cloud.databricks.com")
-	got := buildEnv(ctx)
+	got := buildEnv(ctx, nil)
 
 	_, ok := got["DATABRICKS_CLIENT_ID"]
 	assert.False(t, ok, "unset var should not leak into env map")
@@ -54,9 +55,33 @@ func TestBuildEnvMapsProxyVarsUppercase(t *testing.T) {
 	ctx := env.Set(t.Context(), "http_proxy", "http://proxy.example:3128")
 	ctx = env.Set(ctx, "HTTPS_PROXY", "http://proxy.example:3129")
 
-	got := buildEnv(ctx)
+	got := buildEnv(ctx, nil)
 	assert.Equal(t, "http://proxy.example:3128", got["HTTP_PROXY"])
 	assert.Equal(t, "http://proxy.example:3129", got["HTTPS_PROXY"])
+}
+
+// TestBuildEnvMaterializesResolvedAuth pins the behaviour that makes
+// `ucm plan`/`ucm deploy` work when auth comes from ~/.databrickscfg
+// instead of DATABRICKS_* env vars. The resolved SDK config must be
+// serialised into DATABRICKS_* so the terraform subprocess can auth.
+func TestBuildEnvMaterializesResolvedAuth(t *testing.T) {
+	authCfg := &config.Config{
+		Host:  "https://profile.cloud.databricks.com",
+		Token: "resolved-token",
+	}
+	got := buildEnv(t.Context(), authCfg)
+	assert.Equal(t, "https://profile.cloud.databricks.com", got["DATABRICKS_HOST"])
+	assert.Equal(t, "resolved-token", got["DATABRICKS_TOKEN"])
+}
+
+// TestBuildEnvResolvedAuthOverridesPassthrough pins the overlay ordering:
+// a resolved --profile host must win over a stale DATABRICKS_HOST that
+// happens to be set on the parent env.
+func TestBuildEnvResolvedAuthOverridesPassthrough(t *testing.T) {
+	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://stale.cloud.databricks.com")
+	authCfg := &config.Config{Host: "https://profile.cloud.databricks.com"}
+	got := buildEnv(ctx, authCfg)
+	assert.Equal(t, "https://profile.cloud.databricks.com", got["DATABRICKS_HOST"])
 }
 
 func TestLockIdentityDerivesPathFromTarget(t *testing.T) {

--- a/ucm/deploy/terraform/tfdyn/tfdyn.go
+++ b/ucm/deploy/terraform/tfdyn/tfdyn.go
@@ -9,6 +9,14 @@ import (
 	"github.com/databricks/cli/ucm"
 )
 
+// providerSource and providerVersion mirror the constants in the parent
+// terraform package. Duplicated (rather than imported) to keep this
+// subpackage import-cycle-free — the parent package imports tfdyn.
+const (
+	providerSource  = "databricks/databricks"
+	providerVersion = "1.112.0"
+)
+
 // convertOrder controls the order in which resource kinds are walked. The
 // ordering matters because downstream converters inspect earlier ones
 // (schemas look at Resources.Catalog to decide whether to emit depends_on;
@@ -68,8 +76,11 @@ func Convert(ctx context.Context, u *ucm.Ucm) (dyn.Value, error) {
 	return buildResourceTree(out), nil
 }
 
-// buildResourceTree assembles the `{resource: {<tf_type>: {<key>: ...}}}`
-// dyn.Value from the per-kind maps produced by the converters.
+// buildResourceTree assembles the top-level Terraform JSON tree. The output
+// shape mirrors what bundle/deploy/terraform writes so `terraform init`
+// resolves the databricks provider out of the databricks/databricks
+// namespace instead of defaulting to hashicorp/databricks (which does not
+// exist in the registry).
 func buildResourceTree(out *Resources) dyn.Value {
 	blocks := []struct {
 		tfType string
@@ -104,10 +115,38 @@ func buildResourceTree(out *Resources) dyn.Value {
 		})
 	}
 
-	return dyn.V(dyn.NewMappingFromPairs([]dyn.Pair{
+	rootPairs := []dyn.Pair{
+		{Key: dyn.V("terraform"), Value: buildTerraformBlock()},
+		{Key: dyn.V("provider"), Value: buildProviderBlock()},
 		{
 			Key:   dyn.V("resource"),
 			Value: dyn.V(dyn.NewMappingFromPairs(resourcePairs)),
 		},
+	}
+	return dyn.V(dyn.NewMappingFromPairs(rootPairs))
+}
+
+// buildTerraformBlock returns the `terraform.required_providers.databricks`
+// value that pins the provider source and version.
+func buildTerraformBlock() dyn.Value {
+	databricks := dyn.V(dyn.NewMappingFromPairs([]dyn.Pair{
+		{Key: dyn.V("source"), Value: dyn.V(providerSource)},
+		{Key: dyn.V("version"), Value: dyn.V(providerVersion)},
+	}))
+	required := dyn.V(dyn.NewMappingFromPairs([]dyn.Pair{
+		{Key: dyn.V("databricks"), Value: databricks},
+	}))
+	return dyn.V(dyn.NewMappingFromPairs([]dyn.Pair{
+		{Key: dyn.V("required_providers"), Value: required},
+	}))
+}
+
+// buildProviderBlock returns an empty `provider.databricks` block. The
+// databricks terraform provider picks up its auth from the DATABRICKS_*
+// env vars that buildEnv passes through to terraform-exec, so no fields
+// need to be set here — the block's presence is what matters.
+func buildProviderBlock() dyn.Value {
+	return dyn.V(dyn.NewMappingFromPairs([]dyn.Pair{
+		{Key: dyn.V("databricks"), Value: dyn.V(dyn.NewMapping())},
 	}))
 }

--- a/ucm/deploy/terraform/tfdyn/tfdyn_test.go
+++ b/ucm/deploy/terraform/tfdyn/tfdyn_test.go
@@ -36,6 +36,17 @@ resources:
 	require.NoError(t, err)
 
 	want := map[string]any{
+		"terraform": map[string]any{
+			"required_providers": map[string]any{
+				"databricks": map[string]any{
+					"source":  "databricks/databricks",
+					"version": "1.112.0",
+				},
+			},
+		},
+		"provider": map[string]any{
+			"databricks": map[string]any{},
+		},
 		"resource": map[string]any{
 			"databricks_catalog": map[string]any{
 				"sales": map[string]any{
@@ -80,7 +91,20 @@ ucm:
 
 	got, err := Convert(t.Context(), u)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]any{"resource": map[string]any{}}, got.AsAny())
+	assert.Equal(t, map[string]any{
+		"terraform": map[string]any{
+			"required_providers": map[string]any{
+				"databricks": map[string]any{
+					"source":  "databricks/databricks",
+					"version": "1.112.0",
+				},
+			},
+		},
+		"provider": map[string]any{
+			"databricks": map[string]any{},
+		},
+		"resource": map[string]any{},
+	}, got.AsAny())
 }
 
 func TestConvert_PreservesLocations(t *testing.T) {

--- a/ucm/deployplan/action.go
+++ b/ucm/deployplan/action.go
@@ -1,0 +1,71 @@
+// Package deployplan is ucm's fork of bundle/deployplan.
+//
+// Forked rather than imported per cmd/ucm/CLAUDE.md: the bundle package is
+// upstream-owned and will evolve, so pinning to its internals would break on
+// every upstream sync. The on-disk / JSON shape is kept compatible with DAB
+// so that consumers like `ucm plan -o json` produce the same structure as
+// `bundle plan -o json` for the fields ucm exercises.
+package deployplan
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Action struct {
+	ResourceKey string
+	ActionType  ActionType
+}
+
+// String returns the DAB-style "  <action> <key>" form used by plan output.
+func (a Action) String() string {
+	return fmt.Sprintf("  %s %s", a.ActionType.StringShort(), a.ResourceKey)
+}
+
+type ActionType string
+
+const (
+	Undefined    ActionType = ""
+	Skip         ActionType = "skip"
+	Resize       ActionType = "resize"
+	Update       ActionType = "update"
+	UpdateWithID ActionType = "update_id"
+	Create       ActionType = "create"
+	Recreate     ActionType = "recreate"
+	Delete       ActionType = "delete"
+)
+
+var actionOrder = map[ActionType]int{
+	Undefined:    0,
+	Skip:         1,
+	Resize:       2,
+	Update:       3,
+	UpdateWithID: 4,
+	Create:       5,
+	Recreate:     6,
+	Delete:       7,
+}
+
+// KeepsID reports whether an action preserves the resource's existing id.
+func (a ActionType) KeepsID() bool {
+	switch a {
+	case Create, UpdateWithID, Recreate, Delete:
+		return false
+	default:
+		return true
+	}
+}
+
+// StringShort returns the verb without the "_..." suffix (e.g. "update_id" → "update").
+func (a ActionType) StringShort() string {
+	items := strings.SplitN(string(a), "_", 2)
+	return items[0]
+}
+
+// GetHigherAction returns the action with higher severity between a and b.
+func GetHigherAction(a, b ActionType) ActionType {
+	if actionOrder[a] > actionOrder[b] {
+		return a
+	}
+	return b
+}

--- a/ucm/deployplan/plan.go
+++ b/ucm/deployplan/plan.go
@@ -1,0 +1,47 @@
+package deployplan
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/databricks/cli/internal/build"
+)
+
+// Plan is the ucm deployment plan, deliberately kept shape-compatible with
+// bundle/deployplan.Plan for the fields Phase 1 exercises. Direct-engine
+// fields (DependsOn, NewState, RemoteState, Changes, lineage, serial) are
+// left off until Phase 2 needs them.
+type Plan struct {
+	PlanVersion int                   `json:"plan_version,omitempty"`
+	CLIVersion  string                `json:"cli_version,omitempty"`
+	Plan        map[string]*PlanEntry `json:"plan,omitzero"`
+}
+
+type PlanEntry struct {
+	Action ActionType `json:"action,omitempty"`
+}
+
+// NewPlanTerraform creates a Plan for terraform-engine output. Mirrors
+// bundle/deployplan.NewPlanTerraform: no plan_version (terraform-backed plans
+// are not loaded back from disk as direct-engine plans are).
+func NewPlanTerraform() *Plan {
+	return &Plan{
+		CLIVersion: build.GetInfo().Version,
+		Plan:       make(map[string]*PlanEntry),
+	}
+}
+
+// GetActions returns the plan's entries sorted by resource key.
+func (p *Plan) GetActions() []Action {
+	actions := make([]Action, 0, len(p.Plan))
+	for key, entry := range p.Plan {
+		actions = append(actions, Action{
+			ResourceKey: key,
+			ActionType:  entry.Action,
+		})
+	}
+	slices.SortFunc(actions, func(x, y Action) int {
+		return cmp.Compare(x.ResourceKey, y.ResourceKey)
+	})
+	return actions
+}

--- a/ucm/phases/deploy.go
+++ b/ucm/phases/deploy.go
@@ -8,26 +8,41 @@ import (
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/direct"
 )
 
 // Deploy runs the initialize → build → terraform-init → terraform-apply →
-// state-push sequence. Errors are reported via logdiag; state.Push is only
-// called when the apply succeeds, so a mid-apply failure leaves the remote
-// state on the previous Seq and the local cache updated but un-acknowledged.
+// state-push sequence for the terraform engine, or the direct-apply path for
+// the direct engine. Errors are reported via logdiag; terraform-engine
+// state.Push is only called when the apply succeeds, so a mid-apply failure
+// leaves the remote state on the previous Seq and the local cache updated
+// but un-acknowledged.
 //
 // The terraform apply acquires its own deploy lock for the write window; the
 // preceding Pull (in Initialize) and the subsequent Push each acquire and
 // release the lock independently. Between those two lock windows the lock is
 // released — intentional, because holding a remote lock across a long
 // terraform apply would create availability problems for other targets.
+//
+// The direct engine is lock-free at this layer: state is a per-root local
+// file and the SDK calls it issues serialize naturally through the UC API.
+// Cross-process contention on the same target is a known gap — follow-up.
 func Deploy(ctx context.Context, u *ucm.Ucm, opts Options) {
 	log.Info(ctx, "Phase: deploy")
 
 	setting := Initialize(ctx, u, opts)
-	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+	if logdiag.HasError(ctx) {
 		return
 	}
 
+	if setting.Type.IsDirect() {
+		deployDirect(ctx, u, opts)
+		return
+	}
+	deployTerraform(ctx, u, opts)
+}
+
+func deployTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
 	tf := Build(ctx, u, opts)
 	if tf == nil || logdiag.HasError(ctx) {
 		return
@@ -46,5 +61,36 @@ func Deploy(ctx context.Context, u *ucm.Ucm, opts Options) {
 	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
 		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
 		return
+	}
+}
+
+func deployDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
+	factory := opts.directClientFactoryOrDefault()
+	client, err := factory(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("resolve direct client: %w", err))
+		return
+	}
+
+	statePath := direct.StatePath(u)
+	state, err := direct.LoadState(statePath)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		return
+	}
+
+	plan := direct.CalculatePlan(u, state)
+	applyErr := direct.Apply(ctx, u, client, plan, state)
+	// Always persist state — Apply mutates it as it goes, so partial progress
+	// from a mid-apply error must survive the process exit.
+	if saveErr := direct.SaveState(statePath, state); saveErr != nil {
+		if applyErr == nil {
+			logdiag.LogError(ctx, fmt.Errorf("save direct state: %w", saveErr))
+			return
+		}
+		log.Warnf(ctx, "save direct state after apply error: %v", saveErr)
+	}
+	if applyErr != nil {
+		logdiag.LogError(ctx, fmt.Errorf("direct apply: %w", applyErr))
 	}
 }

--- a/ucm/phases/deploy_test.go
+++ b/ucm/phases/deploy_test.go
@@ -47,20 +47,24 @@ func TestDeployHappyPath(t *testing.T) {
 	assert.Equal(t, 1, readRemoteSeq(t, f))
 }
 
-func TestDeployShortCircuitsOnDirectEngine(t *testing.T) {
+// TestDeployDirectEngineSkipsTerraform asserts that when the direct engine
+// is selected Deploy routes through direct.Apply rather than the terraform
+// wrapper: the terraform fake's counters stay at zero, no remote state is
+// pushed, and no error is raised by the happy empty-config path.
+func TestDeployDirectEngineSkipsTerraform(t *testing.T) {
 	f := newFixture(t)
 	f.u.Config.Ucm.Engine = engine.EngineDirect
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
 	phases.Deploy(ctx, f.u, phases.Options{
-		Backend:          f.backend,
-		TerraformFactory: fakeTfFactory(f.tf),
+		TerraformFactory:    fakeTfFactory(f.tf),
+		DirectClientFactory: fakeDirectClientFactory(),
 	})
 
-	assert.True(t, logdiag.HasError(ctx))
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, 0, f.tf.ApplyCalls)
-	assert.Equal(t, -1, readRemoteSeq(t, f), "remote state must not advance when apply is skipped")
+	assert.Equal(t, -1, readRemoteSeq(t, f), "direct engine must never touch remote state")
 }
 
 func TestDeployBailsOnApplyError(t *testing.T) {

--- a/ucm/phases/destroy.go
+++ b/ucm/phases/destroy.go
@@ -8,22 +8,40 @@ import (
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/direct"
 )
 
 // Destroy runs the initialize → terraform-init → terraform-destroy →
-// state-push sequence. The Build phase is skipped — destroy operates on the
-// already-rendered terraform config cached from the last apply (tf.Init
-// re-renders from current ucm.yml which is still necessary for the resource
-// graph). The final Push uploads the post-destroy terraform.tfstate so peers
-// observe the emptied state.
+// state-push sequence for the terraform engine, or the direct engine's
+// equivalent: delete every recorded resource and persist the emptied state.
+//
+// For the terraform engine, the Build phase is skipped — destroy operates
+// on the already-rendered terraform config cached from the last apply
+// (tf.Init re-renders from current ucm.yml which is still necessary for the
+// resource graph). The final Push uploads the post-destroy terraform.tfstate
+// so peers observe the emptied state.
+//
+// For the direct engine, destroy walks the recorded state in reverse UC
+// dependency order (grants → schemas → catalogs) and issues per-resource
+// delete calls. The state file is rewritten on every successful delete so a
+// mid-destroy error leaves the file consistent with whatever actually
+// survived the run.
 func Destroy(ctx context.Context, u *ucm.Ucm, opts Options) {
 	log.Info(ctx, "Phase: destroy")
 
 	setting := Initialize(ctx, u, opts)
-	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+	if logdiag.HasError(ctx) {
 		return
 	}
 
+	if setting.Type.IsDirect() {
+		destroyDirect(ctx, u, opts)
+		return
+	}
+	destroyTerraform(ctx, u, opts)
+}
+
+func destroyTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
 	factory := opts.terraformFactoryOrDefault()
 	tf, err := factory(ctx, u)
 	if err != nil {
@@ -44,5 +62,33 @@ func Destroy(ctx context.Context, u *ucm.Ucm, opts Options) {
 	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
 		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
 		return
+	}
+}
+
+func destroyDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
+	factory := opts.directClientFactoryOrDefault()
+	client, err := factory(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("resolve direct client: %w", err))
+		return
+	}
+
+	statePath := direct.StatePath(u)
+	state, err := direct.LoadState(statePath)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		return
+	}
+
+	_, destroyErr := direct.Destroy(ctx, u, client, state)
+	if saveErr := direct.SaveState(statePath, state); saveErr != nil {
+		if destroyErr == nil {
+			logdiag.LogError(ctx, fmt.Errorf("save direct state: %w", saveErr))
+			return
+		}
+		log.Warnf(ctx, "save direct state after destroy error: %v", saveErr)
+	}
+	if destroyErr != nil {
+		logdiag.LogError(ctx, fmt.Errorf("direct destroy: %w", destroyErr))
 	}
 }

--- a/ucm/phases/destroy_test.go
+++ b/ucm/phases/destroy_test.go
@@ -30,18 +30,21 @@ func TestDestroyHappyPath(t *testing.T) {
 	assert.Equal(t, 1, readRemoteSeq(t, f))
 }
 
-func TestDestroyShortCircuitsOnDirectEngine(t *testing.T) {
+// TestDestroyDirectEngineSkipsTerraform asserts Destroy with engine=direct
+// uses direct.Destroy instead of the terraform wrapper. Empty state means
+// zero SDK calls fire on the fake client.
+func TestDestroyDirectEngineSkipsTerraform(t *testing.T) {
 	f := newFixture(t)
 	f.u.Config.Ucm.Engine = engine.EngineDirect
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
 	phases.Destroy(ctx, f.u, phases.Options{
-		Backend:          f.backend,
-		TerraformFactory: fakeTfFactory(f.tf),
+		TerraformFactory:    fakeTfFactory(f.tf),
+		DirectClientFactory: fakeDirectClientFactory(),
 	})
 
-	require.True(t, logdiag.HasError(ctx))
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, 0, f.tf.DestroyCalls)
 }
 

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config"
 	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/direct"
 	ucmfiler "github.com/databricks/cli/ucm/deploy/filer"
 	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,3 +115,48 @@ func newFixture(t *testing.T) *fixture {
 // errSentinel is a stable error identity for tests that assert the wrapped
 // cause propagates through logdiag-formatted diagnostics.
 var errSentinel = errors.New("sentinel")
+
+// fakeDirectClient is the phases-level stand-in for direct.Client. It lets
+// direct-engine tests exercise Plan/Deploy/Destroy without a real SDK. For
+// the zero-resource fixture tests where Apply has nothing to do, the fake is
+// never invoked — phases.Options.DirectClientFactory just needs to hand back
+// a non-nil Client to satisfy the factory signature.
+type fakeDirectClient struct{}
+
+func (*fakeDirectClient) GetCatalog(_ context.Context, _ string) (*catalog.CatalogInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) CreateCatalog(_ context.Context, _ catalog.CreateCatalog) (*catalog.CatalogInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) UpdateCatalog(_ context.Context, _ catalog.UpdateCatalog) (*catalog.CatalogInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) DeleteCatalog(_ context.Context, _ string) error { return nil }
+
+func (*fakeDirectClient) GetSchema(_ context.Context, _ string) (*catalog.SchemaInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) CreateSchema(_ context.Context, _ catalog.CreateSchema) (*catalog.SchemaInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) UpdateSchema(_ context.Context, _ catalog.UpdateSchema) (*catalog.SchemaInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) DeleteSchema(_ context.Context, _ string) error { return nil }
+
+func (*fakeDirectClient) UpdatePermissions(_ context.Context, _ catalog.UpdatePermissions) error {
+	return nil
+}
+
+func fakeDirectClientFactory() phases.DirectClientFactory {
+	return func(_ context.Context, _ *ucm.Ucm) (direct.Client, error) {
+		return &fakeDirectClient{}, nil
+	}
+}

--- a/ucm/phases/initialize.go
+++ b/ucm/phases/initialize.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
@@ -77,13 +76,9 @@ func Initialize(ctx context.Context, u *ucm.Ucm, opts Options) engine.EngineSett
 	log.Debugf(ctx, "initialize: engine=%s source=%s", setting.Type, setting.Source)
 
 	if setting.Type.IsDirect() {
-		// Direct engine landed as a design goal but has no M1 implementation.
-		// Report via logdiag and bail — downstream phases will skip on
-		// logdiag.HasError.
-		logdiag.LogDiag(ctx, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "ucm direct engine is not yet implemented; set ucm.engine to terraform or unset DATABRICKS_UCM_ENGINE",
-		})
+		// Direct engine state is a local-only artefact; there is no remote
+		// tfstate to pull. Initialize is therefore a no-op beyond resolving
+		// the engine so downstream phases can branch on setting.Type.
 		return setting
 	}
 

--- a/ucm/phases/initialize_test.go
+++ b/ucm/phases/initialize_test.go
@@ -23,20 +23,24 @@ func TestInitializeHappyPath(t *testing.T) {
 	assert.Equal(t, "default", setting.Source)
 }
 
-func TestInitializeDirectEngineIsStubbed(t *testing.T) {
+// TestInitializeDirectEngineSkipsPull asserts Initialize for the direct
+// engine resolves the engine but does NOT call deploy.Pull — direct state
+// is local-only, so pulling would error on a zero-valued Backend without
+// adding value.
+func TestInitializeDirectEngineSkipsPull(t *testing.T) {
 	f := newFixture(t)
 	f.u.Config.Ucm.Engine = engine.EngineDirect
 
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
-	setting := phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
+	// Zero-valued Backend — direct mode must not call deploy.Pull, so this
+	// is not an error.
+	setting := phases.Initialize(ctx, f.u, phases.Options{})
 
-	assert.True(t, logdiag.HasError(ctx))
-	diags := logdiag.FlushCollected(ctx)
-	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Summary, "direct engine is not yet implemented")
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, engine.EngineDirect, setting.Type)
+	assert.Equal(t, "config", setting.Source)
 }
 
 func TestInitializeDirectEngineViaEnv(t *testing.T) {
@@ -47,7 +51,7 @@ func TestInitializeDirectEngineViaEnv(t *testing.T) {
 
 	setting := phases.Initialize(ctx, f.u, phases.Options{Backend: f.backend})
 
-	assert.True(t, logdiag.HasError(ctx))
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, engine.EngineDirect, setting.Type)
 	assert.Equal(t, "env", setting.Source)
 }

--- a/ucm/phases/options.go
+++ b/ucm/phases/options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/direct"
 	"github.com/databricks/cli/ucm/deploy/terraform"
 )
 
@@ -38,6 +39,23 @@ func DefaultTerraformFactory(ctx context.Context, u *ucm.Ucm) (TerraformWrapper,
 	return terraform.New(ctx, u)
 }
 
+// DirectClientFactory constructs the direct-engine Client bound to u.
+// Production callers pass DefaultDirectClientFactory (which reads the memoized
+// *databricks.WorkspaceClient off u); tests hand in a factory that returns an
+// in-memory fake so the SDK surface never has to authenticate.
+type DirectClientFactory func(ctx context.Context, u *ucm.Ucm) (direct.Client, error)
+
+// DefaultDirectClientFactory is the production implementation used by the CLI
+// layer. It resolves the memoized workspace client off u and wraps it in the
+// narrower direct.Client interface.
+func DefaultDirectClientFactory(_ context.Context, u *ucm.Ucm) (direct.Client, error) {
+	w, err := u.WorkspaceClientE()
+	if err != nil {
+		return nil, err
+	}
+	return direct.NewClient(w), nil
+}
+
 // Options bundles the externally-supplied dependencies a phase needs at
 // runtime. Zero-valued Options is never meaningful in production — the CLI
 // layer (U7) will always populate Backend + TerraformFactory before invoking
@@ -46,13 +64,17 @@ func DefaultTerraformFactory(ctx context.Context, u *ucm.Ucm) (TerraformWrapper,
 type Options struct {
 	// Backend is the pull/push state-storage pair used by Initialize and
 	// the post-apply/destroy Push. Required for Plan/Deploy/Destroy in the
-	// terraform engine; callers that set the engine to direct (and thus
-	// short-circuit) may leave it nil.
+	// terraform engine; direct-engine callers may leave it nil since there
+	// is no remote state to pull.
 	Backend deploy.Backend
 
 	// TerraformFactory produces the terraform wrapper bound to u. When nil,
 	// phases fall back to DefaultTerraformFactory.
 	TerraformFactory TerraformFactory
+
+	// DirectClientFactory produces the direct-engine SDK client bound to u.
+	// When nil, phases fall back to DefaultDirectClientFactory.
+	DirectClientFactory DirectClientFactory
 }
 
 // terraformFactoryOrDefault returns o.TerraformFactory or the production
@@ -62,4 +84,13 @@ func (o Options) terraformFactoryOrDefault() TerraformFactory {
 		return o.TerraformFactory
 	}
 	return DefaultTerraformFactory
+}
+
+// directClientFactoryOrDefault returns o.DirectClientFactory or the
+// production factory when unset.
+func (o Options) directClientFactoryOrDefault() DirectClientFactory {
+	if o.DirectClientFactory != nil {
+		return o.DirectClientFactory
+	}
+	return DefaultDirectClientFactory
 }

--- a/ucm/phases/plan.go
+++ b/ucm/phases/plan.go
@@ -7,25 +7,36 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
-	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/deployplan"
 )
 
-// Plan runs the initialize → build → terraform-init → terraform-plan sequence
-// and returns the resulting *terraform.PlanResult. Errors are reported via
-// logdiag; on error Plan returns nil and the caller should check
-// logdiag.HasError before rendering any output.
+// Plan runs the initialize → build → engine-specific plan sequence and
+// returns a *PlanOutcome carrying the structured plan + summary bits.
+// Errors are reported via logdiag; on error Plan returns nil and the
+// caller should check logdiag.HasError before rendering any output.
 //
-// Plan does NOT call state.Push — a plan never advances remote state. The
-// deploy-side lock is held only for the state.Pull in Initialize and
+// The terraform engine runs: initialize → build → tf init → tf plan.
+// The direct engine runs: initialize → load state → compute diff.
+//
+// Plan does NOT call state.Push — a plan never advances remote state.
+// The deploy-side lock is held only for the state.Pull in Initialize and
 // released; planning itself runs lock-free because it never writes.
-func Plan(ctx context.Context, u *ucm.Ucm, opts Options) *terraform.PlanResult {
+func Plan(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
 	log.Info(ctx, "Phase: plan")
 
 	setting := Initialize(ctx, u, opts)
-	if logdiag.HasError(ctx) || setting.Type.IsDirect() {
+	if logdiag.HasError(ctx) {
 		return nil
 	}
 
+	if setting.Type.IsDirect() {
+		return planDirect(ctx, u, opts)
+	}
+	return planTerraform(ctx, u, opts)
+}
+
+func planTerraform(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
 	tf := Build(ctx, u, opts)
 	if tf == nil || logdiag.HasError(ctx) {
 		return nil
@@ -41,5 +52,55 @@ func Plan(ctx context.Context, u *ucm.Ucm, opts Options) *terraform.PlanResult {
 		logdiag.LogError(ctx, fmt.Errorf("terraform plan: %w", err))
 		return nil
 	}
-	return result
+	if result == nil {
+		return nil
+	}
+
+	return &PlanOutcome{
+		Plan:       result.Plan,
+		HasChanges: result.HasChanges,
+		Summary:    result.Summary,
+	}
+}
+
+func planDirect(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
+	state, err := direct.LoadState(direct.StatePath(u))
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		return nil
+	}
+
+	plan := direct.CalculatePlan(u, state)
+	hasChanges := planHasChanges(plan)
+	_ = opts // direct engine doesn't currently need client access to plan
+	return &PlanOutcome{
+		Plan:       plan,
+		HasChanges: hasChanges,
+		Summary:    planSummary(hasChanges),
+	}
+}
+
+// planHasChanges reports true when the plan contains at least one non-Skip
+// action. Mirrors the terraform wrapper's HasChanges semantics so the
+// two engines share a definition of "plan has changes".
+func planHasChanges(plan *deployplan.Plan) bool {
+	if plan == nil {
+		return false
+	}
+	for _, entry := range plan.Plan {
+		if entry.Action != deployplan.Skip && entry.Action != deployplan.Undefined {
+			return true
+		}
+	}
+	return false
+}
+
+// planSummary returns the legacy one-liner the terraform engine has always
+// emitted. Kept local to this file because the terraform wrapper has its own
+// identical helper; duplicating avoids a cross-package call for a 2-arm switch.
+func planSummary(hasChanges bool) string {
+	if hasChanges {
+		return "plan has changes"
+	}
+	return "no changes"
 }

--- a/ucm/phases/plan_test.go
+++ b/ucm/phases/plan_test.go
@@ -43,19 +43,26 @@ func TestPlanBailsOnInitializeError(t *testing.T) {
 	assert.Equal(t, 0, f.tf.RenderCalls, "Build must not run when Initialize failed")
 }
 
-func TestPlanShortCircuitsOnDirectEngine(t *testing.T) {
+// TestPlanDirectEngineReturnsEmptyOutcome covers the direct-engine path when
+// no resources are declared: CalculatePlan returns a plan with zero entries,
+// HasChanges is false, and none of the terraform wrapper's hooks run. The
+// direct client factory is exercised only so the code path is end-to-end; a
+// fake client suffices because the empty plan never issues SDK calls.
+func TestPlanDirectEngineReturnsEmptyOutcome(t *testing.T) {
 	f := newFixture(t)
 	f.u.Config.Ucm.Engine = engine.EngineDirect
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
 	result := phases.Plan(ctx, f.u, phases.Options{
-		Backend:          f.backend,
-		TerraformFactory: fakeTfFactory(f.tf),
+		TerraformFactory:    fakeTfFactory(f.tf),
+		DirectClientFactory: fakeDirectClientFactory(),
 	})
 
-	assert.Nil(t, result)
-	assert.True(t, logdiag.HasError(ctx))
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	require.NotNil(t, result)
+	assert.False(t, result.HasChanges)
+	assert.Empty(t, result.Plan.Plan)
 	assert.Equal(t, 0, f.tf.RenderCalls)
 	assert.Equal(t, 0, f.tf.InitCalls)
 	assert.Equal(t, 0, f.tf.PlanCalls)

--- a/ucm/phases/result.go
+++ b/ucm/phases/result.go
@@ -1,0 +1,24 @@
+package phases
+
+import "github.com/databricks/cli/ucm/deployplan"
+
+// PlanOutcome is the engine-neutral result of the Plan phase: the structured
+// plan itself plus a pair of legacy summary fields (HasChanges / Summary)
+// preserved so existing callers and tests don't need to count plan entries
+// manually. Both engines (terraform and direct) produce PlanOutcome so cmd
+// /ucm/plan.go can render the same way regardless of engine.
+type PlanOutcome struct {
+	// Plan is the DAB-parity structured plan. Always non-nil on a successful
+	// Plan call, even when there are no changes — in that case Plan.Plan is
+	// an empty map.
+	Plan *deployplan.Plan
+
+	// HasChanges is true when Plan contains at least one non-Skip action.
+	HasChanges bool
+
+	// Summary is the legacy one-liner ("plan has changes" / "no changes")
+	// emitted by the terraform engine's output pipeline. The direct engine
+	// produces the same two strings so downstream consumers of Summary see
+	// byte-identical output across engines.
+	Summary string
+}


### PR DESCRIPTION
Closes #50

## Summary

- Align `ucm plan` output shape with `bundle plan` (terraform engine) so cross-tool diffs are clean.
- Implement the direct engine for catalogs/schemas/grants (previously only a stub) so `DATABRICKS_BUNDLE_ENGINE=direct` is a real choice.
- Add acceptance fixtures covering the three plan scenarios: happy path, no-changes, and JSON output.
- Materialize resolved SDK auth (`*config.Config` from the workspace client) into `DATABRICKS_*` env vars on the terraform subprocess so `--profile` / OAuth-cache auth survives.

## Why

Plan divergence from `bundle plan` made it hard for users migrating from DABs to see what really changed. The direct engine had to be real before the engine-parity discipline (every new UC resource ships on both engines day one) could hold. And without the resolved-auth overlay, `ucm deploy` failed whenever auth came from `~/.databrickscfg` instead of env vars — a very common path.

## Test plan

- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`
- [ ] CI green on the fork-scoped CI gate

## Follow-on

This unblocks the Phase A epic (#48) — storage_credential (#49) is the first child and will open on a fresh branch.