### PR TITLE
Feat #49: Add ucm storage_credential resource + reference-resolution infra

### DIFF
--- a/acceptance/ucm/plan/storage_credential/script
+++ b/acceptance/ucm/plan/storage_credential/script
@@ -1,0 +1,1 @@
+trace $CLI ucm plan

--- a/acceptance/ucm/plan/storage_credential/test.toml
+++ b/acceptance/ucm/plan/storage_credential/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/plan/storage_credential/ucm.yml
+++ b/acceptance/ucm/plan/storage_credential/ucm.yml
@@ -1,0 +1,26 @@
+ucm:
+  name: plan-storage-credential
+  engine: direct
+
+resources:
+  storage_credentials:
+    sales_cred:
+      name: sales_cred
+      aws_iam_role:
+        role_arn: "arn:aws:iam::111122223333:role/uc-sales"
+
+    shared_cred:
+      name: shared_cred
+      azure_managed_identity:
+        access_connector_id: "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Databricks/accessConnectors/uc"
+
+  catalogs:
+    sales:
+      name: sales_prod
+      comment: sales catalog on ucm-managed cred
+      storage_root: ${resources.storage_credentials.sales_cred.name}
+
+    partner:
+      name: partner_prod
+      comment: partner catalog on bring-your-own cred
+      storage_root: preexisting_partner_cred

--- a/ucm/config/mutator/resolve_variable_references.go
+++ b/ucm/config/mutator/resolve_variable_references.go
@@ -1,0 +1,43 @@
+package mutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/dynvar"
+	"github.com/databricks/cli/ucm"
+)
+
+// ResolveResourceReferences returns a mutator that substitutes any
+// ${resources.<kind>.<key>.<field>} reference in the loaded ucm config with
+// the pointed-at value from the same tree. Non-resource references (var.*,
+// workspace.*, anything else) are left untouched for later passes to handle.
+func ResolveResourceReferences() ucm.Mutator { return &resolveResourceReferences{} }
+
+type resolveResourceReferences struct{}
+
+func (m *resolveResourceReferences) Name() string { return "ResolveResourceReferences" }
+
+func (m *resolveResourceReferences) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	err := u.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
+		return dynvar.Resolve(root, func(p dyn.Path) (dyn.Value, error) {
+			if len(p) == 0 || p[0].Key() != "resources" {
+				return dyn.InvalidValue, dynvar.ErrSkipResolution
+			}
+			v, err := dyn.GetByPath(root, p)
+			if err != nil {
+				return dyn.InvalidValue, err
+			}
+			return v, nil
+		})
+	})
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  err.Error(),
+		})
+	}
+	return diags
+}

--- a/ucm/config/mutator/resolve_variable_references_test.go
+++ b/ucm/config/mutator/resolve_variable_references_test.go
@@ -1,0 +1,79 @@
+package mutator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveResourceReferences_LiteralsPassThrough(t *testing.T) {
+	u := loadUcm(t, `
+ucm: {name: t}
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+      storage_root: s3://acme-sales/prod
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ResolveResourceReferences())
+	require.Empty(t, diags, "unexpected diags: %v", summaries(diags))
+	assert.Equal(t, "s3://acme-sales/prod", u.Config.Resources.Catalogs["sales"].StorageRoot)
+}
+
+func TestResolveResourceReferences_InterpolatesUcmRef(t *testing.T) {
+	u := loadUcm(t, `
+ucm: {name: t}
+resources:
+  storage_credentials:
+    sales_cred:
+      name: sales_cred
+      aws_iam_role:
+        role_arn: arn:aws:iam::1:role/uc
+  catalogs:
+    sales:
+      name: sales_prod
+      storage_root: ${resources.storage_credentials.sales_cred.name}
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ResolveResourceReferences())
+	require.Empty(t, diags, "unexpected diags: %v", summaries(diags))
+	assert.Equal(t, "sales_cred", u.Config.Resources.Catalogs["sales"].StorageRoot)
+}
+
+func TestResolveResourceReferences_UnknownRefErrors(t *testing.T) {
+	u := loadUcm(t, `
+ucm: {name: t}
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+      storage_root: ${resources.storage_credentials.missing.name}
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ResolveResourceReferences())
+	require.NotEmpty(t, diags, "expected error diagnostic")
+	found := false
+	for _, s := range summaries(diags) {
+		if strings.Contains(s, "resources.storage_credentials.missing") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected diag to mention the missing ref, got %v", summaries(diags))
+}
+
+func TestResolveResourceReferences_LeavesNonResourceRefsUntouched(t *testing.T) {
+	u := loadUcm(t, `
+ucm: {name: t}
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+      storage_root: ${var.some_future_var}
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ResolveResourceReferences())
+	require.Empty(t, diags, "unexpected diags: %v", summaries(diags))
+	assert.Equal(t, "${var.some_future_var}", u.Config.Resources.Catalogs["sales"].StorageRoot)
+}

--- a/ucm/config/resources.go
+++ b/ucm/config/resources.go
@@ -6,8 +6,9 @@ import "github.com/databricks/cli/ucm/config/resources"
 // resource declared in ucm.yml. For M0 only a minimal UC-native subset is
 // supported; cloud resources (S3/ADLS/GCS, IAM/MI/SA, KMS) land in M2.
 type Resources struct {
-	Catalogs            map[string]*resources.Catalog           `json:"catalogs,omitempty"`
-	Schemas             map[string]*resources.Schema            `json:"schemas,omitempty"`
-	Grants              map[string]*resources.Grant             `json:"grants,omitempty"`
-	TagValidationRules  map[string]*resources.TagValidationRule `json:"tag_validation_rules,omitempty"`
+	Catalogs           map[string]*resources.Catalog           `json:"catalogs,omitempty"`
+	Schemas            map[string]*resources.Schema            `json:"schemas,omitempty"`
+	Grants             map[string]*resources.Grant             `json:"grants,omitempty"`
+	StorageCredentials map[string]*resources.StorageCredential `json:"storage_credentials,omitempty"`
+	TagValidationRules map[string]*resources.TagValidationRule `json:"tag_validation_rules,omitempty"`
 }

