### PR TITLE
Fix #55: Include storage_credential in ucm plan summary

### DIFF
--- a/ucm/deploy/terraform/showplan.go
+++ b/ucm/deploy/terraform/showplan.go
@@ -17,9 +17,10 @@ import (
 // and pinning to a bundle map will drift as upstream adds resources ucm does
 // not model. See cmd/ucm/CLAUDE.md on fork isolation.
 var terraformToGroupName = map[string]string{
-	"databricks_catalog": "catalogs",
-	"databricks_schema":  "schemas",
-	"databricks_grants":  "grants",
+	"databricks_catalog":            "catalogs",
+	"databricks_schema":             "schemas",
+	"databricks_grants":             "grants",
+	"databricks_storage_credential": "storage_credentials",
 }
 
 // populatePlan fills `plan` from terraform resource changes using the

--- a/ucm/deploy/terraform/showplan_test.go
+++ b/ucm/deploy/terraform/showplan_test.go
@@ -21,11 +21,13 @@ func TestPopulatePlan_MapsActionsAndKeys(t *testing.T) {
 		{Type: "databricks_catalog", Name: "main", Change: change(tfjson.Actions{tfjson.ActionCreate})},
 		{Type: "databricks_schema", Name: "sales_raw", Change: change(tfjson.Actions{tfjson.ActionUpdate})},
 		{Type: "databricks_grants", Name: "analysts", Change: change(tfjson.Actions{tfjson.ActionDelete})},
+		{Type: "databricks_storage_credential", Name: "sales_cred", Change: change(tfjson.Actions{tfjson.ActionCreate})},
 	})
 
 	assert.Equal(t, deployplan.Create, plan.Plan["resources.catalogs.main"].Action)
 	assert.Equal(t, deployplan.Update, plan.Plan["resources.schemas.sales_raw"].Action)
 	assert.Equal(t, deployplan.Delete, plan.Plan["resources.grants.analysts"].Action)
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.storage_credentials.sales_cred"].Action)
 }
 
 func TestPopulatePlan_ReplaceBecomesRecreate(t *testing.T) {


### PR DESCRIPTION
Closes #55

## Summary

Add \`databricks_storage_credential\` → \`storage_credentials\` to \`terraformToGroupName\` in \`ucm/deploy/terraform/showplan.go\`. Without it the plan summarizer dropped storage_credential changes on the floor — terraform planned the create correctly but \`ucm plan\` reported \`0 to add\` plus a \`Warn: unknown resource type "databricks_storage_credential"\`.

## Why

Regression from PR #52. The tfdyn converter, the interpolate rewrite table, and the direct engine all got updated for storage_credential, but the terraform-plan summary's allowlist didn't. `TestPopulatePlan_MapsActionsAndKeys` now covers the new type so the next resource's PR is forced to touch this file too.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./cmd/ucm/... ./ucm/...\`
- [x] \`go test ./cmd/ucm/... ./ucm/...\`
- [x] Manual: re-run the reporter's fixture, confirm \`Plan: 1 to add\` with no warning.

## Follow-on

Filed as a footnote on #55: \`terraformToGroupName\` and \`GroupToTerraformName\` (in interpolate.go) are shadow copies of each other. One should be derived from the other — separate tracking issue, not part of this fix.