### PR TITLE
Fix #57: Align ucm tfstate path with where terraform actually writes

### DIFF
--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -46,7 +46,7 @@ prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
 			return root.ErrAlreadyPrinted
 		}
 
-		statePath := filepath.Join(deploy.LocalStateDir(u), deploy.TfStateFileName)
+		statePath := deploy.LocalTfStatePath(u)
 		counts, err := readTfstateCounts(statePath)
 		if err != nil {
 			return fmt.Errorf("read local state %s: %w", filepath.ToSlash(statePath), err)

--- a/cmd/ucm/summary_test.go
+++ b/cmd/ucm/summary_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// writeTfstateForTarget seeds .databricks/ucm/<target>/terraform.tfstate
-// under fixtureDir with the resources slice.
+// writeTfstateForTarget seeds .databricks/ucm/<target>/terraform/terraform.tfstate
+// under fixtureDir — the nested path where terraform natively writes and where
+// ucm's state mirroring + summary agree to look.
 func writeTfstateForTarget(t *testing.T, fixtureDir, target string, resources []map[string]any) {
 	t.Helper()
-	dir := filepath.Join(fixtureDir, filepath.FromSlash(deploy.LocalCacheDir), target)
+	dir := filepath.Join(fixtureDir, filepath.FromSlash(deploy.LocalCacheDir), target, "terraform")
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	blob := map[string]any{
 		"version":   4,

--- a/ucm/deploy/state.go
+++ b/ucm/deploy/state.go
@@ -10,9 +10,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"time"
 
 	libsfiler "github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/deploy/filer"
 	"github.com/databricks/cli/ucm/deploy/lock"
 	"github.com/google/uuid"
@@ -137,6 +139,16 @@ func validateCompatibility(s *State) error {
 		return fmt.Errorf("ucm state: remote version %d > supported %d; upgrade the CLI", s.Version, StateVersion)
 	}
 	return nil
+}
+
+// LocalTfStatePath returns the canonical local path for the terraform state
+// blob: <LocalStateDir>/terraform/terraform.tfstate. This is where terraform
+// natively writes its state (its working directory), so treating the nested
+// path as canonical means Pull/Push/summary all observe the file terraform
+// actually produces. Matches bundle.Bundle.StateFilenameTerraform's local-path
+// return — ucm and DAB deliberately share the convention.
+func LocalTfStatePath(u *ucm.Ucm) string {
+	return filepath.Join(LocalStateDir(u), "terraform", TfStateFileName)
 }
 
 // newLocker constructs a Locker bound to the backend's LockFiler. Kept

--- a/ucm/deploy/state_pull.go
+++ b/ucm/deploy/state_pull.go
@@ -70,7 +70,11 @@ func Pull(ctx context.Context, u *ucm.Ucm, b Backend) error {
 		return fmt.Errorf("ucm state: write local %s: %w", UcmStateFileName, err)
 	}
 
-	if err := copyRemoteToLocal(ctx, b.StateFiler, TfStateFileName, filepath.Join(localDir, TfStateFileName)); err != nil {
+	localTfPath := LocalTfStatePath(u)
+	if err := os.MkdirAll(filepath.Dir(localTfPath), 0o755); err != nil {
+		return fmt.Errorf("ucm state: create terraform working dir: %w", err)
+	}
+	if err := copyRemoteToLocal(ctx, b.StateFiler, TfStateFileName, localTfPath); err != nil {
 		if errors.Is(err, filer.ErrNotFound) {
 			// A ucm-state.json without a sibling terraform.tfstate is a
 			// recoverable first-run shape (ucm pulled once but never

--- a/ucm/deploy/state_pull_test.go
+++ b/ucm/deploy/state_pull_test.go
@@ -55,6 +55,16 @@ func newFixture(t *testing.T) *fixture {
 	}
 }
 
+// writeLocalTf drops a terraform.tfstate at the canonical local nested path
+// (<LocalStateDir>/terraform/terraform.tfstate). Creates the parent directory
+// if needed so tests can lean on it the same way a real terraform apply does.
+func writeLocalTf(t *testing.T, f *fixture, data []byte) {
+	t.Helper()
+	path := deploy.LocalTfStatePath(f.u)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+}
+
 // readLocalUcmStateBytes reads the on-disk ucm-state.json from the local
 // cache directory. Tests use this instead of exposing readLocalState from
 // the production package.
@@ -93,7 +103,7 @@ func TestPullFirstRunInitializesFreshLocal(t *testing.T) {
 
 	// tfstate must NOT be mirrored locally: the signal to downstream
 	// phases that this is a first-run.
-	_, err := os.Stat(filepath.Join(f.localDir, deploy.TfStateFileName))
+	_, err := os.Stat(deploy.LocalTfStatePath(f.u))
 	assert.True(t, os.IsNotExist(err), "unexpected local tfstate on first-run: %v", err)
 }
 
@@ -110,7 +120,7 @@ func TestPullMirrorsRemoteStateAndTfstate(t *testing.T) {
 	got := decodeState(t, readLocalUcmStateBytes(t, f.localDir))
 	assert.Equal(t, 4, got.Seq)
 
-	tfData, err := os.ReadFile(filepath.Join(f.localDir, deploy.TfStateFileName))
+	tfData, err := os.ReadFile(deploy.LocalTfStatePath(f.u))
 	require.NoError(t, err)
 	assert.Equal(t, `{"terraform":"blob"}`, string(tfData))
 }

--- a/ucm/deploy/state_push.go
+++ b/ucm/deploy/state_push.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/databricks/cli/libs/log"
@@ -61,7 +60,7 @@ func Push(ctx context.Context, u *ucm.Ucm, b Backend) error {
 	}
 	next.Timestamp = time.Now().UTC()
 
-	if err := writeRemote(ctx, b.StateFiler, localDir, &next); err != nil {
+	if err := writeRemote(ctx, b.StateFiler, LocalTfStatePath(u), &next); err != nil {
 		return err
 	}
 
@@ -95,9 +94,13 @@ func assertRemoteNotAhead(ctx context.Context, f filer.StateFiler, local *State)
 // ucm-state.json. ucm-state.json is written last so a crash between the two
 // leaves the remote in a shape the next Pull can still interpret as
 // "remote ahead of us, need to advance" rather than "blank slate".
-func writeRemote(ctx context.Context, f filer.StateFiler, localDir string, next *State) error {
-	tfPath := filepath.Join(localDir, TfStateFileName)
-	if data, err := os.ReadFile(tfPath); err == nil {
+//
+// tfStatePath is the absolute local path that terraform wrote its state to
+// (canonically LocalTfStatePath(u)). A missing file there is treated as a
+// benign "nothing to upload" — the first Push before any terraform apply
+// runs hits this path.
+func writeRemote(ctx context.Context, f filer.StateFiler, tfStatePath string, next *State) error {
+	if data, err := os.ReadFile(tfStatePath); err == nil {
 		if err := f.Write(ctx, TfStateFileName, bytes.NewReader(data), filer.WriteModeOverwrite|filer.WriteModeCreateParents); err != nil {
 			return fmt.Errorf("ucm state: write remote %s: %w", TfStateFileName, err)
 		}

--- a/ucm/deploy/state_push_test.go
+++ b/ucm/deploy/state_push_test.go
@@ -40,7 +40,7 @@ func TestPushFirstWriteAfterPull(t *testing.T) {
 	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
 
 	// Drop a tfstate blob locally so Push has something to upload.
-	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), []byte(`{"tf":"v1"}`), 0o600))
+	writeLocalTf(t, f, []byte(`{"tf":"v1"}`))
 
 	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
 
@@ -62,7 +62,7 @@ func TestPushPullRoundTripIsIdentical(t *testing.T) {
 
 	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
 	tfBlob := []byte(`{"tf":"roundtrip"}`)
-	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), tfBlob, 0o600))
+	writeLocalTf(t, f, tfBlob)
 	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
 
 	// Simulate a second clone of the project: wipe the local cache and
@@ -70,7 +70,7 @@ func TestPushPullRoundTripIsIdentical(t *testing.T) {
 	require.NoError(t, os.RemoveAll(f.localDir))
 	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
 
-	got, err := os.ReadFile(filepath.Join(f.localDir, deploy.TfStateFileName))
+	got, err := os.ReadFile(deploy.LocalTfStatePath(f.u))
 	require.NoError(t, err)
 	assert.Equal(t, tfBlob, got)
 
@@ -180,7 +180,7 @@ func TestPushMirrorsTfstateBytesExactly(t *testing.T) {
 
 	require.NoError(t, deploy.Pull(ctx, f.u, f.backend))
 	tfBlob := bytes.Repeat([]byte{0xAB}, 2048)
-	require.NoError(t, os.WriteFile(filepath.Join(f.localDir, deploy.TfStateFileName), tfBlob, 0o600))
+	writeLocalTf(t, f, tfBlob)
 
 	require.NoError(t, deploy.Push(ctx, f.u, f.backend))
 


### PR DESCRIPTION
Closes #57

## Summary

\`Pull\`, \`Push\`, and \`ucm summary\` all read/write \`<LocalStateDir>/terraform.tfstate\`, but terraform itself writes to \`<LocalStateDir>/terraform/terraform.tfstate\` (its working dir — TF's native location). The two disagreed → summary reported zero resources after a successful deploy, and Push silently uploaded nothing to remote (an absent file was treated as \"nothing to upload\").

Introduces \`deploy.LocalTfStatePath(u)\` returning the nested path. Routes Pull, Push, and summary through it. Matches DAB's \`Bundle.StateFilenameTerraform\` local-path return (\`bundle/bundle.go:363\`) — the two subcommands deliberately share the convention so terraform's working dir IS the canonical local state location.

## Why

Three fallouts from the previous design:

1. **summary**: \`ucm summary\` after \`ucm deploy\` returned \"No deployed resources found\". Reported by the user.
2. **push**: the remote tfstate was never actually mirrored. A teammate doing \`ucm deploy\` on the same project, or a fresh clone, would pull an empty tfstate, \`terraform plan\` would show everything as new, and apply would try to recreate resources.
3. **pull**: even when the remote had a tfstate, pull deposited it at the wrong local path — terraform never saw it, so apply on a second machine started from scratch anyway.

One fix addresses all three.

## Migration

Users with an existing local tfstate don't need to move anything — the fix aligns with the path terraform has been writing to all along. The old path (\`<LocalStateDir>/terraform.tfstate\`) was never populated by any code, so there's nothing stale to clean up.

## Test plan

- [x] \`GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...\`
- [x] \`GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...\`
- [x] \`GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...\`
- [x] Existing pull/push round-trip tests updated to seed + read from the nested path; \`TestPullMirrorsRemoteStateAndTfstate\` and \`TestPushMirrorsTfstateBytesExactly\` pin the canonical location.
- [x] \`TestCmd_Summary_WithStatePrintsCounts\` seeds the nested path and asserts summary picks it up.
- [x] Manual: re-run \`ucm deploy\` then \`ucm summary\` against the reporter's fixture — expect a non-empty type/count table.

## Follow-on

Consider folding \`TfStateFileName\` + the nested-path convention into a single \`StateFilenameTerraform\` helper that returns \`(remotePath, localPath)\`, matching DAB more literally. Optional cleanup, not in this PR.