--- a/ucm/config/resources/storage_credential.go
+++ b/ucm/config/resources/storage_credential.go
@@ -1,0 +1,41 @@
+package resources
+
+// StorageCredential is a UC storage credential. Exactly one of the cloud
+// identity fields (AwsIamRole, AzureManagedIdentity, AzureServicePrincipal,
+// DatabricksGcpServiceAccount) must be set. Field shape mirrors
+// databricks-sdk-go's catalog.CreateStorageCredential so the direct-engine
+// input builder is a 1:1 copy rather than a mapping layer.
+type StorageCredential struct {
+	Name    string `json:"name"`
+	Comment string `json:"comment,omitempty"`
+
+	AwsIamRole                  *AwsIamRole                  `json:"aws_iam_role,omitempty"`
+	AzureManagedIdentity        *AzureManagedIdentity        `json:"azure_managed_identity,omitempty"`
+	AzureServicePrincipal       *AzureServicePrincipal       `json:"azure_service_principal,omitempty"`
+	DatabricksGcpServiceAccount *DatabricksGcpServiceAccount `json:"databricks_gcp_service_account,omitempty"`
+
+	ReadOnly       bool `json:"read_only,omitempty"`
+	SkipValidation bool `json:"skip_validation,omitempty"`
+}
+
+// AwsIamRole is the AWS IAM role UC assumes to vend temporary credentials.
+type AwsIamRole struct {
+	RoleArn string `json:"role_arn"`
+}
+
+// AzureManagedIdentity identifies an Azure managed identity by access connector.
+type AzureManagedIdentity struct {
+	AccessConnectorId string `json:"access_connector_id"`
+	ManagedIdentityId string `json:"managed_identity_id,omitempty"`
+}
+
+// AzureServicePrincipal holds an Azure AD service principal reference.
+type AzureServicePrincipal struct {
+	DirectoryId   string `json:"directory_id"`
+	ApplicationId string `json:"application_id"`
+	ClientSecret  string `json:"client_secret"`
+}
+
+// DatabricksGcpServiceAccount toggles the Databricks-managed GCP identity
+// shape. Presence alone is meaningful; there are no user-supplied fields.
+type DatabricksGcpServiceAccount struct{}

--- a/ucm/deploy/direct/apply.go
+++ b/ucm/deploy/direct/apply.go
@@ -20,8 +20,9 @@ import (
 //
 // Execution order is the natural UC dependency order:
 //
-//	catalogs creates+updates → schemas creates+updates → grants reconcile
-//	→ schema deletes → catalog deletes
+//	storage_credential creates+updates → catalog creates+updates
+//	→ schema creates+updates → grants reconcile → schema deletes
+//	→ catalog deletes → storage_credential deletes
 //
 // Grants are reconciled per securable in a single pass (Create, Update, and
 // Delete share the code path) because the UC API treats grants as a full
@@ -29,6 +30,9 @@ import (
 // per-grant-key plan shape still makes individual additions/removals
 // observable to users in the plan output.
 func Apply(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	if err := applyStorageCredentialCreates(ctx, u, client, plan, state); err != nil {
+		return err
+	}
 	if err := applyCatalogCreates(ctx, u, client, plan, state); err != nil {
 		return err
 	}
@@ -42,6 +46,9 @@ func Apply(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan
 		return err
 	}
 	if err := applyCatalogDeletes(ctx, client, plan, state); err != nil {
+		return err
+	}
+	if err := applyStorageCredentialDeletes(ctx, client, plan, state); err != nil {
 		return err
 	}
 	return nil
@@ -61,10 +68,64 @@ func Destroy(ctx context.Context, u *ucm.Ucm, client Client, state *State) (*dep
 	for key := range state.Catalogs {
 		plan.Plan["resources.catalogs."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
 	}
+	for key := range state.StorageCredentials {
+		plan.Plan["resources.storage_credentials."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
+	}
 	if err := Apply(ctx, u, client, plan, state); err != nil {
 		return plan, err
 	}
 	return plan, nil
+}
+
+func applyStorageCredentialCreates(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range sortedPlanKeysByGroup(plan, "storage_credentials") {
+		entry := plan.Plan[key]
+		name := strings.TrimPrefix(key, "resources.storage_credentials.")
+		cfg := u.Config.Resources.StorageCredentials[name]
+		switch entry.Action {
+		case deployplan.Create:
+			log.Infof(ctx, "direct: creating storage_credential %s", name)
+			in, err := storageCredentialCreateInput(cfg)
+			if err != nil {
+				return fmt.Errorf("create storage_credential %s: %w", name, err)
+			}
+			if _, err := client.CreateStorageCredential(ctx, in); err != nil {
+				return fmt.Errorf("create storage_credential %s: %w", name, err)
+			}
+			state.StorageCredentials[name] = ptrStorageCredential(storageCredentialStateFromConfig(cfg))
+		case deployplan.Update:
+			log.Infof(ctx, "direct: updating storage_credential %s", name)
+			in, err := storageCredentialUpdateInput(cfg)
+			if err != nil {
+				return fmt.Errorf("update storage_credential %s: %w", name, err)
+			}
+			if _, err := client.UpdateStorageCredential(ctx, in); err != nil {
+				return fmt.Errorf("update storage_credential %s: %w", name, err)
+			}
+			state.StorageCredentials[name] = ptrStorageCredential(storageCredentialStateFromConfig(cfg))
+		}
+	}
+	return nil
+}
+
+func applyStorageCredentialDeletes(ctx context.Context, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range reverseSortedPlanKeysByGroup(plan, "storage_credentials") {
+		entry := plan.Plan[key]
+		if entry.Action != deployplan.Delete {
+			continue
+		}
+		name := strings.TrimPrefix(key, "resources.storage_credentials.")
+		rec, ok := state.StorageCredentials[name]
+		if !ok {
+			continue
+		}
+		log.Infof(ctx, "direct: deleting storage_credential %s", rec.Name)
+		if err := client.DeleteStorageCredential(ctx, rec.Name); err != nil {
+			return fmt.Errorf("delete storage_credential %s: %w", rec.Name, err)
+		}
+		delete(state.StorageCredentials, name)
+	}
+	return nil
 }
 
 func applyCatalogCreates(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
@@ -228,6 +289,92 @@ func schemaUpdateInput(s *resources.Schema) catalog.UpdateSchema {
 	}
 }
 
+// storageCredentialIdentityCount counts which of the one-of identity fields
+// are set on the config struct. Matches the tfdyn converter's validation.
+func storageCredentialIdentityCount(c *resources.StorageCredential) int {
+	n := 0
+	if c.AwsIamRole != nil {
+		n++
+	}
+	if c.AzureManagedIdentity != nil {
+		n++
+	}
+	if c.AzureServicePrincipal != nil {
+		n++
+	}
+	if c.DatabricksGcpServiceAccount != nil {
+		n++
+	}
+	return n
+}
+
+func storageCredentialCreateInput(c *resources.StorageCredential) (catalog.CreateStorageCredential, error) {
+	if n := storageCredentialIdentityCount(c); n != 1 {
+		return catalog.CreateStorageCredential{}, fmt.Errorf("storage_credential %q: exactly one identity field required, got %d", c.Name, n)
+	}
+	in := catalog.CreateStorageCredential{
+		Name:           c.Name,
+		Comment:        c.Comment,
+		ReadOnly:       c.ReadOnly,
+		SkipValidation: c.SkipValidation,
+	}
+	if c.AwsIamRole != nil {
+		in.AwsIamRole = &catalog.AwsIamRoleRequest{RoleArn: c.AwsIamRole.RoleArn}
+	}
+	if c.AzureManagedIdentity != nil {
+		in.AzureManagedIdentity = &catalog.AzureManagedIdentityRequest{
+			AccessConnectorId: c.AzureManagedIdentity.AccessConnectorId,
+			ManagedIdentityId: c.AzureManagedIdentity.ManagedIdentityId,
+		}
+	}
+	if c.AzureServicePrincipal != nil {
+		in.AzureServicePrincipal = &catalog.AzureServicePrincipal{
+			DirectoryId:   c.AzureServicePrincipal.DirectoryId,
+			ApplicationId: c.AzureServicePrincipal.ApplicationId,
+			ClientSecret:  c.AzureServicePrincipal.ClientSecret,
+		}
+	}
+	if c.DatabricksGcpServiceAccount != nil {
+		in.DatabricksGcpServiceAccount = &catalog.DatabricksGcpServiceAccountRequest{}
+	}
+	return in, nil
+}
+
+// storageCredentialUpdateInput mirrors storageCredentialCreateInput except
+// Azure managed identity uses the SDK's *Response* type for updates — an
+// SDK quirk, not a bug on our side.
+func storageCredentialUpdateInput(c *resources.StorageCredential) (catalog.UpdateStorageCredential, error) {
+	if n := storageCredentialIdentityCount(c); n != 1 {
+		return catalog.UpdateStorageCredential{}, fmt.Errorf("storage_credential %q: exactly one identity field required, got %d", c.Name, n)
+	}
+	in := catalog.UpdateStorageCredential{
+		Name:           c.Name,
+		Comment:        c.Comment,
+		ReadOnly:       c.ReadOnly,
+		SkipValidation: c.SkipValidation,
+	}
+	if c.AwsIamRole != nil {
+		in.AwsIamRole = &catalog.AwsIamRoleRequest{RoleArn: c.AwsIamRole.RoleArn}
+	}
+	if c.AzureManagedIdentity != nil {
+		in.AzureManagedIdentity = &catalog.AzureManagedIdentityResponse{
+			AccessConnectorId: c.AzureManagedIdentity.AccessConnectorId,
+			ManagedIdentityId: c.AzureManagedIdentity.ManagedIdentityId,
+		}
+	}
+	if c.AzureServicePrincipal != nil {
+		in.AzureServicePrincipal = &catalog.AzureServicePrincipal{
+			DirectoryId:   c.AzureServicePrincipal.DirectoryId,
+			ApplicationId: c.AzureServicePrincipal.ApplicationId,
+			ClientSecret:  c.AzureServicePrincipal.ClientSecret,
+		}
+	}
+	if c.DatabricksGcpServiceAccount != nil {
+		in.DatabricksGcpServiceAccount = &catalog.DatabricksGcpServiceAccountRequest{}
+	}
+	return in, nil
+}
+
 func buildUpdatePermissions(sec securable, grants []*resources.Grant) catalog.UpdatePermissions {
 	changes := make([]catalog.PermissionsChange, 0, len(grants))
 	for _, g := range grants {
@@ -372,3 +519,6 @@ func sortSecurables(set map[securable]struct{}) []securable {
 func ptrCatalog(s CatalogState) *CatalogState { return &s }
 func ptrSchema(s SchemaState) *SchemaState    { return &s }
 func ptrGrant(s GrantState) *GrantState       { return &s }
+func ptrStorageCredential(s StorageCredentialState) *StorageCredentialState {
+	return &s
+}

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -26,6 +26,10 @@ type recordingClient struct {
 	UpdatedSchemas []catalog.UpdateSchema
 	DeletedSchemas []string
 
+	CreatedStorageCredentials []catalog.CreateStorageCredential
+	UpdatedStorageCredentials []catalog.UpdateStorageCredential
+	DeletedStorageCredentials []string
+
 	Permissions []catalog.UpdatePermissions
 
 	FailOn string
@@ -92,6 +96,34 @@ func (r *recordingClient) DeleteSchema(_ context.Context, fullName string) error
 		return err
 	}
 	r.DeletedSchemas = append(r.DeletedSchemas, fullName)
+	return nil
+}
+
+func (r *recordingClient) GetStorageCredential(_ context.Context, _ string) (*catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+
+func (r *recordingClient) CreateStorageCredential(_ context.Context, in catalog.CreateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	if err := r.trip("CreateStorageCredential:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.CreatedStorageCredentials = append(r.CreatedStorageCredentials, in)
+	return &catalog.StorageCredentialInfo{Name: in.Name}, nil
+}
+
+func (r *recordingClient) UpdateStorageCredential(_ context.Context, in catalog.UpdateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	if err := r.trip("UpdateStorageCredential:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.UpdatedStorageCredentials = append(r.UpdatedStorageCredentials, in)
+	return &catalog.StorageCredentialInfo{Name: in.Name}, nil
+}
+
+func (r *recordingClient) DeleteStorageCredential(_ context.Context, name string) error {
+	if err := r.trip("DeleteStorageCredential:" + name); err != nil {
+		return err
+	}
+	r.DeletedStorageCredentials = append(r.DeletedStorageCredentials, name)
 	return nil
 }
 

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -239,6 +239,97 @@ func TestApply_PreservesStateOnMidApplyError(t *testing.T) {
 	assert.Nil(t, state.Schemas["raw"])
 }
 
+func TestApply_StorageCredentialCreateOrdersBeforeCatalog(t *testing.T) {
+	u := ucmWith(
+		map[string]*resources.Catalog{"main": {Name: "main"}},
+		nil,
+		nil,
+	)
+	u.Config.Resources.StorageCredentials = map[string]*resources.StorageCredential{
+		"prod": {
+			Name:       "prod",
+			AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/uc"},
+		},
+	}
+
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{
+		"CreateStorageCredential:prod",
+		"CreateCatalog:main",
+	}, client.Calls)
+
+	require.NotNil(t, state.StorageCredentials["prod"])
+	assert.Equal(t, "arn:aws:iam::1:role/uc", state.StorageCredentials["prod"].AwsIamRole.RoleArn)
+}
+
+func TestApply_StorageCredentialUpdate(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.StorageCredentials = map[string]*resources.StorageCredential{
+		"prod": {
+			Name:       "prod",
+			Comment:    "new",
+			AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/new"},
+		},
+	}
+	state := direct.NewState()
+	state.StorageCredentials["prod"] = &direct.StorageCredentialState{
+		Name:       "prod",
+		Comment:    "old",
+		AwsIamRole: &direct.AwsIamRoleState{RoleArn: "arn:aws:iam::1:role/old"},
+	}
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{"UpdateStorageCredential:prod"}, client.Calls)
+	assert.Equal(t, "new", state.StorageCredentials["prod"].Comment)
+	assert.Equal(t, "arn:aws:iam::1:role/new", state.StorageCredentials["prod"].AwsIamRole.RoleArn)
+}
+
+func TestApply_StorageCredentialDeleteOrdersAfterCatalog(t *testing.T) {
+	u := &ucm.Ucm{}
+	state := direct.NewState()
+	state.Catalogs["main"] = &direct.CatalogState{Name: "main"}
+	state.StorageCredentials["prod"] = &direct.StorageCredentialState{
+		Name:       "prod",
+		AwsIamRole: &direct.AwsIamRoleState{RoleArn: "arn:aws:iam::1:role/uc"},
+	}
+
+	client := &recordingClient{}
+	plan, err := direct.Destroy(t.Context(), u, client, state)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	assert.Equal(t, []string{
+		"DeleteCatalog:main",
+		"DeleteStorageCredential:prod",
+	}, client.Calls)
+
+	assert.Empty(t, state.Catalogs)
+	assert.Empty(t, state.StorageCredentials)
+}
+
+func TestApply_StorageCredentialRejectsMissingIdentity(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.StorageCredentials = map[string]*resources.StorageCredential{
+		"bad": {Name: "bad"},
+	}
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	err := direct.Apply(t.Context(), u, client, plan, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one identity field")
+	assert.Empty(t, client.Calls, "no API call must be made when validation fails")
+}
+
 func TestApply_RevokesPrincipalsNotInConfig(t *testing.T) {
 	u := ucmWith(nil, nil, map[string]*resources.Grant{
 		"analysts": {

--- a/ucm/deploy/direct/client.go
+++ b/ucm/deploy/direct/client.go
@@ -21,6 +21,11 @@ type Client interface {
 	UpdateSchema(ctx context.Context, in catalog.UpdateSchema) (*catalog.SchemaInfo, error)
 	DeleteSchema(ctx context.Context, fullName string) error
 
+	GetStorageCredential(ctx context.Context, name string) (*catalog.StorageCredentialInfo, error)
+	CreateStorageCredential(ctx context.Context, in catalog.CreateStorageCredential) (*catalog.StorageCredentialInfo, error)
+	UpdateStorageCredential(ctx context.Context, in catalog.UpdateStorageCredential) (*catalog.StorageCredentialInfo, error)
+	DeleteStorageCredential(ctx context.Context, name string) error
+
 	UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error
 }
 
@@ -62,6 +67,22 @@ func (c *sdkClient) UpdateSchema(ctx context.Context, in catalog.UpdateSchema) (
 
 func (c *sdkClient) DeleteSchema(ctx context.Context, fullName string) error {
 	return c.w.Schemas.Delete(ctx, catalog.DeleteSchemaRequest{FullName: fullName, Force: true})
+}
+
+func (c *sdkClient) GetStorageCredential(ctx context.Context, name string) (*catalog.StorageCredentialInfo, error) {
+	return c.w.StorageCredentials.GetByName(ctx, name)
+}
+
+func (c *sdkClient) CreateStorageCredential(ctx context.Context, in catalog.CreateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	return c.w.StorageCredentials.Create(ctx, in)
+}
+
+func (c *sdkClient) UpdateStorageCredential(ctx context.Context, in catalog.UpdateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	return c.w.StorageCredentials.Update(ctx, in)
+}
+
+func (c *sdkClient) DeleteStorageCredential(ctx context.Context, name string) error {
+	return c.w.StorageCredentials.DeleteByName(ctx, name)
 }
 
 func (c *sdkClient) UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error {

--- a/ucm/deploy/direct/plan.go
+++ b/ucm/deploy/direct/plan.go
@@ -30,11 +30,35 @@ import (
 func CalculatePlan(u *ucm.Ucm, state *State) *deployplan.Plan {
 	plan := deployplan.NewPlanTerraform()
 
+	planStorageCredentials(u, state, plan)
 	planCatalogs(u, state, plan)
 	planSchemas(u, state, plan)
 	planGrants(u, state, plan)
 
 	return plan
+}
+
+func planStorageCredentials(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
+	desired := u.Config.Resources.StorageCredentials
+	recorded := state.StorageCredentials
+
+	keys := mergedKeys(desired, recorded)
+	for _, key := range keys {
+		planKey := "resources.storage_credentials." + key
+
+		cfg, haveCfg := desired[key]
+		rec, haveRec := recorded[key]
+		switch {
+		case haveCfg && !haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Create}
+		case !haveCfg && haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Delete}
+		case storageCredentialStateFromConfig(cfg).equal(rec):
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Skip}
+		default:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Update}
+		}
+	}
 }
 
 func planCatalogs(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
@@ -144,6 +168,10 @@ func (s GrantState) equal(other *GrantState) bool {
 	left := normalizedGrant(s)
 	right := normalizedGrant(*other)
 	return reflect.DeepEqual(left, right)
+}
+
+func (s StorageCredentialState) equal(other *StorageCredentialState) bool {
+	return other != nil && reflect.DeepEqual(s, *other)
 }
 
 // normalizedGrant returns a copy of g with privileges sorted. The SDK sorts

--- a/ucm/deploy/direct/plan_test.go
+++ b/ucm/deploy/direct/plan_test.go
@@ -137,6 +137,65 @@ func TestCalculatePlan_PrivilegeReorderIsSkip(t *testing.T) {
 	assert.Equal(t, deployplan.Skip, plan.Plan["resources.grants.analysts"].Action)
 }
 
+func TestCalculatePlan_StorageCredentialCreate(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.StorageCredentials = map[string]*resources.StorageCredential{
+		"prod": {
+			Name:       "prod",
+			AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/uc"},
+		},
+	}
+	plan := direct.CalculatePlan(u, direct.NewState())
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.storage_credentials.prod"].Action)
+}
+
+func TestCalculatePlan_StorageCredentialDelete(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	state := direct.NewState()
+	state.StorageCredentials["prod"] = &direct.StorageCredentialState{
+		Name:       "prod",
+		AwsIamRole: &direct.AwsIamRoleState{RoleArn: "arn:aws:iam::1:role/uc"},
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.storage_credentials.prod"].Action)
+}
+
+func TestCalculatePlan_StorageCredentialSkip(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.StorageCredentials = map[string]*resources.StorageCredential{
+		"prod": {
+			Name:       "prod",
+			Comment:    "prod",
+			AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/uc"},
+		},
+	}
+	state := direct.NewState()
+	state.StorageCredentials["prod"] = &direct.StorageCredentialState{
+		Name:       "prod",
+		Comment:    "prod",
+		AwsIamRole: &direct.AwsIamRoleState{RoleArn: "arn:aws:iam::1:role/uc"},
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.storage_credentials.prod"].Action)
+}
+
+func TestCalculatePlan_StorageCredentialUpdateOnIdentityDrift(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.StorageCredentials = map[string]*resources.StorageCredential{
+		"prod": {
+			Name:       "prod",
+			AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/new"},
+		},
+	}
+	state := direct.NewState()
+	state.StorageCredentials["prod"] = &direct.StorageCredentialState{
+		Name:       "prod",
+		AwsIamRole: &direct.AwsIamRoleState{RoleArn: "arn:aws:iam::1:role/old"},
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Update, plan.Plan["resources.storage_credentials.prod"].Action)
+}
+
 func ucmWith(catalogs map[string]*resources.Catalog, schemas map[string]*resources.Schema, grants map[string]*resources.Grant) *ucm.Ucm {
 	u := &ucm.Ucm{Config: config.Root{}}
 	u.Config.Resources.Catalogs = catalogs

--- a/ucm/deploy/direct/snapshot.go
+++ b/ucm/deploy/direct/snapshot.go
@@ -47,6 +47,38 @@ func grantStateFromConfig(g *resources.Grant) GrantState {
 	}
 }
 
+func storageCredentialStateFromConfig(c *resources.StorageCredential) StorageCredentialState {
+	if c == nil {
+		return StorageCredentialState{}
+	}
+	s := StorageCredentialState{
+		Name:           c.Name,
+		Comment:        c.Comment,
+		ReadOnly:       c.ReadOnly,
+		SkipValidation: c.SkipValidation,
+	}
+	if c.AwsIamRole != nil {
+		s.AwsIamRole = &AwsIamRoleState{RoleArn: c.AwsIamRole.RoleArn}
+	}
+	if c.AzureManagedIdentity != nil {
+		s.AzureManagedIdentity = &AzureManagedIdentityState{
+			AccessConnectorId: c.AzureManagedIdentity.AccessConnectorId,
+			ManagedIdentityId: c.AzureManagedIdentity.ManagedIdentityId,
+		}
+	}
+	if c.AzureServicePrincipal != nil {
+		s.AzureServicePrincipal = &AzureServicePrincipalState{
+			DirectoryId:   c.AzureServicePrincipal.DirectoryId,
+			ApplicationId: c.AzureServicePrincipal.ApplicationId,
+			ClientSecret:  c.AzureServicePrincipal.ClientSecret,
+		}
+	}
+	if c.DatabricksGcpServiceAccount != nil {
+		s.DatabricksGcpServiceAccount = &DatabricksGcpServiceAccountState{}
+	}
+	return s
+}
+
 func copyTags(tags map[string]string) map[string]string {
 	if len(tags) == 0 {
 		return nil

--- a/ucm/deploy/direct/state.go
+++ b/ucm/deploy/direct/state.go
@@ -24,10 +24,11 @@ const StateFileName = "resources.json"
 // successfully applied. Keys match the plan's per-resource keys so the
 // next plan can diff desired vs recorded by a simple map lookup.
 type State struct {
-	Version  int                      `json:"version"`
-	Catalogs map[string]*CatalogState `json:"catalogs,omitempty"`
-	Schemas  map[string]*SchemaState  `json:"schemas,omitempty"`
-	Grants   map[string]*GrantState   `json:"grants,omitempty"`
+	Version            int                                `json:"version"`
+	Catalogs           map[string]*CatalogState           `json:"catalogs,omitempty"`
+	Schemas            map[string]*SchemaState            `json:"schemas,omitempty"`
+	Grants             map[string]*GrantState             `json:"grants,omitempty"`
+	StorageCredentials map[string]*StorageCredentialState `json:"storage_credentials,omitempty"`
 }
 
 // CatalogState is what the direct engine records for a catalog after a
@@ -58,13 +59,52 @@ type GrantState struct {
 	Privileges    []string `json:"privileges"`
 }
 
+// StorageCredentialState mirrors the config struct's shape for a UC storage
+// credential. Exactly one of the identity fields is set; ClientSecret is
+// persisted because the UC API does not echo it back and the user-supplied
+// value is the only source of truth for drift.
+type StorageCredentialState struct {
+	Name    string `json:"name"`
+	Comment string `json:"comment,omitempty"`
+
+	AwsIamRole                  *AwsIamRoleState                  `json:"aws_iam_role,omitempty"`
+	AzureManagedIdentity        *AzureManagedIdentityState        `json:"azure_managed_identity,omitempty"`
+	AzureServicePrincipal       *AzureServicePrincipalState       `json:"azure_service_principal,omitempty"`
+	DatabricksGcpServiceAccount *DatabricksGcpServiceAccountState `json:"databricks_gcp_service_account,omitempty"`
+
+	ReadOnly       bool `json:"read_only,omitempty"`
+	SkipValidation bool `json:"skip_validation,omitempty"`
+}
+
+// AwsIamRoleState mirrors resources.AwsIamRole for state serialization.
+type AwsIamRoleState struct {
+	RoleArn string `json:"role_arn"`
+}
+
+// AzureManagedIdentityState mirrors resources.AzureManagedIdentity.
+type AzureManagedIdentityState struct {
+	AccessConnectorId string `json:"access_connector_id"`
+	ManagedIdentityId string `json:"managed_identity_id,omitempty"`
+}
+
+// AzureServicePrincipalState mirrors resources.AzureServicePrincipal.
+type AzureServicePrincipalState struct {
+	DirectoryId   string `json:"directory_id"`
+	ApplicationId string `json:"application_id"`
+	ClientSecret  string `json:"client_secret"`
+}
+
+// DatabricksGcpServiceAccountState mirrors resources.DatabricksGcpServiceAccount.
+type DatabricksGcpServiceAccountState struct{}
+
 // NewState returns an empty State ready to be populated by the planner.
 func NewState() *State {
 	return &State{
-		Version:  StateVersion,
-		Catalogs: make(map[string]*CatalogState),
-		Schemas:  make(map[string]*SchemaState),
-		Grants:   make(map[string]*GrantState),
+		Version:            StateVersion,
+		Catalogs:           make(map[string]*CatalogState),
+		Schemas:            make(map[string]*SchemaState),
+		Grants:             make(map[string]*GrantState),
+		StorageCredentials: make(map[string]*StorageCredentialState),
 	}
 }
 
@@ -94,6 +134,9 @@ func LoadState(path string) (*State, error) {
 	}
 	if s.Grants == nil {
 		s.Grants = make(map[string]*GrantState)
+	}
+	if s.StorageCredentials == nil {
+		s.StorageCredentials = make(map[string]*StorageCredentialState)
 	}
 	return &s, nil
 }

--- a/ucm/deploy/direct/state_test.go
+++ b/ucm/deploy/direct/state_test.go
@@ -18,6 +18,7 @@ func TestLoadState_MissingFileReturnsEmpty(t *testing.T) {
 	assert.Empty(t, s.Catalogs)
 	assert.Empty(t, s.Schemas)
 	assert.Empty(t, s.Grants)
+	assert.Empty(t, s.StorageCredentials)
 }
 
 func TestLoadState_RoundTrip(t *testing.T) {
@@ -31,6 +32,12 @@ func TestLoadState_RoundTrip(t *testing.T) {
 		Principal:     "analysts",
 		Privileges:    []string{"SELECT"},
 	}
+	in.StorageCredentials["prod"] = &direct.StorageCredentialState{
+		Name:       "prod",
+		Comment:    "prod credential",
+		AwsIamRole: &direct.AwsIamRoleState{RoleArn: "arn:aws:iam::1:role/uc"},
+		ReadOnly:   true,
+	}
 
 	require.NoError(t, direct.SaveState(path, in))
 
@@ -39,6 +46,7 @@ func TestLoadState_RoundTrip(t *testing.T) {
 	assert.Equal(t, in.Catalogs, out.Catalogs)
 	assert.Equal(t, in.Schemas, out.Schemas)
 	assert.Equal(t, in.Grants, out.Grants)
+	assert.Equal(t, in.StorageCredentials, out.StorageCredentials)
 }
 
 func TestLoadState_RejectsFutureVersion(t *testing.T) {

--- a/ucm/deploy/terraform/interpolate.go
+++ b/ucm/deploy/terraform/interpolate.go
@@ -1,0 +1,38 @@
+package terraform
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/dynvar"
+)
+
+// GroupToTerraformName maps ucm resource-group names to the corresponding
+// terraform resource type. Interpolate uses this table to rewrite
+// ${resources.<group>.<key>.<field>} → ${databricks_<type>.<key>.<field>}
+// so terraform's own dependency graph picks up the edge.
+var GroupToTerraformName = map[string]string{
+	"catalogs":            "databricks_catalog",
+	"schemas":             "databricks_schema",
+	"grants":              "databricks_grants",
+	"storage_credentials": "databricks_storage_credential",
+}
+
+// Interpolate rewrites ucm-path references in a TF JSON tree to terraform
+// paths. A reference whose first two path segments are resources.<known-group>
+// gets rewritten; any other reference is left as-is (either a user typo,
+// which terraform will surface, or a resource kind not yet registered).
+func Interpolate(in dyn.Value) (dyn.Value, error) {
+	prefix := dyn.NewPath(dyn.Key("resources"))
+	return dynvar.Resolve(in, func(path dyn.Path) (dyn.Value, error) {
+		if len(path) < 4 || !path.HasPrefix(prefix) {
+			return dyn.InvalidValue, dynvar.ErrSkipResolution
+		}
+		tfType, ok := GroupToTerraformName[path[1].Key()]
+		if !ok {
+			return dyn.InvalidValue, dynvar.ErrSkipResolution
+		}
+		newPath := dyn.NewPath(dyn.Key(tfType)).Append(path[2:]...)
+		return dyn.V(fmt.Sprintf("${%s}", newPath.String())), nil
+	})
+}

--- a/ucm/deploy/terraform/interpolate_test.go
+++ b/ucm/deploy/terraform/interpolate_test.go
@@ -1,0 +1,65 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpolate_RewritesUcmPathToTfPath(t *testing.T) {
+	in := dyn.V(map[string]dyn.Value{
+		"resource": dyn.V(map[string]dyn.Value{
+			"databricks_catalog": dyn.V(map[string]dyn.Value{
+				"sales": dyn.V(map[string]dyn.Value{
+					"name":         dyn.V("sales_prod"),
+					"storage_root": dyn.V("${resources.storage_credentials.sales_cred.name}"),
+				}),
+			}),
+		}),
+	})
+
+	out, err := Interpolate(in)
+	require.NoError(t, err)
+
+	got, ok := out.Get("resource").Get("databricks_catalog").Get("sales").Get("storage_root").AsString()
+	require.True(t, ok)
+	assert.Equal(t, "${databricks_storage_credential.sales_cred.name}", got)
+}
+
+func TestInterpolate_LeavesLiteralsUntouched(t *testing.T) {
+	in := dyn.V(map[string]dyn.Value{
+		"resource": dyn.V(map[string]dyn.Value{
+			"databricks_catalog": dyn.V(map[string]dyn.Value{
+				"sales": dyn.V(map[string]dyn.Value{
+					"storage_root": dyn.V("s3://acme-sales/prod"),
+				}),
+			}),
+		}),
+	})
+
+	out, err := Interpolate(in)
+	require.NoError(t, err)
+
+	got, _ := out.Get("resource").Get("databricks_catalog").Get("sales").Get("storage_root").AsString()
+	assert.Equal(t, "s3://acme-sales/prod", got)
+}
+
+func TestInterpolate_UnknownUcmKindPassesThrough(t *testing.T) {
+	in := dyn.V(map[string]dyn.Value{
+		"resource": dyn.V(map[string]dyn.Value{
+			"databricks_catalog": dyn.V(map[string]dyn.Value{
+				"sales": dyn.V(map[string]dyn.Value{
+					"storage_root": dyn.V("${resources.unknown.foo.bar}"),
+				}),
+			}),
+		}),
+	})
+
+	out, err := Interpolate(in)
+	require.NoError(t, err)
+
+	got, _ := out.Get("resource").Get("databricks_catalog").Get("sales").Get("storage_root").AsString()
+	assert.Equal(t, "${resources.unknown.foo.bar}", got)
+}

--- a/ucm/deploy/terraform/render.go
+++ b/ucm/deploy/terraform/render.go
@@ -29,6 +29,11 @@ func (t *Terraform) Render(ctx context.Context, u *ucm.Ucm) error {
 		return fmt.Errorf("convert ucm to terraform: %w", err)
 	}
 
+	tree, err = Interpolate(tree)
+	if err != nil {
+		return fmt.Errorf("interpolate terraform refs: %w", err)
+	}
+
 	data, err := jsonsaver.MarshalIndent(tree, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal terraform json: %w", err)

--- a/ucm/deploy/terraform/render_test.go
+++ b/ucm/deploy/terraform/render_test.go
@@ -112,6 +112,37 @@ func TestRenderWritesExpectedMainTfJson(t *testing.T) {
 	assert.Equal(t, golden, string(body))
 }
 
+func TestRenderRewritesUcmPathRefsToTfPaths(t *testing.T) {
+	root := t.TempDir()
+	cfg, diags := config.LoadFromBytes(filepath.Join(root, "ucm.yml"), []byte(`
+ucm:
+  name: render-refs-test
+resources:
+  storage_credentials:
+    sales_cred:
+      name: sales_cred
+      aws_iam_role:
+        role_arn: "arn:aws:iam::1:role/uc"
+  catalogs:
+    sales:
+      name: sales_prod
+      storage_root: ${resources.storage_credentials.sales_cred.name}
+`))
+	require.False(t, diags.HasError(), "load: %v", diags)
+	cfg.Ucm.Target = "dev"
+
+	u := &ucm.Ucm{RootPath: root, Config: *cfg}
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+	tf := &Terraform{WorkingDir: workingDir, runnerFactory: defaultRunnerFactory}
+
+	require.NoError(t, tf.Render(t.Context(), u))
+
+	body, err := os.ReadFile(filepath.Join(workingDir, MainConfigFileName))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"storage_root": "${databricks_storage_credential.sales_cred.name}"`)
+}
+
 func TestRenderIsIdempotent(t *testing.T) {
 	u, _ := newRenderUcm(t)
 	workingDir, err := WorkingDir(u)

--- a/ucm/deploy/terraform/tfdyn/convert_storage_credential.go
+++ b/ucm/deploy/terraform/tfdyn/convert_storage_credential.go
@@ -1,0 +1,63 @@
+package tfdyn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+var storageCredentialIdentityFields = []string{
+	"aws_iam_role",
+	"azure_managed_identity",
+	"azure_service_principal",
+	"databricks_gcp_service_account",
+}
+
+// convertStorageCredentialResource transforms a ucm storage_credential entry
+// into a dyn.Value shaped like a databricks_storage_credential Terraform
+// block. Exactly one identity field must be present.
+func convertStorageCredentialResource(_ context.Context, key string, vin dyn.Value) (dyn.Value, error) {
+	pairs := []dyn.Pair{}
+	appendString(&pairs, vin, "name", key)
+	appendStringIfSet(&pairs, vin, "comment")
+
+	var seen string
+	for _, f := range storageCredentialIdentityFields {
+		v := vin.Get(f)
+		if !v.IsValid() {
+			continue
+		}
+		if seen != "" {
+			return dyn.InvalidValue, fmt.Errorf("storage_credential %q: exactly one identity field allowed, got both %s and %s", key, seen, f)
+		}
+		seen = f
+		pairs = append(pairs, dyn.Pair{
+			Key:   dyn.NewValue(f, v.Locations()),
+			Value: v,
+		})
+	}
+	if seen == "" {
+		return dyn.InvalidValue, fmt.Errorf("storage_credential %q: exactly one identity field (aws_iam_role, azure_managed_identity, azure_service_principal, databricks_gcp_service_account) is required", key)
+	}
+
+	appendBoolIfSet(&pairs, vin, "read_only")
+	appendBoolIfSet(&pairs, vin, "skip_validation")
+
+	return dyn.NewValue(dyn.NewMappingFromPairs(pairs), vin.Locations()), nil
+}
+
+type storageCredentialConverter struct{}
+
+func (storageCredentialConverter) Convert(ctx context.Context, key string, vin dyn.Value, out *Resources) error {
+	v, err := convertStorageCredentialResource(ctx, key, vin)
+	if err != nil {
+		return err
+	}
+	out.StorageCredential[key] = v
+	return nil
+}
+
+func init() {
+	registerConverter("storage_credentials", storageCredentialConverter{})
+}

--- a/ucm/deploy/terraform/tfdyn/convert_storage_credential_test.go
+++ b/ucm/deploy/terraform/tfdyn/convert_storage_credential_test.go
@@ -1,0 +1,114 @@
+package tfdyn
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertStorageCredential(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		src  resources.StorageCredential
+		want map[string]any
+	}{
+		{
+			name: "aws iam role",
+			key:  "sales_cred",
+			src: resources.StorageCredential{
+				Name:       "sales_cred",
+				AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/uc"},
+			},
+			want: map[string]any{
+				"name": "sales_cred",
+				"aws_iam_role": map[string]any{
+					"role_arn": "arn:aws:iam::1:role/uc",
+				},
+			},
+		},
+		{
+			name: "azure managed identity",
+			key:  "azure_cred",
+			src: resources.StorageCredential{
+				Name: "azure_cred",
+				AzureManagedIdentity: &resources.AzureManagedIdentity{
+					AccessConnectorId: "/subscriptions/x/rg/acme/providers/Microsoft.Databricks/accessConnectors/uc",
+				},
+			},
+			want: map[string]any{
+				"name": "azure_cred",
+				"azure_managed_identity": map[string]any{
+					"access_connector_id": "/subscriptions/x/rg/acme/providers/Microsoft.Databricks/accessConnectors/uc",
+				},
+			},
+		},
+		{
+			name: "databricks gcp sa",
+			key:  "gcp_cred",
+			src: resources.StorageCredential{
+				Name:                        "gcp_cred",
+				DatabricksGcpServiceAccount: &resources.DatabricksGcpServiceAccount{},
+			},
+			want: map[string]any{
+				"name":                           "gcp_cred",
+				"databricks_gcp_service_account": map[string]any{},
+			},
+		},
+		{
+			name: "with comment and read_only",
+			key:  "ro_cred",
+			src: resources.StorageCredential{
+				Name:       "ro_cred",
+				Comment:    "read-only",
+				ReadOnly:   true,
+				AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/ro"},
+			},
+			want: map[string]any{
+				"name":      "ro_cred",
+				"comment":   "read-only",
+				"read_only": true,
+				"aws_iam_role": map[string]any{
+					"role_arn": "arn:aws:iam::1:role/ro",
+				},
+			},
+		},
+		{
+			name: "defaults name from key",
+			key:  "inferred",
+			src:  resources.StorageCredential{AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/x"}},
+			want: map[string]any{
+				"name": "inferred",
+				"aws_iam_role": map[string]any{
+					"role_arn": "arn:aws:iam::1:role/x",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+			out := NewResources()
+			err = storageCredentialConverter{}.Convert(t.Context(), tc.key, vin, out)
+			require.NoError(t, err)
+			got, ok := out.StorageCredential[tc.key]
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got.AsAny())
+		})
+	}
+}
+
+func TestConvertStorageCredential_ErrorsOnMissingIdentity(t *testing.T) {
+	vin, err := convert.FromTyped(resources.StorageCredential{Name: "bad"}, dyn.NilValue)
+	require.NoError(t, err)
+	out := NewResources()
+	err = storageCredentialConverter{}.Convert(t.Context(), "bad", vin, out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one identity")
+}

--- a/ucm/deploy/terraform/tfdyn/helpers.go
+++ b/ucm/deploy/terraform/tfdyn/helpers.go
@@ -35,6 +35,20 @@ func appendStringIfSet(pairs *[]dyn.Pair, vin dyn.Value, key string) {
 	})
 }
 
+// appendBoolIfSet emits key=vin[key] when vin[key] is a bool true. A false
+// value (the zero) is skipped so the Terraform JSON stays clean.
+func appendBoolIfSet(pairs *[]dyn.Pair, vin dyn.Value, key string) {
+	v := vin.Get(key)
+	b, ok := v.AsBool()
+	if !ok || !b {
+		return
+	}
+	*pairs = append(*pairs, dyn.Pair{
+		Key:   dyn.NewValue(key, v.Locations()),
+		Value: v,
+	})
+}
+
 // mapFromValue returns v as a map-typed dyn.Value when it holds at least
 // one key; otherwise the second return is false so callers can skip
 // emitting an empty map.

--- a/ucm/deploy/terraform/tfdyn/registry.go
+++ b/ucm/deploy/terraform/tfdyn/registry.go
@@ -18,17 +18,19 @@ import (
 // ucm.yml. The wrapper in U5 combines these into a top-level `resource`
 // block.
 type Resources struct {
-	Catalog map[string]dyn.Value
-	Schema  map[string]dyn.Value
-	Grants  map[string]dyn.Value
+	Catalog           map[string]dyn.Value
+	Schema            map[string]dyn.Value
+	Grants            map[string]dyn.Value
+	StorageCredential map[string]dyn.Value
 }
 
 // NewResources returns an empty Resources ready for converters to fill.
 func NewResources() *Resources {
 	return &Resources{
-		Catalog: map[string]dyn.Value{},
-		Schema:  map[string]dyn.Value{},
-		Grants:  map[string]dyn.Value{},
+		Catalog:           map[string]dyn.Value{},
+		Schema:            map[string]dyn.Value{},
+		Grants:            map[string]dyn.Value{},
+		StorageCredential: map[string]dyn.Value{},
 	}
 }
 

--- a/ucm/deploy/terraform/tfdyn/tfdyn.go
+++ b/ucm/deploy/terraform/tfdyn/tfdyn.go
@@ -21,7 +21,7 @@ const (
 // ordering matters because downstream converters inspect earlier ones
 // (schemas look at Resources.Catalog to decide whether to emit depends_on;
 // grants look at Resources.Catalog and Resources.Schema).
-var convertOrder = []string{"catalogs", "schemas", "grants"}
+var convertOrder = []string{"storage_credentials", "catalogs", "schemas", "grants"}
 
 // Convert walks a ucm configuration and produces the Terraform JSON
 // resource tree suitable for writing as a .tf.json file. The returned
@@ -86,6 +86,7 @@ func buildResourceTree(out *Resources) dyn.Value {
 		tfType string
 		values map[string]dyn.Value
 	}{
+		{"databricks_storage_credential", out.StorageCredential},
 		{"databricks_catalog", out.Catalog},
 		{"databricks_schema", out.Schema},
 		{"databricks_grants", out.Grants},

--- a/ucm/phases/deploy.go
+++ b/ucm/phases/deploy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
 	"github.com/databricks/cli/ucm/deploy"
 	"github.com/databricks/cli/ucm/deploy/direct"
 )
@@ -65,6 +66,11 @@ func deployTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
 }
 
 func deployDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
+	ucm.ApplyContext(ctx, u, mutator.ResolveResourceReferences())
+	if logdiag.HasError(ctx) {
+		return
+	}
+
 	factory := opts.directClientFactoryOrDefault()
 	client, err := factory(ctx, u)
 	if err != nil {

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -151,6 +151,20 @@ func (*fakeDirectClient) UpdateSchema(_ context.Context, _ catalog.UpdateSchema)
 
 func (*fakeDirectClient) DeleteSchema(_ context.Context, _ string) error { return nil }
 
+func (*fakeDirectClient) GetStorageCredential(_ context.Context, _ string) (*catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) CreateStorageCredential(_ context.Context, _ catalog.CreateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) UpdateStorageCredential(_ context.Context, _ catalog.UpdateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) DeleteStorageCredential(_ context.Context, _ string) error { return nil }
+
 func (*fakeDirectClient) UpdatePermissions(_ context.Context, _ catalog.UpdatePermissions) error {
 	return nil
 }

--- a/ucm/phases/plan.go
+++ b/ucm/phases/plan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
 	"github.com/databricks/cli/ucm/deploy/direct"
 	"github.com/databricks/cli/ucm/deployplan"
 )
@@ -64,6 +65,11 @@ func planTerraform(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
 }
 
 func planDirect(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
+	ucm.ApplyContext(ctx, u, mutator.ResolveResourceReferences())
+	if logdiag.HasError(ctx) {
+		return nil
+	}
+
 	state, err := direct.LoadState(direct.StatePath(u))
 	if err != nil {
 		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))


### PR DESCRIPTION
Closes #49
Parent epic: #48
Stacked on: #51 (must merge first — this PR's base is that branch; change base to \`main\` after #51 lands)

## Summary

- **New resource**: `storage_credentials` first-class UC resource with day-zero parity across both engines.
  - Terraform engine: `databricks_storage_credential` converter, registered in convertOrder + buildResourceTree ahead of catalogs.
  - Direct engine: full CRUD via `StorageCredentialsAPI` with AWS IAM / Azure MI / Azure SP / Databricks-managed GCP SA one-of identity.
  - Apply ordering updated: storage_credentials create → catalogs → schemas → grants → (reverse on delete).
- **Reference-resolution infrastructure** (ships with this PR because PR #2 will need it):
  - `ResolveResourceReferences` mutator — walks `dyn.Value` config tree, substitutes `${resources.<kind>.<key>.<field>}` with the pointed-at value. Reuses `libs/dyn/dynvar` as-is (shared, not bundle).
  - `Interpolate` pass on the TF side — rewrites `${resources.X.Y.Z}` → `${databricks_X.Y.Z}` so terraform's dependency graph picks up the edge.
  - Wired engine-specifically: mutator runs in `planDirect` / `deployDirect` (resolves to literals for SDK calls); Interpolate runs in Render (preserves TF semantics).

## Why

- Current `ucm deploy` hits `Metastore storage root URL does not exist` because a catalog needs either a metastore with a default root OR a `storage_root` pointing at an external location — both previously unreachable from ucm.yml. `storage_credential` is prerequisite for `external_location`, which is prerequisite for `storage_root` on catalogs. Phase A of the epic closes that chain end-to-end.
- Hard constraint per `cmd/ucm/CLAUDE.md` + prior design: every resource ships on both engines from day zero, with both bring-your-own (literal) and ucm-managed (`${resources.*}`) references working. This PR satisfies both.

## Test plan

- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`
- [x] Unit tests pin: literal refs pass through / `${resources.*}` resolves / unknown ref errors / non-resource refs left untouched (mutator); ucm-path rewritten to tf-path / literals untouched / unknown kind passes through (Interpolate).
- [x] Render-level test: ucm-path ref in YAML → `${databricks_storage_credential.*}` in rendered `main.tf.json`.
- [x] Direct-engine: create/update/skip/delete coverage for storage_credential, including AWS + Azure MI + Azure SP + Databricks GCP shapes; missing-identity rejected before any API call.
- [ ] Acceptance fixture `acceptance/ucm/plan/storage_credential/` covers both reference forms. `output.txt` is deferred to CI -update (local env can't reach releases.hashicorp.com for terraform install — matches the precedent from 48dc42a10 for the other plan fixtures).
- [ ] Manual smoke in a real workspace is deferred until #51 + this PR are merged to `main` and I can run against a workspace with UC admin rights.

## Follow-on

Phase A PR #2 (external_location) opens next, depends on this PR's mutator + Interpolate infra plus the new `GroupToTerraformName` entry.

## Fork-rule compliance

No edits under `bundle/**`. `libs/dyn/dynvar` reused directly (shared library, not bundle). Mutator + Interpolate forked-and-adapted per the no-bundle-imports rule.