### PR TITLE
Feat: Complete Phase A — external_location + volume + connection (closes #59 #60 #61)

### DIFF
--- a/acceptance/ucm/plan/connection/script
+++ b/acceptance/ucm/plan/connection/script
@@ -1,0 +1,1 @@
+trace $CLI ucm plan

--- a/acceptance/ucm/plan/connection/test.toml
+++ b/acceptance/ucm/plan/connection/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/plan/connection/ucm.yml
+++ b/acceptance/ucm/plan/connection/ucm.yml
@@ -1,0 +1,24 @@
+ucm:
+  name: plan-connection
+  engine: direct
+
+resources:
+  connections:
+    sales_mysql:
+      name: sales_mysql
+      connection_type: MYSQL
+      comment: "foreign sales db"
+      options:
+        host: mysql.acme.internal
+        port: "3306"
+        user: uc-reader
+      properties:
+        purpose: analytics
+
+    warehouse_pg:
+      name: warehouse_pg
+      connection_type: POSTGRESQL
+      read_only: true
+      options:
+        host: pg.acme.internal
+        user: uc-reader

--- a/acceptance/ucm/plan/external_location/script
+++ b/acceptance/ucm/plan/external_location/script
@@ -1,0 +1,1 @@
+trace $CLI ucm plan

--- a/acceptance/ucm/plan/external_location/test.toml
+++ b/acceptance/ucm/plan/external_location/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/plan/external_location/ucm.yml
+++ b/acceptance/ucm/plan/external_location/ucm.yml
@@ -1,0 +1,22 @@
+ucm:
+  name: plan-external-location
+  engine: direct
+
+resources:
+  storage_credentials:
+    sales_cred:
+      name: sales_cred
+      aws_iam_role:
+        role_arn: "arn:aws:iam::111122223333:role/uc-sales"
+
+  external_locations:
+    sales_loc:
+      name: sales_loc
+      url: "s3://acme-sales/prod"
+      credential_name: ${resources.storage_credentials.sales_cred.name}
+
+    shared_loc:
+      name: shared_loc
+      url: "abfss://shared@acme.dfs.core.windows.net/common"
+      credential_name: preexisting_shared_cred
+      read_only: true

--- a/acceptance/ucm/plan/volume/script
+++ b/acceptance/ucm/plan/volume/script
@@ -1,0 +1,1 @@
+trace $CLI ucm plan

--- a/acceptance/ucm/plan/volume/test.toml
+++ b/acceptance/ucm/plan/volume/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/plan/volume/ucm.yml
+++ b/acceptance/ucm/plan/volume/ucm.yml
@@ -1,0 +1,28 @@
+ucm:
+  name: plan-volume
+  engine: direct
+
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+
+  schemas:
+    raw:
+      name: raw
+      catalog: sales
+
+  volumes:
+    landing:
+      name: landing
+      catalog_name: ${resources.catalogs.sales.name}
+      schema_name: ${resources.schemas.raw.name}
+      volume_type: MANAGED
+      comment: "managed landing volume"
+
+    archive:
+      name: archive
+      catalog_name: sales_prod
+      schema_name: raw
+      volume_type: EXTERNAL
+      storage_location: "s3://acme-archive/sales/raw"

--- a/ucm/config/resources.go
+++ b/ucm/config/resources.go
@@ -10,5 +10,6 @@ type Resources struct {
 	Schemas            map[string]*resources.Schema            `json:"schemas,omitempty"`
 	Grants             map[string]*resources.Grant             `json:"grants,omitempty"`
 	StorageCredentials map[string]*resources.StorageCredential `json:"storage_credentials,omitempty"`
+	ExternalLocations  map[string]*resources.ExternalLocation  `json:"external_locations,omitempty"`
 	TagValidationRules map[string]*resources.TagValidationRule `json:"tag_validation_rules,omitempty"`
 }

--- a/ucm/config/resources.go
+++ b/ucm/config/resources.go
@@ -11,5 +11,7 @@ type Resources struct {
 	Grants             map[string]*resources.Grant             `json:"grants,omitempty"`
 	StorageCredentials map[string]*resources.StorageCredential `json:"storage_credentials,omitempty"`
 	ExternalLocations  map[string]*resources.ExternalLocation  `json:"external_locations,omitempty"`
+	Volumes            map[string]*resources.Volume            `json:"volumes,omitempty"`
+	Connections        map[string]*resources.Connection        `json:"connections,omitempty"`
 	TagValidationRules map[string]*resources.TagValidationRule `json:"tag_validation_rules,omitempty"`
 }

--- a/ucm/config/resources/connection.go
+++ b/ucm/config/resources/connection.go
@@ -1,0 +1,18 @@
+package resources
+
+// Connection is a UC foreign-catalog connection (the federation link that
+// lets a foreign catalog reference tables in MySQL, PostgreSQL, Snowflake,
+// etc.). Field names mirror databricks-sdk-go's catalog.CreateConnection.
+//
+// ConnectionType is a free string matching the SDK enum (e.g. MYSQL,
+// POSTGRESQL, SNOWFLAKE, REDSHIFT, BIGQUERY). Options carries the
+// connection-specific configuration (host, port, user, password, etc.) and
+// must contain at least enough keys for UC to authenticate.
+type Connection struct {
+	Name           string            `json:"name"`
+	ConnectionType string            `json:"connection_type"`
+	Options        map[string]string `json:"options"`
+	Comment        string            `json:"comment,omitempty"`
+	Properties     map[string]string `json:"properties,omitempty"`
+	ReadOnly       bool              `json:"read_only,omitempty"`
+}

--- a/ucm/config/resources/external_location.go
+++ b/ucm/config/resources/external_location.go
@@ -1,0 +1,19 @@
+package resources
+
+// ExternalLocation is a UC external location. URL + storage credential
+// together grant UC access to a specific cloud-storage prefix. Field names
+// mirror databricks-sdk-go's catalog.CreateExternalLocation so the direct-
+// engine input builder stays a 1:1 copy rather than a mapping layer.
+//
+// M0 scope: name, url, credential_name, comment, read_only, skip_validation,
+// fallback. Encryption details and file-event queue support land later.
+type ExternalLocation struct {
+	Name           string `json:"name"`
+	Url            string `json:"url"`
+	CredentialName string `json:"credential_name"`
+
+	Comment        string `json:"comment,omitempty"`
+	ReadOnly       bool   `json:"read_only,omitempty"`
+	SkipValidation bool   `json:"skip_validation,omitempty"`
+	Fallback       bool   `json:"fallback,omitempty"`
+}

--- a/ucm/config/resources/volume.go
+++ b/ucm/config/resources/volume.go
@@ -1,0 +1,17 @@
+package resources
+
+// Volume is a UC volume (managed or external). Field names mirror
+// databricks-sdk-go's catalog.CreateVolumeRequestContent so the direct-
+// engine input builder stays a 1:1 copy.
+//
+// VolumeType is "MANAGED" (UC provisions the underlying storage) or
+// "EXTERNAL" (points at a cloud path under an external_location).
+// StorageLocation is required for EXTERNAL and unset for MANAGED.
+type Volume struct {
+	Name            string `json:"name"`
+	CatalogName     string `json:"catalog_name"`
+	SchemaName      string `json:"schema_name"`
+	VolumeType      string `json:"volume_type"`
+	StorageLocation string `json:"storage_location,omitempty"`
+	Comment         string `json:"comment,omitempty"`
+}

--- a/ucm/deploy/direct/apply.go
+++ b/ucm/deploy/direct/apply.go
@@ -43,7 +43,13 @@ func Apply(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan
 	if err := applySchemaCreates(ctx, u, client, plan, state); err != nil {
 		return err
 	}
+	if err := applyVolumeCreates(ctx, u, client, plan, state); err != nil {
+		return err
+	}
 	if err := applyGrantChanges(ctx, u, client, plan, state); err != nil {
+		return err
+	}
+	if err := applyVolumeDeletes(ctx, client, plan, state); err != nil {
 		return err
 	}
 	if err := applySchemaDeletes(ctx, client, plan, state); err != nil {
@@ -68,6 +74,9 @@ func Destroy(ctx context.Context, u *ucm.Ucm, client Client, state *State) (*dep
 	plan := deployplan.NewPlanTerraform()
 	for key := range state.Grants {
 		plan.Plan["resources.grants."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
+	}
+	for key := range state.Volumes {
+		plan.Plan["resources.volumes."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
 	}
 	for key := range state.Schemas {
 		plan.Plan["resources.schemas."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
@@ -223,6 +232,54 @@ func applySchemaCreates(ctx context.Context, u *ucm.Ucm, client Client, plan *de
 			}
 			state.Schemas[name] = ptrSchema(schemaStateFromConfig(cfg))
 		}
+	}
+	return nil
+}
+
+func applyVolumeCreates(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range sortedPlanKeysByGroup(plan, "volumes") {
+		entry := plan.Plan[key]
+		name := strings.TrimPrefix(key, "resources.volumes.")
+		cfg := u.Config.Resources.Volumes[name]
+		switch entry.Action {
+		case deployplan.Create:
+			log.Infof(ctx, "direct: creating volume %s.%s.%s", cfg.CatalogName, cfg.SchemaName, cfg.Name)
+			in, err := volumeCreateInput(cfg)
+			if err != nil {
+				return fmt.Errorf("create volume %s.%s.%s: %w", cfg.CatalogName, cfg.SchemaName, cfg.Name, err)
+			}
+			if _, err := client.CreateVolume(ctx, in); err != nil {
+				return fmt.Errorf("create volume %s.%s.%s: %w", cfg.CatalogName, cfg.SchemaName, cfg.Name, err)
+			}
+			state.Volumes[name] = ptrVolume(volumeStateFromConfig(cfg))
+		case deployplan.Update:
+			log.Infof(ctx, "direct: updating volume %s.%s.%s", cfg.CatalogName, cfg.SchemaName, cfg.Name)
+			if _, err := client.UpdateVolume(ctx, volumeUpdateInput(cfg)); err != nil {
+				return fmt.Errorf("update volume %s.%s.%s: %w", cfg.CatalogName, cfg.SchemaName, cfg.Name, err)
+			}
+			state.Volumes[name] = ptrVolume(volumeStateFromConfig(cfg))
+		}
+	}
+	return nil
+}
+
+func applyVolumeDeletes(ctx context.Context, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range reverseSortedPlanKeysByGroup(plan, "volumes") {
+		entry := plan.Plan[key]
+		if entry.Action != deployplan.Delete {
+			continue
+		}
+		name := strings.TrimPrefix(key, "resources.volumes.")
+		rec, ok := state.Volumes[name]
+		if !ok {
+			continue
+		}
+		fullName := rec.CatalogName + "." + rec.SchemaName + "." + rec.Name
+		log.Infof(ctx, "direct: deleting volume %s", fullName)
+		if err := client.DeleteVolume(ctx, fullName); err != nil {
+			return fmt.Errorf("delete volume %s: %w", fullName, err)
+		}
+		delete(state.Volumes, name)
 	}
 	return nil
 }
@@ -428,6 +485,40 @@ func storageCredentialUpdateInput(c *resources.StorageCredential) (catalog.Updat
 	return in, nil
 }
 
+// volumeCreateInput validates the MANAGED/EXTERNAL invariant and builds the
+// SDK Create payload. EXTERNAL volumes require storage_location; MANAGED ones
+// must not carry one.
+func volumeCreateInput(v *resources.Volume) (catalog.CreateVolumeRequestContent, error) {
+	vType := strings.ToUpper(v.VolumeType)
+	if vType != "MANAGED" && vType != "EXTERNAL" {
+		return catalog.CreateVolumeRequestContent{}, fmt.Errorf("volume %q: volume_type must be MANAGED or EXTERNAL, got %q", v.Name, v.VolumeType)
+	}
+	if vType == "EXTERNAL" && v.StorageLocation == "" {
+		return catalog.CreateVolumeRequestContent{}, fmt.Errorf("volume %q: storage_location is required for EXTERNAL volumes", v.Name)
+	}
+	if vType == "MANAGED" && v.StorageLocation != "" {
+		return catalog.CreateVolumeRequestContent{}, fmt.Errorf("volume %q: storage_location must not be set for MANAGED volumes", v.Name)
+	}
+	return catalog.CreateVolumeRequestContent{
+		Name:            v.Name,
+		CatalogName:     v.CatalogName,
+		SchemaName:      v.SchemaName,
+		VolumeType:      catalog.VolumeType(vType),
+		StorageLocation: v.StorageLocation,
+		Comment:         v.Comment,
+	}, nil
+}
+
+// volumeUpdateInput produces a comment-only update. The UC API only supports
+// renaming, changing the owner, or updating the comment on a volume — drift
+// on catalog/schema/volume_type/storage_location is effectively immutable.
+func volumeUpdateInput(v *resources.Volume) catalog.UpdateVolumeRequestContent {
+	return catalog.UpdateVolumeRequestContent{
+		Name:    v.CatalogName + "." + v.SchemaName + "." + v.Name,
+		Comment: v.Comment,
+	}
+}
+
 func externalLocationCreateInput(e *resources.ExternalLocation) catalog.CreateExternalLocation {
 	return catalog.CreateExternalLocation{
 		Name:           e.Name,
@@ -601,3 +692,5 @@ func ptrStorageCredential(s StorageCredentialState) *StorageCredentialState {
 }
 
 func ptrExternalLocation(s ExternalLocationState) *ExternalLocationState { return &s }
+
+func ptrVolume(s VolumeState) *VolumeState { return &s }

--- a/ucm/deploy/direct/apply.go
+++ b/ucm/deploy/direct/apply.go
@@ -20,9 +20,10 @@ import (
 //
 // Execution order is the natural UC dependency order:
 //
-//	storage_credential creates+updates → catalog creates+updates
-//	→ schema creates+updates → grants reconcile → schema deletes
-//	→ catalog deletes → storage_credential deletes
+//	storage_credential creates+updates → external_location creates+updates
+//	→ catalog creates+updates → schema creates+updates → grants reconcile
+//	→ schema deletes → catalog deletes → external_location deletes
+//	→ storage_credential deletes
 //
 // Grants are reconciled per securable in a single pass (Create, Update, and
 // Delete share the code path) because the UC API treats grants as a full
@@ -31,6 +32,9 @@ import (
 // observable to users in the plan output.
 func Apply(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
 	if err := applyStorageCredentialCreates(ctx, u, client, plan, state); err != nil {
+		return err
+	}
+	if err := applyExternalLocationCreates(ctx, u, client, plan, state); err != nil {
 		return err
 	}
 	if err := applyCatalogCreates(ctx, u, client, plan, state); err != nil {
@@ -46,6 +50,9 @@ func Apply(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan
 		return err
 	}
 	if err := applyCatalogDeletes(ctx, client, plan, state); err != nil {
+		return err
+	}
+	if err := applyExternalLocationDeletes(ctx, client, plan, state); err != nil {
 		return err
 	}
 	if err := applyStorageCredentialDeletes(ctx, client, plan, state); err != nil {
@@ -67,6 +74,9 @@ func Destroy(ctx context.Context, u *ucm.Ucm, client Client, state *State) (*dep
 	}
 	for key := range state.Catalogs {
 		plan.Plan["resources.catalogs."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
+	}
+	for key := range state.ExternalLocations {
+		plan.Plan["resources.external_locations."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
 	}
 	for key := range state.StorageCredentials {
 		plan.Plan["resources.storage_credentials."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
@@ -124,6 +134,49 @@ func applyStorageCredentialDeletes(ctx context.Context, client Client, plan *dep
 			return fmt.Errorf("delete storage_credential %s: %w", rec.Name, err)
 		}
 		delete(state.StorageCredentials, name)
+	}
+	return nil
+}
+
+func applyExternalLocationCreates(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range sortedPlanKeysByGroup(plan, "external_locations") {
+		entry := plan.Plan[key]
+		name := strings.TrimPrefix(key, "resources.external_locations.")
+		cfg := u.Config.Resources.ExternalLocations[name]
+		switch entry.Action {
+		case deployplan.Create:
+			log.Infof(ctx, "direct: creating external_location %s", name)
+			if _, err := client.CreateExternalLocation(ctx, externalLocationCreateInput(cfg)); err != nil {
+				return fmt.Errorf("create external_location %s: %w", name, err)
+			}
+			state.ExternalLocations[name] = ptrExternalLocation(externalLocationStateFromConfig(cfg))
+		case deployplan.Update:
+			log.Infof(ctx, "direct: updating external_location %s", name)
+			if _, err := client.UpdateExternalLocation(ctx, externalLocationUpdateInput(cfg)); err != nil {
+				return fmt.Errorf("update external_location %s: %w", name, err)
+			}
+			state.ExternalLocations[name] = ptrExternalLocation(externalLocationStateFromConfig(cfg))
+		}
+	}
+	return nil
+}
+
+func applyExternalLocationDeletes(ctx context.Context, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range reverseSortedPlanKeysByGroup(plan, "external_locations") {
+		entry := plan.Plan[key]
+		if entry.Action != deployplan.Delete {
+			continue
+		}
+		name := strings.TrimPrefix(key, "resources.external_locations.")
+		rec, ok := state.ExternalLocations[name]
+		if !ok {
+			continue
+		}
+		log.Infof(ctx, "direct: deleting external_location %s", rec.Name)
+		if err := client.DeleteExternalLocation(ctx, rec.Name); err != nil {
+			return fmt.Errorf("delete external_location %s: %w", rec.Name, err)
+		}
+		delete(state.ExternalLocations, name)
 	}
 	return nil
 }
@@ -375,6 +428,30 @@ func storageCredentialUpdateInput(c *resources.StorageCredential) (catalog.Updat
 	return in, nil
 }
 
+func externalLocationCreateInput(e *resources.ExternalLocation) catalog.CreateExternalLocation {
+	return catalog.CreateExternalLocation{
+		Name:           e.Name,
+		Url:            e.Url,
+		CredentialName: e.CredentialName,
+		Comment:        e.Comment,
+		ReadOnly:       e.ReadOnly,
+		SkipValidation: e.SkipValidation,
+		Fallback:       e.Fallback,
+	}
+}
+
+func externalLocationUpdateInput(e *resources.ExternalLocation) catalog.UpdateExternalLocation {
+	return catalog.UpdateExternalLocation{
+		Name:           e.Name,
+		Url:            e.Url,
+		CredentialName: e.CredentialName,
+		Comment:        e.Comment,
+		ReadOnly:       e.ReadOnly,
+		SkipValidation: e.SkipValidation,
+		Fallback:       e.Fallback,
+	}
+}
+
 func buildUpdatePermissions(sec securable, grants []*resources.Grant) catalog.UpdatePermissions {
 	changes := make([]catalog.PermissionsChange, 0, len(grants))
 	for _, g := range grants {
@@ -522,3 +599,5 @@ func ptrGrant(s GrantState) *GrantState       { return &s }
 func ptrStorageCredential(s StorageCredentialState) *StorageCredentialState {
 	return &s
 }
+
+func ptrExternalLocation(s ExternalLocationState) *ExternalLocationState { return &s }

--- a/ucm/deploy/direct/apply.go
+++ b/ucm/deploy/direct/apply.go
@@ -46,7 +46,13 @@ func Apply(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan
 	if err := applyVolumeCreates(ctx, u, client, plan, state); err != nil {
 		return err
 	}
+	if err := applyConnectionCreates(ctx, u, client, plan, state); err != nil {
+		return err
+	}
 	if err := applyGrantChanges(ctx, u, client, plan, state); err != nil {
+		return err
+	}
+	if err := applyConnectionDeletes(ctx, client, plan, state); err != nil {
 		return err
 	}
 	if err := applyVolumeDeletes(ctx, client, plan, state); err != nil {
@@ -74,6 +80,9 @@ func Destroy(ctx context.Context, u *ucm.Ucm, client Client, state *State) (*dep
 	plan := deployplan.NewPlanTerraform()
 	for key := range state.Grants {
 		plan.Plan["resources.grants."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
+	}
+	for key := range state.Connections {
+		plan.Plan["resources.connections."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
 	}
 	for key := range state.Volumes {
 		plan.Plan["resources.volumes."+key] = &deployplan.PlanEntry{Action: deployplan.Delete}
@@ -280,6 +289,53 @@ func applyVolumeDeletes(ctx context.Context, client Client, plan *deployplan.Pla
 			return fmt.Errorf("delete volume %s: %w", fullName, err)
 		}
 		delete(state.Volumes, name)
+	}
+	return nil
+}
+
+func applyConnectionCreates(ctx context.Context, u *ucm.Ucm, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range sortedPlanKeysByGroup(plan, "connections") {
+		entry := plan.Plan[key]
+		name := strings.TrimPrefix(key, "resources.connections.")
+		cfg := u.Config.Resources.Connections[name]
+		switch entry.Action {
+		case deployplan.Create:
+			log.Infof(ctx, "direct: creating connection %s", cfg.Name)
+			in, err := connectionCreateInput(cfg)
+			if err != nil {
+				return fmt.Errorf("create connection %s: %w", cfg.Name, err)
+			}
+			if _, err := client.CreateConnection(ctx, in); err != nil {
+				return fmt.Errorf("create connection %s: %w", cfg.Name, err)
+			}
+			state.Connections[name] = ptrConnection(connectionStateFromConfig(cfg))
+		case deployplan.Update:
+			log.Infof(ctx, "direct: updating connection %s", cfg.Name)
+			if _, err := client.UpdateConnection(ctx, connectionUpdateInput(cfg)); err != nil {
+				return fmt.Errorf("update connection %s: %w", cfg.Name, err)
+			}
+			state.Connections[name] = ptrConnection(connectionStateFromConfig(cfg))
+		}
+	}
+	return nil
+}
+
+func applyConnectionDeletes(ctx context.Context, client Client, plan *deployplan.Plan, state *State) error {
+	for _, key := range reverseSortedPlanKeysByGroup(plan, "connections") {
+		entry := plan.Plan[key]
+		if entry.Action != deployplan.Delete {
+			continue
+		}
+		name := strings.TrimPrefix(key, "resources.connections.")
+		rec, ok := state.Connections[name]
+		if !ok {
+			continue
+		}
+		log.Infof(ctx, "direct: deleting connection %s", rec.Name)
+		if err := client.DeleteConnection(ctx, rec.Name); err != nil {
+			return fmt.Errorf("delete connection %s: %w", rec.Name, err)
+		}
+		delete(state.Connections, name)
 	}
 	return nil
 }
@@ -519,6 +575,35 @@ func volumeUpdateInput(v *resources.Volume) catalog.UpdateVolumeRequestContent {
 	}
 }
 
+// connectionCreateInput validates options is non-empty and builds the SDK
+// Create payload. Per-connection-type key validation lives server-side.
+func connectionCreateInput(c *resources.Connection) (catalog.CreateConnection, error) {
+	if c.ConnectionType == "" {
+		return catalog.CreateConnection{}, fmt.Errorf("connection %q: connection_type is required", c.Name)
+	}
+	if len(c.Options) == 0 {
+		return catalog.CreateConnection{}, fmt.Errorf("connection %q: options is required and must be non-empty", c.Name)
+	}
+	return catalog.CreateConnection{
+		Name:           c.Name,
+		ConnectionType: catalog.ConnectionType(c.ConnectionType),
+		Options:        copyTags(c.Options),
+		Comment:        c.Comment,
+		Properties:     copyTags(c.Properties),
+		ReadOnly:       c.ReadOnly,
+	}, nil
+}
+
+// connectionUpdateInput produces an options-only update. The UC API allows
+// changing only name/owner/options on a connection — connection_type,
+// comment, properties, and read_only drift is effectively immutable.
+func connectionUpdateInput(c *resources.Connection) catalog.UpdateConnection {
+	return catalog.UpdateConnection{
+		Name:    c.Name,
+		Options: copyTags(c.Options),
+	}
+}
+
 func externalLocationCreateInput(e *resources.ExternalLocation) catalog.CreateExternalLocation {
 	return catalog.CreateExternalLocation{
 		Name:           e.Name,
@@ -694,3 +779,5 @@ func ptrStorageCredential(s StorageCredentialState) *StorageCredentialState {
 func ptrExternalLocation(s ExternalLocationState) *ExternalLocationState { return &s }
 
 func ptrVolume(s VolumeState) *VolumeState { return &s }
+
+func ptrConnection(s ConnectionState) *ConnectionState { return &s }

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -483,6 +483,155 @@ func TestApply_ExternalLocationDestroyOrder(t *testing.T) {
 	assert.Empty(t, state.StorageCredentials)
 }
 
+func TestApply_VolumeCreateOrdersAfterSchema(t *testing.T) {
+	u := ucmWith(
+		map[string]*resources.Catalog{"main": {Name: "main"}},
+		map[string]*resources.Schema{"bronze": {Name: "bronze", Catalog: "main"}},
+		nil,
+	)
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:        "raw",
+			CatalogName: "main",
+			SchemaName:  "bronze",
+			VolumeType:  "MANAGED",
+		},
+	}
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{
+		"CreateCatalog:main",
+		"CreateSchema:main.bronze",
+		"CreateVolume:main.bronze.raw",
+	}, client.Calls)
+
+	require.NotNil(t, state.Volumes["raw"])
+	assert.Equal(t, "main", state.Volumes["raw"].CatalogName)
+	assert.Equal(t, "bronze", state.Volumes["raw"].SchemaName)
+	assert.Equal(t, "MANAGED", state.Volumes["raw"].VolumeType)
+}
+
+func TestApply_VolumeExternalCreatePreservesStorageLocation(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:            "raw",
+			CatalogName:     "main",
+			SchemaName:      "bronze",
+			VolumeType:      "EXTERNAL",
+			StorageLocation: "s3://bucket/raw",
+		},
+	}
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	require.Len(t, client.CreatedVolumes, 1)
+	assert.Equal(t, "s3://bucket/raw", client.CreatedVolumes[0].StorageLocation)
+	assert.Equal(t, catalog.VolumeTypeExternal, client.CreatedVolumes[0].VolumeType)
+}
+
+func TestApply_VolumeUpdate(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:        "raw",
+			CatalogName: "main",
+			SchemaName:  "bronze",
+			VolumeType:  "MANAGED",
+			Comment:     "new",
+		},
+	}
+	state := direct.NewState()
+	state.Volumes["raw"] = &direct.VolumeState{
+		Name:        "raw",
+		CatalogName: "main",
+		SchemaName:  "bronze",
+		VolumeType:  "MANAGED",
+		Comment:     "old",
+	}
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{"UpdateVolume:main.bronze.raw"}, client.Calls)
+	assert.Equal(t, "new", state.Volumes["raw"].Comment)
+}
+
+func TestApply_VolumeDestroyOrder(t *testing.T) {
+	u := &ucm.Ucm{}
+	state := direct.NewState()
+	state.Catalogs["main"] = &direct.CatalogState{Name: "main"}
+	state.Schemas["bronze"] = &direct.SchemaState{Name: "bronze", Catalog: "main"}
+	state.Volumes["raw"] = &direct.VolumeState{
+		Name:        "raw",
+		CatalogName: "main",
+		SchemaName:  "bronze",
+		VolumeType:  "MANAGED",
+	}
+
+	client := &recordingClient{}
+	plan, err := direct.Destroy(t.Context(), u, client, state)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	assert.Equal(t, []string{
+		"DeleteVolume:main.bronze.raw",
+		"DeleteSchema:main.bronze",
+		"DeleteCatalog:main",
+	}, client.Calls)
+
+	assert.Empty(t, state.Catalogs)
+	assert.Empty(t, state.Schemas)
+	assert.Empty(t, state.Volumes)
+}
+
+func TestApply_VolumeRejectsInvalidType(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:        "raw",
+			CatalogName: "main",
+			SchemaName:  "bronze",
+			VolumeType:  "BOGUS",
+		},
+	}
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	err := direct.Apply(t.Context(), u, client, plan, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volume_type must be MANAGED or EXTERNAL")
+	assert.Empty(t, client.Calls)
+}
+
+func TestApply_VolumeExternalRequiresStorageLocation(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:        "raw",
+			CatalogName: "main",
+			SchemaName:  "bronze",
+			VolumeType:  "EXTERNAL",
+		},
+	}
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	err := direct.Apply(t.Context(), u, client, plan, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage_location is required for EXTERNAL")
+}
+
 func TestApply_RevokesPrincipalsNotInConfig(t *testing.T) {
 	u := ucmWith(nil, nil, map[string]*resources.Grant{
 		"analysts": {

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -38,6 +38,10 @@ type recordingClient struct {
 	UpdatedVolumes []catalog.UpdateVolumeRequestContent
 	DeletedVolumes []string
 
+	CreatedConnections []catalog.CreateConnection
+	UpdatedConnections []catalog.UpdateConnection
+	DeletedConnections []string
+
 	Permissions []catalog.UpdatePermissions
 
 	FailOn string
@@ -188,6 +192,34 @@ func (r *recordingClient) DeleteVolume(_ context.Context, name string) error {
 		return err
 	}
 	r.DeletedVolumes = append(r.DeletedVolumes, name)
+	return nil
+}
+
+func (r *recordingClient) GetConnection(_ context.Context, _ string) (*catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+
+func (r *recordingClient) CreateConnection(_ context.Context, in catalog.CreateConnection) (*catalog.ConnectionInfo, error) {
+	if err := r.trip("CreateConnection:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.CreatedConnections = append(r.CreatedConnections, in)
+	return &catalog.ConnectionInfo{Name: in.Name}, nil
+}
+
+func (r *recordingClient) UpdateConnection(_ context.Context, in catalog.UpdateConnection) (*catalog.ConnectionInfo, error) {
+	if err := r.trip("UpdateConnection:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.UpdatedConnections = append(r.UpdatedConnections, in)
+	return &catalog.ConnectionInfo{Name: in.Name}, nil
+}
+
+func (r *recordingClient) DeleteConnection(_ context.Context, name string) error {
+	if err := r.trip("DeleteConnection:" + name); err != nil {
+		return err
+	}
+	r.DeletedConnections = append(r.DeletedConnections, name)
 	return nil
 }
 

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -30,6 +30,10 @@ type recordingClient struct {
 	UpdatedStorageCredentials []catalog.UpdateStorageCredential
 	DeletedStorageCredentials []string
 
+	CreatedExternalLocations []catalog.CreateExternalLocation
+	UpdatedExternalLocations []catalog.UpdateExternalLocation
+	DeletedExternalLocations []string
+
 	Permissions []catalog.UpdatePermissions
 
 	FailOn string
@@ -124,6 +128,34 @@ func (r *recordingClient) DeleteStorageCredential(_ context.Context, name string
 		return err
 	}
 	r.DeletedStorageCredentials = append(r.DeletedStorageCredentials, name)
+	return nil
+}
+
+func (r *recordingClient) GetExternalLocation(_ context.Context, _ string) (*catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+
+func (r *recordingClient) CreateExternalLocation(_ context.Context, in catalog.CreateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	if err := r.trip("CreateExternalLocation:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.CreatedExternalLocations = append(r.CreatedExternalLocations, in)
+	return &catalog.ExternalLocationInfo{Name: in.Name}, nil
+}
+
+func (r *recordingClient) UpdateExternalLocation(_ context.Context, in catalog.UpdateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	if err := r.trip("UpdateExternalLocation:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.UpdatedExternalLocations = append(r.UpdatedExternalLocations, in)
+	return &catalog.ExternalLocationInfo{Name: in.Name}, nil
+}
+
+func (r *recordingClient) DeleteExternalLocation(_ context.Context, name string) error {
+	if err := r.trip("DeleteExternalLocation:" + name); err != nil {
+		return err
+	}
+	r.DeletedExternalLocations = append(r.DeletedExternalLocations, name)
 	return nil
 }
 

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -34,6 +34,10 @@ type recordingClient struct {
 	UpdatedExternalLocations []catalog.UpdateExternalLocation
 	DeletedExternalLocations []string
 
+	CreatedVolumes []catalog.CreateVolumeRequestContent
+	UpdatedVolumes []catalog.UpdateVolumeRequestContent
+	DeletedVolumes []string
+
 	Permissions []catalog.UpdatePermissions
 
 	FailOn string
@@ -156,6 +160,34 @@ func (r *recordingClient) DeleteExternalLocation(_ context.Context, name string)
 		return err
 	}
 	r.DeletedExternalLocations = append(r.DeletedExternalLocations, name)
+	return nil
+}
+
+func (r *recordingClient) GetVolume(_ context.Context, _ string) (*catalog.VolumeInfo, error) {
+	return nil, nil
+}
+
+func (r *recordingClient) CreateVolume(_ context.Context, in catalog.CreateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	if err := r.trip("CreateVolume:" + in.CatalogName + "." + in.SchemaName + "." + in.Name); err != nil {
+		return nil, err
+	}
+	r.CreatedVolumes = append(r.CreatedVolumes, in)
+	return &catalog.VolumeInfo{Name: in.Name, CatalogName: in.CatalogName, SchemaName: in.SchemaName}, nil
+}
+
+func (r *recordingClient) UpdateVolume(_ context.Context, in catalog.UpdateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	if err := r.trip("UpdateVolume:" + in.Name); err != nil {
+		return nil, err
+	}
+	r.UpdatedVolumes = append(r.UpdatedVolumes, in)
+	return &catalog.VolumeInfo{FullName: in.Name}, nil
+}
+
+func (r *recordingClient) DeleteVolume(_ context.Context, name string) error {
+	if err := r.trip("DeleteVolume:" + name); err != nil {
+		return err
+	}
+	r.DeletedVolumes = append(r.DeletedVolumes, name)
 	return nil
 }
 

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -664,6 +664,111 @@ func TestApply_VolumeExternalRequiresStorageLocation(t *testing.T) {
 	assert.Contains(t, err.Error(), "storage_location is required for EXTERNAL")
 }
 
+func TestApply_ConnectionCreateOrdersAfterVolume(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:        "raw",
+			CatalogName: "main",
+			SchemaName:  "bronze",
+			VolumeType:  "MANAGED",
+		},
+	}
+	u.Config.Resources.Connections = map[string]*resources.Connection{
+		"mysql_prod": {
+			Name:           "mysql_prod",
+			ConnectionType: "MYSQL",
+			Options:        map[string]string{"host": "db.example.com"},
+		},
+	}
+
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{
+		"CreateVolume:main.bronze.raw",
+		"CreateConnection:mysql_prod",
+	}, client.Calls)
+
+	require.NotNil(t, state.Connections["mysql_prod"])
+	assert.Equal(t, "MYSQL", state.Connections["mysql_prod"].ConnectionType)
+	assert.Equal(t, "db.example.com", state.Connections["mysql_prod"].Options["host"])
+}
+
+func TestApply_ConnectionUpdate(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.Connections = map[string]*resources.Connection{
+		"mysql_prod": {
+			Name:           "mysql_prod",
+			ConnectionType: "MYSQL",
+			Options:        map[string]string{"host": "new.example.com"},
+		},
+	}
+	state := direct.NewState()
+	state.Connections["mysql_prod"] = &direct.ConnectionState{
+		Name:           "mysql_prod",
+		ConnectionType: "MYSQL",
+		Options:        map[string]string{"host": "old.example.com"},
+	}
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{"UpdateConnection:mysql_prod"}, client.Calls)
+	assert.Equal(t, "new.example.com", state.Connections["mysql_prod"].Options["host"])
+}
+
+func TestApply_ConnectionDestroyOrder(t *testing.T) {
+	u := &ucm.Ucm{}
+	state := direct.NewState()
+	state.Volumes["raw"] = &direct.VolumeState{
+		Name:        "raw",
+		CatalogName: "main",
+		SchemaName:  "bronze",
+		VolumeType:  "MANAGED",
+	}
+	state.Connections["mysql_prod"] = &direct.ConnectionState{
+		Name:           "mysql_prod",
+		ConnectionType: "MYSQL",
+		Options:        map[string]string{"host": "db.example.com"},
+	}
+
+	client := &recordingClient{}
+	plan, err := direct.Destroy(t.Context(), u, client, state)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	assert.Equal(t, []string{
+		"DeleteConnection:mysql_prod",
+		"DeleteVolume:main.bronze.raw",
+	}, client.Calls)
+
+	assert.Empty(t, state.Volumes)
+	assert.Empty(t, state.Connections)
+}
+
+func TestApply_ConnectionRejectsMissingOptions(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.Connections = map[string]*resources.Connection{
+		"mysql_prod": {
+			Name:           "mysql_prod",
+			ConnectionType: "MYSQL",
+		},
+	}
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	err := direct.Apply(t.Context(), u, client, plan, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "options is required")
+	assert.Empty(t, client.Calls)
+}
+
 func TestApply_RevokesPrincipalsNotInConfig(t *testing.T) {
 	u := ucmWith(nil, nil, map[string]*resources.Grant{
 		"analysts": {

--- a/ucm/deploy/direct/apply_test.go
+++ b/ucm/deploy/direct/apply_test.go
@@ -362,6 +362,95 @@ func TestApply_StorageCredentialRejectsMissingIdentity(t *testing.T) {
 	assert.Empty(t, client.Calls, "no API call must be made when validation fails")
 }
 
+func TestApply_ExternalLocationCreateOrdersAfterStorageCredential(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.StorageCredentials = map[string]*resources.StorageCredential{
+		"prod": {
+			Name:       "prod",
+			AwsIamRole: &resources.AwsIamRole{RoleArn: "arn:aws:iam::1:role/uc"},
+		},
+	}
+	u.Config.Resources.ExternalLocations = map[string]*resources.ExternalLocation{
+		"data": {
+			Name:           "data",
+			Url:            "s3://bucket/prefix",
+			CredentialName: "prod",
+		},
+	}
+
+	state := direct.NewState()
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{
+		"CreateStorageCredential:prod",
+		"CreateExternalLocation:data",
+	}, client.Calls)
+
+	require.NotNil(t, state.ExternalLocations["data"])
+	assert.Equal(t, "s3://bucket/prefix", state.ExternalLocations["data"].Url)
+	assert.Equal(t, "prod", state.ExternalLocations["data"].CredentialName)
+}
+
+func TestApply_ExternalLocationUpdate(t *testing.T) {
+	u := &ucm.Ucm{}
+	u.Config.Resources.ExternalLocations = map[string]*resources.ExternalLocation{
+		"data": {
+			Name:           "data",
+			Url:            "s3://bucket/new",
+			CredentialName: "prod",
+			Comment:        "new",
+		},
+	}
+	state := direct.NewState()
+	state.ExternalLocations["data"] = &direct.ExternalLocationState{
+		Name:           "data",
+		Url:            "s3://bucket/old",
+		CredentialName: "prod",
+		Comment:        "old",
+	}
+	plan := direct.CalculatePlan(u, state)
+
+	client := &recordingClient{}
+	require.NoError(t, direct.Apply(t.Context(), u, client, plan, state))
+
+	assert.Equal(t, []string{"UpdateExternalLocation:data"}, client.Calls)
+	assert.Equal(t, "s3://bucket/new", state.ExternalLocations["data"].Url)
+	assert.Equal(t, "new", state.ExternalLocations["data"].Comment)
+}
+
+func TestApply_ExternalLocationDestroyOrder(t *testing.T) {
+	u := &ucm.Ucm{}
+	state := direct.NewState()
+	state.Catalogs["main"] = &direct.CatalogState{Name: "main"}
+	state.ExternalLocations["data"] = &direct.ExternalLocationState{
+		Name:           "data",
+		Url:            "s3://bucket/prefix",
+		CredentialName: "prod",
+	}
+	state.StorageCredentials["prod"] = &direct.StorageCredentialState{
+		Name:       "prod",
+		AwsIamRole: &direct.AwsIamRoleState{RoleArn: "arn:aws:iam::1:role/uc"},
+	}
+
+	client := &recordingClient{}
+	plan, err := direct.Destroy(t.Context(), u, client, state)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	assert.Equal(t, []string{
+		"DeleteCatalog:main",
+		"DeleteExternalLocation:data",
+		"DeleteStorageCredential:prod",
+	}, client.Calls)
+
+	assert.Empty(t, state.Catalogs)
+	assert.Empty(t, state.ExternalLocations)
+	assert.Empty(t, state.StorageCredentials)
+}
+
 func TestApply_RevokesPrincipalsNotInConfig(t *testing.T) {
 	u := ucmWith(nil, nil, map[string]*resources.Grant{
 		"analysts": {

--- a/ucm/deploy/direct/client.go
+++ b/ucm/deploy/direct/client.go
@@ -31,6 +31,11 @@ type Client interface {
 	UpdateExternalLocation(ctx context.Context, in catalog.UpdateExternalLocation) (*catalog.ExternalLocationInfo, error)
 	DeleteExternalLocation(ctx context.Context, name string) error
 
+	GetVolume(ctx context.Context, name string) (*catalog.VolumeInfo, error)
+	CreateVolume(ctx context.Context, in catalog.CreateVolumeRequestContent) (*catalog.VolumeInfo, error)
+	UpdateVolume(ctx context.Context, in catalog.UpdateVolumeRequestContent) (*catalog.VolumeInfo, error)
+	DeleteVolume(ctx context.Context, name string) error
+
 	UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error
 }
 
@@ -104,6 +109,22 @@ func (c *sdkClient) UpdateExternalLocation(ctx context.Context, in catalog.Updat
 
 func (c *sdkClient) DeleteExternalLocation(ctx context.Context, name string) error {
 	return c.w.ExternalLocations.DeleteByName(ctx, name)
+}
+
+func (c *sdkClient) GetVolume(ctx context.Context, name string) (*catalog.VolumeInfo, error) {
+	return c.w.Volumes.ReadByName(ctx, name)
+}
+
+func (c *sdkClient) CreateVolume(ctx context.Context, in catalog.CreateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	return c.w.Volumes.Create(ctx, in)
+}
+
+func (c *sdkClient) UpdateVolume(ctx context.Context, in catalog.UpdateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	return c.w.Volumes.Update(ctx, in)
+}
+
+func (c *sdkClient) DeleteVolume(ctx context.Context, name string) error {
+	return c.w.Volumes.DeleteByName(ctx, name)
 }
 
 func (c *sdkClient) UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error {

--- a/ucm/deploy/direct/client.go
+++ b/ucm/deploy/direct/client.go
@@ -36,6 +36,11 @@ type Client interface {
 	UpdateVolume(ctx context.Context, in catalog.UpdateVolumeRequestContent) (*catalog.VolumeInfo, error)
 	DeleteVolume(ctx context.Context, name string) error
 
+	GetConnection(ctx context.Context, name string) (*catalog.ConnectionInfo, error)
+	CreateConnection(ctx context.Context, in catalog.CreateConnection) (*catalog.ConnectionInfo, error)
+	UpdateConnection(ctx context.Context, in catalog.UpdateConnection) (*catalog.ConnectionInfo, error)
+	DeleteConnection(ctx context.Context, name string) error
+
 	UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error
 }
 
@@ -125,6 +130,22 @@ func (c *sdkClient) UpdateVolume(ctx context.Context, in catalog.UpdateVolumeReq
 
 func (c *sdkClient) DeleteVolume(ctx context.Context, name string) error {
 	return c.w.Volumes.DeleteByName(ctx, name)
+}
+
+func (c *sdkClient) GetConnection(ctx context.Context, name string) (*catalog.ConnectionInfo, error) {
+	return c.w.Connections.GetByName(ctx, name)
+}
+
+func (c *sdkClient) CreateConnection(ctx context.Context, in catalog.CreateConnection) (*catalog.ConnectionInfo, error) {
+	return c.w.Connections.Create(ctx, in)
+}
+
+func (c *sdkClient) UpdateConnection(ctx context.Context, in catalog.UpdateConnection) (*catalog.ConnectionInfo, error) {
+	return c.w.Connections.Update(ctx, in)
+}
+
+func (c *sdkClient) DeleteConnection(ctx context.Context, name string) error {
+	return c.w.Connections.DeleteByName(ctx, name)
 }
 
 func (c *sdkClient) UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error {

--- a/ucm/deploy/direct/client.go
+++ b/ucm/deploy/direct/client.go
@@ -26,6 +26,11 @@ type Client interface {
 	UpdateStorageCredential(ctx context.Context, in catalog.UpdateStorageCredential) (*catalog.StorageCredentialInfo, error)
 	DeleteStorageCredential(ctx context.Context, name string) error
 
+	GetExternalLocation(ctx context.Context, name string) (*catalog.ExternalLocationInfo, error)
+	CreateExternalLocation(ctx context.Context, in catalog.CreateExternalLocation) (*catalog.ExternalLocationInfo, error)
+	UpdateExternalLocation(ctx context.Context, in catalog.UpdateExternalLocation) (*catalog.ExternalLocationInfo, error)
+	DeleteExternalLocation(ctx context.Context, name string) error
+
 	UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error
 }
 
@@ -83,6 +88,22 @@ func (c *sdkClient) UpdateStorageCredential(ctx context.Context, in catalog.Upda
 
 func (c *sdkClient) DeleteStorageCredential(ctx context.Context, name string) error {
 	return c.w.StorageCredentials.DeleteByName(ctx, name)
+}
+
+func (c *sdkClient) GetExternalLocation(ctx context.Context, name string) (*catalog.ExternalLocationInfo, error) {
+	return c.w.ExternalLocations.GetByName(ctx, name)
+}
+
+func (c *sdkClient) CreateExternalLocation(ctx context.Context, in catalog.CreateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	return c.w.ExternalLocations.Create(ctx, in)
+}
+
+func (c *sdkClient) UpdateExternalLocation(ctx context.Context, in catalog.UpdateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	return c.w.ExternalLocations.Update(ctx, in)
+}
+
+func (c *sdkClient) DeleteExternalLocation(ctx context.Context, name string) error {
+	return c.w.ExternalLocations.DeleteByName(ctx, name)
 }
 
 func (c *sdkClient) UpdatePermissions(ctx context.Context, in catalog.UpdatePermissions) error {

--- a/ucm/deploy/direct/plan.go
+++ b/ucm/deploy/direct/plan.go
@@ -35,6 +35,7 @@ func CalculatePlan(u *ucm.Ucm, state *State) *deployplan.Plan {
 	planCatalogs(u, state, plan)
 	planSchemas(u, state, plan)
 	planVolumes(u, state, plan)
+	planConnections(u, state, plan)
 	planGrants(u, state, plan)
 
 	return plan
@@ -155,6 +156,29 @@ func planVolumes(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
 	}
 }
 
+func planConnections(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
+	desired := u.Config.Resources.Connections
+	recorded := state.Connections
+
+	keys := mergedKeys(desired, recorded)
+	for _, key := range keys {
+		planKey := "resources.connections." + key
+
+		cfg, haveCfg := desired[key]
+		rec, haveRec := recorded[key]
+		switch {
+		case haveCfg && !haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Create}
+		case !haveCfg && haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Delete}
+		case connectionStateFromConfig(cfg).equal(rec):
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Skip}
+		default:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Update}
+		}
+	}
+}
+
 func planGrants(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
 	desired := u.Config.Resources.Grants
 	recorded := state.Grants
@@ -227,6 +251,10 @@ func (s ExternalLocationState) equal(other *ExternalLocationState) bool {
 }
 
 func (s VolumeState) equal(other *VolumeState) bool {
+	return other != nil && reflect.DeepEqual(s, *other)
+}
+
+func (s ConnectionState) equal(other *ConnectionState) bool {
 	return other != nil && reflect.DeepEqual(s, *other)
 }
 

--- a/ucm/deploy/direct/plan.go
+++ b/ucm/deploy/direct/plan.go
@@ -34,6 +34,7 @@ func CalculatePlan(u *ucm.Ucm, state *State) *deployplan.Plan {
 	planExternalLocations(u, state, plan)
 	planCatalogs(u, state, plan)
 	planSchemas(u, state, plan)
+	planVolumes(u, state, plan)
 	planGrants(u, state, plan)
 
 	return plan
@@ -131,6 +132,29 @@ func planSchemas(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
 	}
 }
 
+func planVolumes(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
+	desired := u.Config.Resources.Volumes
+	recorded := state.Volumes
+
+	keys := mergedKeys(desired, recorded)
+	for _, key := range keys {
+		planKey := "resources.volumes." + key
+
+		cfg, haveCfg := desired[key]
+		rec, haveRec := recorded[key]
+		switch {
+		case haveCfg && !haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Create}
+		case !haveCfg && haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Delete}
+		case volumeStateFromConfig(cfg).equal(rec):
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Skip}
+		default:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Update}
+		}
+	}
+}
+
 func planGrants(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
 	desired := u.Config.Resources.Grants
 	recorded := state.Grants
@@ -199,6 +223,10 @@ func (s StorageCredentialState) equal(other *StorageCredentialState) bool {
 }
 
 func (s ExternalLocationState) equal(other *ExternalLocationState) bool {
+	return other != nil && reflect.DeepEqual(s, *other)
+}
+
+func (s VolumeState) equal(other *VolumeState) bool {
 	return other != nil && reflect.DeepEqual(s, *other)
 }
 

--- a/ucm/deploy/direct/plan.go
+++ b/ucm/deploy/direct/plan.go
@@ -31,6 +31,7 @@ func CalculatePlan(u *ucm.Ucm, state *State) *deployplan.Plan {
 	plan := deployplan.NewPlanTerraform()
 
 	planStorageCredentials(u, state, plan)
+	planExternalLocations(u, state, plan)
 	planCatalogs(u, state, plan)
 	planSchemas(u, state, plan)
 	planGrants(u, state, plan)
@@ -54,6 +55,29 @@ func planStorageCredentials(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
 		case !haveCfg && haveRec:
 			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Delete}
 		case storageCredentialStateFromConfig(cfg).equal(rec):
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Skip}
+		default:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Update}
+		}
+	}
+}
+
+func planExternalLocations(u *ucm.Ucm, state *State, plan *deployplan.Plan) {
+	desired := u.Config.Resources.ExternalLocations
+	recorded := state.ExternalLocations
+
+	keys := mergedKeys(desired, recorded)
+	for _, key := range keys {
+		planKey := "resources.external_locations." + key
+
+		cfg, haveCfg := desired[key]
+		rec, haveRec := recorded[key]
+		switch {
+		case haveCfg && !haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Create}
+		case !haveCfg && haveRec:
+			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Delete}
+		case externalLocationStateFromConfig(cfg).equal(rec):
 			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Skip}
 		default:
 			plan.Plan[planKey] = &deployplan.PlanEntry{Action: deployplan.Update}
@@ -171,6 +195,10 @@ func (s GrantState) equal(other *GrantState) bool {
 }
 
 func (s StorageCredentialState) equal(other *StorageCredentialState) bool {
+	return other != nil && reflect.DeepEqual(s, *other)
+}
+
+func (s ExternalLocationState) equal(other *ExternalLocationState) bool {
 	return other != nil && reflect.DeepEqual(s, *other)
 }
 

--- a/ucm/deploy/direct/plan_test.go
+++ b/ucm/deploy/direct/plan_test.go
@@ -196,6 +196,73 @@ func TestCalculatePlan_StorageCredentialUpdateOnIdentityDrift(t *testing.T) {
 	assert.Equal(t, deployplan.Update, plan.Plan["resources.storage_credentials.prod"].Action)
 }
 
+func TestCalculatePlan_ExternalLocationCreate(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.ExternalLocations = map[string]*resources.ExternalLocation{
+		"prod": {
+			Name:           "prod",
+			Url:            "s3://bucket/prefix",
+			CredentialName: "prod",
+		},
+	}
+	plan := direct.CalculatePlan(u, direct.NewState())
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.external_locations.prod"].Action)
+}
+
+func TestCalculatePlan_ExternalLocationDelete(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	state := direct.NewState()
+	state.ExternalLocations["prod"] = &direct.ExternalLocationState{
+		Name:           "prod",
+		Url:            "s3://bucket/prefix",
+		CredentialName: "prod",
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.external_locations.prod"].Action)
+}
+
+func TestCalculatePlan_ExternalLocationSkip(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.ExternalLocations = map[string]*resources.ExternalLocation{
+		"prod": {
+			Name:           "prod",
+			Url:            "s3://bucket/prefix",
+			CredentialName: "prod",
+			Comment:        "prod",
+			ReadOnly:       true,
+		},
+	}
+	state := direct.NewState()
+	state.ExternalLocations["prod"] = &direct.ExternalLocationState{
+		Name:           "prod",
+		Url:            "s3://bucket/prefix",
+		CredentialName: "prod",
+		Comment:        "prod",
+		ReadOnly:       true,
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.external_locations.prod"].Action)
+}
+
+func TestCalculatePlan_ExternalLocationUpdateOnUrlDrift(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.ExternalLocations = map[string]*resources.ExternalLocation{
+		"prod": {
+			Name:           "prod",
+			Url:            "s3://bucket/new",
+			CredentialName: "prod",
+		},
+	}
+	state := direct.NewState()
+	state.ExternalLocations["prod"] = &direct.ExternalLocationState{
+		Name:           "prod",
+		Url:            "s3://bucket/old",
+		CredentialName: "prod",
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Update, plan.Plan["resources.external_locations.prod"].Action)
+}
+
 func ucmWith(catalogs map[string]*resources.Catalog, schemas map[string]*resources.Schema, grants map[string]*resources.Grant) *ucm.Ucm {
 	u := &ucm.Ucm{Config: config.Root{}}
 	u.Config.Resources.Catalogs = catalogs

--- a/ucm/deploy/direct/plan_test.go
+++ b/ucm/deploy/direct/plan_test.go
@@ -338,6 +338,73 @@ func TestCalculatePlan_VolumeUpdateOnCommentDrift(t *testing.T) {
 	assert.Equal(t, deployplan.Update, plan.Plan["resources.volumes.raw"].Action)
 }
 
+func TestCalculatePlan_ConnectionCreate(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Connections = map[string]*resources.Connection{
+		"mysql_prod": {
+			Name:           "mysql_prod",
+			ConnectionType: "MYSQL",
+			Options:        map[string]string{"host": "db.example.com"},
+		},
+	}
+	plan := direct.CalculatePlan(u, direct.NewState())
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.connections.mysql_prod"].Action)
+}
+
+func TestCalculatePlan_ConnectionDelete(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	state := direct.NewState()
+	state.Connections["mysql_prod"] = &direct.ConnectionState{
+		Name:           "mysql_prod",
+		ConnectionType: "MYSQL",
+		Options:        map[string]string{"host": "db.example.com"},
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.connections.mysql_prod"].Action)
+}
+
+func TestCalculatePlan_ConnectionSkip(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Connections = map[string]*resources.Connection{
+		"mysql_prod": {
+			Name:           "mysql_prod",
+			ConnectionType: "MYSQL",
+			Options:        map[string]string{"host": "db.example.com"},
+			Comment:        "prod",
+			ReadOnly:       true,
+		},
+	}
+	state := direct.NewState()
+	state.Connections["mysql_prod"] = &direct.ConnectionState{
+		Name:           "mysql_prod",
+		ConnectionType: "MYSQL",
+		Options:        map[string]string{"host": "db.example.com"},
+		Comment:        "prod",
+		ReadOnly:       true,
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.connections.mysql_prod"].Action)
+}
+
+func TestCalculatePlan_ConnectionUpdateOnOptionsDrift(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Connections = map[string]*resources.Connection{
+		"mysql_prod": {
+			Name:           "mysql_prod",
+			ConnectionType: "MYSQL",
+			Options:        map[string]string{"host": "new.example.com"},
+		},
+	}
+	state := direct.NewState()
+	state.Connections["mysql_prod"] = &direct.ConnectionState{
+		Name:           "mysql_prod",
+		ConnectionType: "MYSQL",
+		Options:        map[string]string{"host": "old.example.com"},
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Update, plan.Plan["resources.connections.mysql_prod"].Action)
+}
+
 func ucmWith(catalogs map[string]*resources.Catalog, schemas map[string]*resources.Schema, grants map[string]*resources.Grant) *ucm.Ucm {
 	u := &ucm.Ucm{Config: config.Root{}}
 	u.Config.Resources.Catalogs = catalogs

--- a/ucm/deploy/direct/plan_test.go
+++ b/ucm/deploy/direct/plan_test.go
@@ -263,6 +263,81 @@ func TestCalculatePlan_ExternalLocationUpdateOnUrlDrift(t *testing.T) {
 	assert.Equal(t, deployplan.Update, plan.Plan["resources.external_locations.prod"].Action)
 }
 
+func TestCalculatePlan_VolumeCreate(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:        "raw",
+			CatalogName: "main",
+			SchemaName:  "bronze",
+			VolumeType:  "MANAGED",
+		},
+	}
+	plan := direct.CalculatePlan(u, direct.NewState())
+	assert.Equal(t, deployplan.Create, plan.Plan["resources.volumes.raw"].Action)
+}
+
+func TestCalculatePlan_VolumeDelete(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	state := direct.NewState()
+	state.Volumes["raw"] = &direct.VolumeState{
+		Name:        "raw",
+		CatalogName: "main",
+		SchemaName:  "bronze",
+		VolumeType:  "MANAGED",
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Delete, plan.Plan["resources.volumes.raw"].Action)
+}
+
+func TestCalculatePlan_VolumeSkip(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:            "raw",
+			CatalogName:     "main",
+			SchemaName:      "bronze",
+			VolumeType:      "EXTERNAL",
+			StorageLocation: "s3://bucket/raw",
+			Comment:         "prod",
+		},
+	}
+	state := direct.NewState()
+	state.Volumes["raw"] = &direct.VolumeState{
+		Name:            "raw",
+		CatalogName:     "main",
+		SchemaName:      "bronze",
+		VolumeType:      "EXTERNAL",
+		StorageLocation: "s3://bucket/raw",
+		Comment:         "prod",
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Skip, plan.Plan["resources.volumes.raw"].Action)
+}
+
+func TestCalculatePlan_VolumeUpdateOnCommentDrift(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"raw": {
+			Name:        "raw",
+			CatalogName: "main",
+			SchemaName:  "bronze",
+			VolumeType:  "MANAGED",
+			Comment:     "new",
+		},
+	}
+	state := direct.NewState()
+	state.Volumes["raw"] = &direct.VolumeState{
+		Name:        "raw",
+		CatalogName: "main",
+		SchemaName:  "bronze",
+		VolumeType:  "MANAGED",
+		Comment:     "old",
+	}
+	plan := direct.CalculatePlan(u, state)
+	assert.Equal(t, deployplan.Update, plan.Plan["resources.volumes.raw"].Action)
+}
+
 func ucmWith(catalogs map[string]*resources.Catalog, schemas map[string]*resources.Schema, grants map[string]*resources.Grant) *ucm.Ucm {
 	u := &ucm.Ucm{Config: config.Root{}}
 	u.Config.Resources.Catalogs = catalogs

--- a/ucm/deploy/direct/snapshot.go
+++ b/ucm/deploy/direct/snapshot.go
@@ -79,6 +79,21 @@ func storageCredentialStateFromConfig(c *resources.StorageCredential) StorageCre
 	return s
 }
 
+func externalLocationStateFromConfig(e *resources.ExternalLocation) ExternalLocationState {
+	if e == nil {
+		return ExternalLocationState{}
+	}
+	return ExternalLocationState{
+		Name:           e.Name,
+		Url:            e.Url,
+		CredentialName: e.CredentialName,
+		Comment:        e.Comment,
+		ReadOnly:       e.ReadOnly,
+		SkipValidation: e.SkipValidation,
+		Fallback:       e.Fallback,
+	}
+}
+
 func copyTags(tags map[string]string) map[string]string {
 	if len(tags) == 0 {
 		return nil

--- a/ucm/deploy/direct/snapshot.go
+++ b/ucm/deploy/direct/snapshot.go
@@ -94,6 +94,20 @@ func externalLocationStateFromConfig(e *resources.ExternalLocation) ExternalLoca
 	}
 }
 
+func volumeStateFromConfig(v *resources.Volume) VolumeState {
+	if v == nil {
+		return VolumeState{}
+	}
+	return VolumeState{
+		Name:            v.Name,
+		CatalogName:     v.CatalogName,
+		SchemaName:      v.SchemaName,
+		VolumeType:      v.VolumeType,
+		StorageLocation: v.StorageLocation,
+		Comment:         v.Comment,
+	}
+}
+
 func copyTags(tags map[string]string) map[string]string {
 	if len(tags) == 0 {
 		return nil

--- a/ucm/deploy/direct/snapshot.go
+++ b/ucm/deploy/direct/snapshot.go
@@ -108,6 +108,20 @@ func volumeStateFromConfig(v *resources.Volume) VolumeState {
 	}
 }
 
+func connectionStateFromConfig(c *resources.Connection) ConnectionState {
+	if c == nil {
+		return ConnectionState{}
+	}
+	return ConnectionState{
+		Name:           c.Name,
+		ConnectionType: c.ConnectionType,
+		Options:        copyTags(c.Options),
+		Comment:        c.Comment,
+		Properties:     copyTags(c.Properties),
+		ReadOnly:       c.ReadOnly,
+	}
+}
+
 func copyTags(tags map[string]string) map[string]string {
 	if len(tags) == 0 {
 		return nil

--- a/ucm/deploy/direct/state.go
+++ b/ucm/deploy/direct/state.go
@@ -30,6 +30,7 @@ type State struct {
 	Grants             map[string]*GrantState             `json:"grants,omitempty"`
 	StorageCredentials map[string]*StorageCredentialState `json:"storage_credentials,omitempty"`
 	ExternalLocations  map[string]*ExternalLocationState  `json:"external_locations,omitempty"`
+	Volumes            map[string]*VolumeState            `json:"volumes,omitempty"`
 }
 
 // CatalogState is what the direct engine records for a catalog after a
@@ -111,6 +112,17 @@ type ExternalLocationState struct {
 	Fallback       bool   `json:"fallback,omitempty"`
 }
 
+// VolumeState mirrors resources.Volume for drift detection. All fields are
+// primitives so reflect.DeepEqual suffices.
+type VolumeState struct {
+	Name            string `json:"name"`
+	CatalogName     string `json:"catalog_name"`
+	SchemaName      string `json:"schema_name"`
+	VolumeType      string `json:"volume_type"`
+	StorageLocation string `json:"storage_location,omitempty"`
+	Comment         string `json:"comment,omitempty"`
+}
+
 // NewState returns an empty State ready to be populated by the planner.
 func NewState() *State {
 	return &State{
@@ -120,6 +132,7 @@ func NewState() *State {
 		Grants:             make(map[string]*GrantState),
 		StorageCredentials: make(map[string]*StorageCredentialState),
 		ExternalLocations:  make(map[string]*ExternalLocationState),
+		Volumes:            make(map[string]*VolumeState),
 	}
 }
 
@@ -155,6 +168,9 @@ func LoadState(path string) (*State, error) {
 	}
 	if s.ExternalLocations == nil {
 		s.ExternalLocations = make(map[string]*ExternalLocationState)
+	}
+	if s.Volumes == nil {
+		s.Volumes = make(map[string]*VolumeState)
 	}
 	return &s, nil
 }

--- a/ucm/deploy/direct/state.go
+++ b/ucm/deploy/direct/state.go
@@ -29,6 +29,7 @@ type State struct {
 	Schemas            map[string]*SchemaState            `json:"schemas,omitempty"`
 	Grants             map[string]*GrantState             `json:"grants,omitempty"`
 	StorageCredentials map[string]*StorageCredentialState `json:"storage_credentials,omitempty"`
+	ExternalLocations  map[string]*ExternalLocationState  `json:"external_locations,omitempty"`
 }
 
 // CatalogState is what the direct engine records for a catalog after a
@@ -97,6 +98,19 @@ type AzureServicePrincipalState struct {
 // DatabricksGcpServiceAccountState mirrors resources.DatabricksGcpServiceAccount.
 type DatabricksGcpServiceAccountState struct{}
 
+// ExternalLocationState mirrors resources.ExternalLocation. All fields are
+// primitives so a reflect.DeepEqual on the struct suffices for drift detection.
+type ExternalLocationState struct {
+	Name           string `json:"name"`
+	Url            string `json:"url"`
+	CredentialName string `json:"credential_name"`
+
+	Comment        string `json:"comment,omitempty"`
+	ReadOnly       bool   `json:"read_only,omitempty"`
+	SkipValidation bool   `json:"skip_validation,omitempty"`
+	Fallback       bool   `json:"fallback,omitempty"`
+}
+
 // NewState returns an empty State ready to be populated by the planner.
 func NewState() *State {
 	return &State{
@@ -105,6 +119,7 @@ func NewState() *State {
 		Schemas:            make(map[string]*SchemaState),
 		Grants:             make(map[string]*GrantState),
 		StorageCredentials: make(map[string]*StorageCredentialState),
+		ExternalLocations:  make(map[string]*ExternalLocationState),
 	}
 }
 
@@ -137,6 +152,9 @@ func LoadState(path string) (*State, error) {
 	}
 	if s.StorageCredentials == nil {
 		s.StorageCredentials = make(map[string]*StorageCredentialState)
+	}
+	if s.ExternalLocations == nil {
+		s.ExternalLocations = make(map[string]*ExternalLocationState)
 	}
 	return &s, nil
 }

--- a/ucm/deploy/direct/state.go
+++ b/ucm/deploy/direct/state.go
@@ -31,6 +31,7 @@ type State struct {
 	StorageCredentials map[string]*StorageCredentialState `json:"storage_credentials,omitempty"`
 	ExternalLocations  map[string]*ExternalLocationState  `json:"external_locations,omitempty"`
 	Volumes            map[string]*VolumeState            `json:"volumes,omitempty"`
+	Connections        map[string]*ConnectionState        `json:"connections,omitempty"`
 }
 
 // CatalogState is what the direct engine records for a catalog after a
@@ -123,6 +124,16 @@ type VolumeState struct {
 	Comment         string `json:"comment,omitempty"`
 }
 
+// ConnectionState mirrors resources.Connection.
+type ConnectionState struct {
+	Name           string            `json:"name"`
+	ConnectionType string            `json:"connection_type"`
+	Options        map[string]string `json:"options"`
+	Comment        string            `json:"comment,omitempty"`
+	Properties     map[string]string `json:"properties,omitempty"`
+	ReadOnly       bool              `json:"read_only,omitempty"`
+}
+
 // NewState returns an empty State ready to be populated by the planner.
 func NewState() *State {
 	return &State{
@@ -133,6 +144,7 @@ func NewState() *State {
 		StorageCredentials: make(map[string]*StorageCredentialState),
 		ExternalLocations:  make(map[string]*ExternalLocationState),
 		Volumes:            make(map[string]*VolumeState),
+		Connections:        make(map[string]*ConnectionState),
 	}
 }
 
@@ -171,6 +183,9 @@ func LoadState(path string) (*State, error) {
 	}
 	if s.Volumes == nil {
 		s.Volumes = make(map[string]*VolumeState)
+	}
+	if s.Connections == nil {
+		s.Connections = make(map[string]*ConnectionState)
 	}
 	return &s, nil
 }

--- a/ucm/deploy/direct/state_test.go
+++ b/ucm/deploy/direct/state_test.go
@@ -21,6 +21,7 @@ func TestLoadState_MissingFileReturnsEmpty(t *testing.T) {
 	assert.Empty(t, s.StorageCredentials)
 	assert.Empty(t, s.ExternalLocations)
 	assert.Empty(t, s.Volumes)
+	assert.Empty(t, s.Connections)
 }
 
 func TestLoadState_RoundTrip(t *testing.T) {

--- a/ucm/deploy/direct/state_test.go
+++ b/ucm/deploy/direct/state_test.go
@@ -19,6 +19,7 @@ func TestLoadState_MissingFileReturnsEmpty(t *testing.T) {
 	assert.Empty(t, s.Schemas)
 	assert.Empty(t, s.Grants)
 	assert.Empty(t, s.StorageCredentials)
+	assert.Empty(t, s.ExternalLocations)
 }
 
 func TestLoadState_RoundTrip(t *testing.T) {
@@ -38,6 +39,13 @@ func TestLoadState_RoundTrip(t *testing.T) {
 		AwsIamRole: &direct.AwsIamRoleState{RoleArn: "arn:aws:iam::1:role/uc"},
 		ReadOnly:   true,
 	}
+	in.ExternalLocations["prod"] = &direct.ExternalLocationState{
+		Name:           "prod",
+		Url:            "s3://bucket/prefix",
+		CredentialName: "prod",
+		Comment:        "prod location",
+		ReadOnly:       true,
+	}
 
 	require.NoError(t, direct.SaveState(path, in))
 
@@ -47,6 +55,7 @@ func TestLoadState_RoundTrip(t *testing.T) {
 	assert.Equal(t, in.Schemas, out.Schemas)
 	assert.Equal(t, in.Grants, out.Grants)
 	assert.Equal(t, in.StorageCredentials, out.StorageCredentials)
+	assert.Equal(t, in.ExternalLocations, out.ExternalLocations)
 }
 
 func TestLoadState_RejectsFutureVersion(t *testing.T) {

--- a/ucm/deploy/direct/state_test.go
+++ b/ucm/deploy/direct/state_test.go
@@ -20,6 +20,7 @@ func TestLoadState_MissingFileReturnsEmpty(t *testing.T) {
 	assert.Empty(t, s.Grants)
 	assert.Empty(t, s.StorageCredentials)
 	assert.Empty(t, s.ExternalLocations)
+	assert.Empty(t, s.Volumes)
 }
 
 func TestLoadState_RoundTrip(t *testing.T) {

--- a/ucm/deploy/terraform/interpolate.go
+++ b/ucm/deploy/terraform/interpolate.go
@@ -16,6 +16,7 @@ var GroupToTerraformName = map[string]string{
 	"schemas":             "databricks_schema",
 	"grants":              "databricks_grants",
 	"storage_credentials": "databricks_storage_credential",
+	"external_locations":  "databricks_external_location",
 }
 
 // Interpolate rewrites ucm-path references in a TF JSON tree to terraform

--- a/ucm/deploy/terraform/interpolate.go
+++ b/ucm/deploy/terraform/interpolate.go
@@ -17,6 +17,8 @@ var GroupToTerraformName = map[string]string{
 	"grants":              "databricks_grants",
 	"storage_credentials": "databricks_storage_credential",
 	"external_locations":  "databricks_external_location",
+	"volumes":             "databricks_volume",
+	"connections":         "databricks_connection",
 }
 
 // Interpolate rewrites ucm-path references in a TF JSON tree to terraform

--- a/ucm/deploy/terraform/showplan.go
+++ b/ucm/deploy/terraform/showplan.go
@@ -22,6 +22,8 @@ var terraformToGroupName = map[string]string{
 	"databricks_grants":             "grants",
 	"databricks_storage_credential": "storage_credentials",
 	"databricks_external_location":  "external_locations",
+	"databricks_volume":             "volumes",
+	"databricks_connection":         "connections",
 }
 
 // populatePlan fills `plan` from terraform resource changes using the

--- a/ucm/deploy/terraform/showplan.go
+++ b/ucm/deploy/terraform/showplan.go
@@ -21,6 +21,7 @@ var terraformToGroupName = map[string]string{
 	"databricks_schema":             "schemas",
 	"databricks_grants":             "grants",
 	"databricks_storage_credential": "storage_credentials",
+	"databricks_external_location":  "external_locations",
 }
 
 // populatePlan fills `plan` from terraform resource changes using the

--- a/ucm/deploy/terraform/tfdyn/convert_connection.go
+++ b/ucm/deploy/terraform/tfdyn/convert_connection.go
@@ -1,0 +1,62 @@
+package tfdyn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+// convertConnectionResource transforms a ucm connection entry into a
+// dyn.Value shaped like a databricks_connection Terraform block.
+// options is required and must contain at least one key; the TF provider
+// handles per-connection-type validation of which keys are expected.
+func convertConnectionResource(_ context.Context, key string, vin dyn.Value) (dyn.Value, error) {
+	pairs := []dyn.Pair{}
+	appendString(&pairs, vin, "name", key)
+
+	typeVal := vin.Get("connection_type")
+	if s, _ := typeVal.AsString(); s == "" {
+		return dyn.InvalidValue, fmt.Errorf("connection %q: connection_type is required", key)
+	}
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.NewValue("connection_type", typeVal.Locations()),
+		Value: typeVal,
+	})
+
+	optsVal := vin.Get("options")
+	optsMap, ok := optsVal.AsMap()
+	if !ok || optsMap.Len() == 0 {
+		return dyn.InvalidValue, fmt.Errorf("connection %q: options is required and must be non-empty", key)
+	}
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.NewValue("options", optsVal.Locations()),
+		Value: optsVal,
+	})
+
+	appendStringIfSet(&pairs, vin, "comment")
+	if props, ok := mapFromValue(vin.Get("properties")); ok {
+		pairs = append(pairs, dyn.Pair{
+			Key:   dyn.NewValue("properties", vin.Get("properties").Locations()),
+			Value: props,
+		})
+	}
+	appendBoolIfSet(&pairs, vin, "read_only")
+
+	return dyn.NewValue(dyn.NewMappingFromPairs(pairs), vin.Locations()), nil
+}
+
+type connectionConverter struct{}
+
+func (connectionConverter) Convert(ctx context.Context, key string, vin dyn.Value, out *Resources) error {
+	v, err := convertConnectionResource(ctx, key, vin)
+	if err != nil {
+		return err
+	}
+	out.Connection[key] = v
+	return nil
+}
+
+func init() {
+	registerConverter("connections", connectionConverter{})
+}

--- a/ucm/deploy/terraform/tfdyn/convert_connection_test.go
+++ b/ucm/deploy/terraform/tfdyn/convert_connection_test.go
@@ -1,0 +1,105 @@
+package tfdyn
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertConnection(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		src  resources.Connection
+		want map[string]any
+	}{
+		{
+			name: "mysql minimal",
+			key:  "sales_mysql",
+			src: resources.Connection{
+				Name:           "sales_mysql",
+				ConnectionType: "MYSQL",
+				Options: map[string]string{
+					"host": "mysql.acme.internal",
+					"port": "3306",
+					"user": "reader",
+				},
+			},
+			want: map[string]any{
+				"name":            "sales_mysql",
+				"connection_type": "MYSQL",
+				"options": map[string]any{
+					"host": "mysql.acme.internal",
+					"port": "3306",
+					"user": "reader",
+				},
+			},
+		},
+		{
+			name: "all fields",
+			key:  "pg",
+			src: resources.Connection{
+				Name:           "pg",
+				ConnectionType: "POSTGRESQL",
+				Options:        map[string]string{"host": "pg.acme.internal"},
+				Comment:        "prod pg",
+				Properties:     map[string]string{"purpose": "analytics"},
+				ReadOnly:       true,
+			},
+			want: map[string]any{
+				"name":            "pg",
+				"connection_type": "POSTGRESQL",
+				"options":         map[string]any{"host": "pg.acme.internal"},
+				"comment":         "prod pg",
+				"properties":      map[string]any{"purpose": "analytics"},
+				"read_only":       true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+			out := NewResources()
+			err = connectionConverter{}.Convert(t.Context(), tc.key, vin, out)
+			require.NoError(t, err)
+			got, ok := out.Connection[tc.key]
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got.AsAny())
+		})
+	}
+}
+
+func TestConvertConnection_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     resources.Connection
+		wantMsg string
+	}{
+		{
+			name:    "missing connection_type",
+			src:     resources.Connection{Name: "c", Options: map[string]string{"host": "x"}},
+			wantMsg: "connection_type is required",
+		},
+		{
+			name:    "missing options",
+			src:     resources.Connection{Name: "c", ConnectionType: "MYSQL"},
+			wantMsg: "options is required",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+			out := NewResources()
+			err = connectionConverter{}.Convert(t.Context(), "k", vin, out)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}

--- a/ucm/deploy/terraform/tfdyn/convert_external_location.go
+++ b/ucm/deploy/terraform/tfdyn/convert_external_location.go
@@ -1,0 +1,58 @@
+package tfdyn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+// convertExternalLocationResource transforms a ucm external_location entry
+// into a dyn.Value shaped like a databricks_external_location Terraform
+// block. credential_name may be either a literal (bring-your-own) or a
+// ${resources.storage_credentials.<key>.name} interpolation — the render-
+// level Interpolate pass rewrites the latter to the tf-native form.
+func convertExternalLocationResource(_ context.Context, key string, vin dyn.Value) (dyn.Value, error) {
+	pairs := []dyn.Pair{}
+	appendString(&pairs, vin, "name", key)
+
+	urlVal := vin.Get("url")
+	if s, _ := urlVal.AsString(); s == "" {
+		return dyn.InvalidValue, fmt.Errorf("external_location %q: url is required", key)
+	}
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.NewValue("url", urlVal.Locations()),
+		Value: urlVal,
+	})
+
+	credVal := vin.Get("credential_name")
+	if s, _ := credVal.AsString(); s == "" {
+		return dyn.InvalidValue, fmt.Errorf("external_location %q: credential_name is required", key)
+	}
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.NewValue("credential_name", credVal.Locations()),
+		Value: credVal,
+	})
+
+	appendStringIfSet(&pairs, vin, "comment")
+	appendBoolIfSet(&pairs, vin, "read_only")
+	appendBoolIfSet(&pairs, vin, "skip_validation")
+	appendBoolIfSet(&pairs, vin, "fallback")
+
+	return dyn.NewValue(dyn.NewMappingFromPairs(pairs), vin.Locations()), nil
+}
+
+type externalLocationConverter struct{}
+
+func (externalLocationConverter) Convert(ctx context.Context, key string, vin dyn.Value, out *Resources) error {
+	v, err := convertExternalLocationResource(ctx, key, vin)
+	if err != nil {
+		return err
+	}
+	out.ExternalLocation[key] = v
+	return nil
+}
+
+func init() {
+	registerConverter("external_locations", externalLocationConverter{})
+}

--- a/ucm/deploy/terraform/tfdyn/convert_external_location_test.go
+++ b/ucm/deploy/terraform/tfdyn/convert_external_location_test.go
@@ -1,0 +1,101 @@
+package tfdyn
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertExternalLocation(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		src  resources.ExternalLocation
+		want map[string]any
+	}{
+		{
+			name: "minimal",
+			key:  "sales_loc",
+			src: resources.ExternalLocation{
+				Name:           "sales_loc",
+				Url:            "s3://acme-sales/prod",
+				CredentialName: "sales_cred",
+			},
+			want: map[string]any{
+				"name":            "sales_loc",
+				"url":             "s3://acme-sales/prod",
+				"credential_name": "sales_cred",
+			},
+		},
+		{
+			name: "all fields",
+			key:  "ro_loc",
+			src: resources.ExternalLocation{
+				Name:           "ro_loc",
+				Url:            "abfss://data@acme.dfs.core.windows.net/ro",
+				CredentialName: "shared_cred",
+				Comment:        "read-only location",
+				ReadOnly:       true,
+				SkipValidation: true,
+				Fallback:       true,
+			},
+			want: map[string]any{
+				"name":            "ro_loc",
+				"url":             "abfss://data@acme.dfs.core.windows.net/ro",
+				"credential_name": "shared_cred",
+				"comment":         "read-only location",
+				"read_only":       true,
+				"skip_validation": true,
+				"fallback":        true,
+			},
+		},
+		{
+			name: "defaults name from key",
+			key:  "inferred",
+			src: resources.ExternalLocation{
+				Url:            "gs://acme/prod",
+				CredentialName: "cred",
+			},
+			want: map[string]any{
+				"name":            "inferred",
+				"url":             "gs://acme/prod",
+				"credential_name": "cred",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+			out := NewResources()
+			err = externalLocationConverter{}.Convert(t.Context(), tc.key, vin, out)
+			require.NoError(t, err)
+			got, ok := out.ExternalLocation[tc.key]
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got.AsAny())
+		})
+	}
+}
+
+func TestConvertExternalLocation_ErrorsOnMissingUrl(t *testing.T) {
+	vin, err := convert.FromTyped(resources.ExternalLocation{Name: "bad", CredentialName: "c"}, dyn.NilValue)
+	require.NoError(t, err)
+	out := NewResources()
+	err = externalLocationConverter{}.Convert(t.Context(), "bad", vin, out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "url is required")
+}
+
+func TestConvertExternalLocation_ErrorsOnMissingCredentialName(t *testing.T) {
+	vin, err := convert.FromTyped(resources.ExternalLocation{Name: "bad", Url: "s3://x/y"}, dyn.NilValue)
+	require.NoError(t, err)
+	out := NewResources()
+	err = externalLocationConverter{}.Convert(t.Context(), "bad", vin, out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential_name is required")
+}

--- a/ucm/deploy/terraform/tfdyn/convert_volume.go
+++ b/ucm/deploy/terraform/tfdyn/convert_volume.go
@@ -1,0 +1,83 @@
+package tfdyn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+// convertVolumeResource transforms a ucm volume entry into a dyn.Value
+// shaped like a databricks_volume Terraform block. Validates the
+// MANAGED-vs-EXTERNAL invariant: EXTERNAL volumes require
+// storage_location, MANAGED ones must not carry one.
+func convertVolumeResource(_ context.Context, key string, vin dyn.Value) (dyn.Value, error) {
+	pairs := []dyn.Pair{}
+	appendString(&pairs, vin, "name", key)
+
+	catVal := vin.Get("catalog_name")
+	if s, _ := catVal.AsString(); s == "" {
+		return dyn.InvalidValue, fmt.Errorf("volume %q: catalog_name is required", key)
+	}
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.NewValue("catalog_name", catVal.Locations()),
+		Value: catVal,
+	})
+
+	schemaVal := vin.Get("schema_name")
+	if s, _ := schemaVal.AsString(); s == "" {
+		return dyn.InvalidValue, fmt.Errorf("volume %q: schema_name is required", key)
+	}
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.NewValue("schema_name", schemaVal.Locations()),
+		Value: schemaVal,
+	})
+
+	typeVal := vin.Get("volume_type")
+	vType, _ := typeVal.AsString()
+	vType = strings.ToUpper(vType)
+	if vType != "MANAGED" && vType != "EXTERNAL" {
+		return dyn.InvalidValue, fmt.Errorf("volume %q: volume_type must be MANAGED or EXTERNAL, got %q", key, vType)
+	}
+	pairs = append(pairs, dyn.Pair{
+		Key:   dyn.NewValue("volume_type", typeVal.Locations()),
+		Value: dyn.NewValue(vType, typeVal.Locations()),
+	})
+
+	locVal := vin.Get("storage_location")
+	locStr, _ := locVal.AsString()
+	switch vType {
+	case "EXTERNAL":
+		if locStr == "" {
+			return dyn.InvalidValue, fmt.Errorf("volume %q: storage_location is required for EXTERNAL volumes", key)
+		}
+		pairs = append(pairs, dyn.Pair{
+			Key:   dyn.NewValue("storage_location", locVal.Locations()),
+			Value: locVal,
+		})
+	case "MANAGED":
+		if locStr != "" {
+			return dyn.InvalidValue, fmt.Errorf("volume %q: storage_location must not be set for MANAGED volumes", key)
+		}
+	}
+
+	appendStringIfSet(&pairs, vin, "comment")
+
+	return dyn.NewValue(dyn.NewMappingFromPairs(pairs), vin.Locations()), nil
+}
+
+type volumeConverter struct{}
+
+func (volumeConverter) Convert(ctx context.Context, key string, vin dyn.Value, out *Resources) error {
+	v, err := convertVolumeResource(ctx, key, vin)
+	if err != nil {
+		return err
+	}
+	out.Volume[key] = v
+	return nil
+}
+
+func init() {
+	registerConverter("volumes", volumeConverter{})
+}

--- a/ucm/deploy/terraform/tfdyn/convert_volume_test.go
+++ b/ucm/deploy/terraform/tfdyn/convert_volume_test.go
@@ -1,0 +1,130 @@
+package tfdyn
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertVolume(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		src  resources.Volume
+		want map[string]any
+	}{
+		{
+			name: "managed",
+			key:  "landing",
+			src: resources.Volume{
+				Name:        "landing",
+				CatalogName: "sales",
+				SchemaName:  "raw",
+				VolumeType:  "MANAGED",
+				Comment:     "landing zone",
+			},
+			want: map[string]any{
+				"name":         "landing",
+				"catalog_name": "sales",
+				"schema_name":  "raw",
+				"volume_type":  "MANAGED",
+				"comment":      "landing zone",
+			},
+		},
+		{
+			name: "external",
+			key:  "archive",
+			src: resources.Volume{
+				Name:            "archive",
+				CatalogName:     "sales",
+				SchemaName:      "raw",
+				VolumeType:      "EXTERNAL",
+				StorageLocation: "s3://acme-archive/sales",
+			},
+			want: map[string]any{
+				"name":             "archive",
+				"catalog_name":     "sales",
+				"schema_name":      "raw",
+				"volume_type":      "EXTERNAL",
+				"storage_location": "s3://acme-archive/sales",
+			},
+		},
+		{
+			name: "lowercase volume_type normalised",
+			key:  "lower",
+			src: resources.Volume{
+				Name:        "lower",
+				CatalogName: "sales",
+				SchemaName:  "raw",
+				VolumeType:  "managed",
+			},
+			want: map[string]any{
+				"name":         "lower",
+				"catalog_name": "sales",
+				"schema_name":  "raw",
+				"volume_type":  "MANAGED",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+			out := NewResources()
+			err = volumeConverter{}.Convert(t.Context(), tc.key, vin, out)
+			require.NoError(t, err)
+			got, ok := out.Volume[tc.key]
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got.AsAny())
+		})
+	}
+}
+
+func TestConvertVolume_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     resources.Volume
+		wantMsg string
+	}{
+		{
+			name:    "missing catalog_name",
+			src:     resources.Volume{Name: "v", SchemaName: "s", VolumeType: "MANAGED"},
+			wantMsg: "catalog_name is required",
+		},
+		{
+			name:    "missing schema_name",
+			src:     resources.Volume{Name: "v", CatalogName: "c", VolumeType: "MANAGED"},
+			wantMsg: "schema_name is required",
+		},
+		{
+			name:    "invalid volume_type",
+			src:     resources.Volume{Name: "v", CatalogName: "c", SchemaName: "s", VolumeType: "WEIRD"},
+			wantMsg: "volume_type must be MANAGED or EXTERNAL",
+		},
+		{
+			name:    "external without storage_location",
+			src:     resources.Volume{Name: "v", CatalogName: "c", SchemaName: "s", VolumeType: "EXTERNAL"},
+			wantMsg: "storage_location is required for EXTERNAL",
+		},
+		{
+			name:    "managed with storage_location",
+			src:     resources.Volume{Name: "v", CatalogName: "c", SchemaName: "s", VolumeType: "MANAGED", StorageLocation: "s3://x/y"},
+			wantMsg: "storage_location must not be set for MANAGED",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vin, err := convert.FromTyped(tc.src, dyn.NilValue)
+			require.NoError(t, err)
+			out := NewResources()
+			err = volumeConverter{}.Convert(t.Context(), "k", vin, out)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}

--- a/ucm/deploy/terraform/tfdyn/registry.go
+++ b/ucm/deploy/terraform/tfdyn/registry.go
@@ -22,6 +22,7 @@ type Resources struct {
 	Schema            map[string]dyn.Value
 	Grants            map[string]dyn.Value
 	StorageCredential map[string]dyn.Value
+	ExternalLocation  map[string]dyn.Value
 }
 
 // NewResources returns an empty Resources ready for converters to fill.
@@ -31,6 +32,7 @@ func NewResources() *Resources {
 		Schema:            map[string]dyn.Value{},
 		Grants:            map[string]dyn.Value{},
 		StorageCredential: map[string]dyn.Value{},
+		ExternalLocation:  map[string]dyn.Value{},
 	}
 }
 

--- a/ucm/deploy/terraform/tfdyn/registry.go
+++ b/ucm/deploy/terraform/tfdyn/registry.go
@@ -23,6 +23,8 @@ type Resources struct {
 	Grants            map[string]dyn.Value
 	StorageCredential map[string]dyn.Value
 	ExternalLocation  map[string]dyn.Value
+	Volume            map[string]dyn.Value
+	Connection        map[string]dyn.Value
 }
 
 // NewResources returns an empty Resources ready for converters to fill.
@@ -33,6 +35,8 @@ func NewResources() *Resources {
 		Grants:            map[string]dyn.Value{},
 		StorageCredential: map[string]dyn.Value{},
 		ExternalLocation:  map[string]dyn.Value{},
+		Volume:            map[string]dyn.Value{},
+		Connection:        map[string]dyn.Value{},
 	}
 }
 

--- a/ucm/deploy/terraform/tfdyn/tfdyn.go
+++ b/ucm/deploy/terraform/tfdyn/tfdyn.go
@@ -21,7 +21,7 @@ const (
 // ordering matters because downstream converters inspect earlier ones
 // (schemas look at Resources.Catalog to decide whether to emit depends_on;
 // grants look at Resources.Catalog and Resources.Schema).
-var convertOrder = []string{"storage_credentials", "external_locations", "catalogs", "schemas", "grants"}
+var convertOrder = []string{"storage_credentials", "external_locations", "catalogs", "schemas", "volumes", "connections", "grants"}
 
 // Convert walks a ucm configuration and produces the Terraform JSON
 // resource tree suitable for writing as a .tf.json file. The returned
@@ -90,6 +90,8 @@ func buildResourceTree(out *Resources) dyn.Value {
 		{"databricks_external_location", out.ExternalLocation},
 		{"databricks_catalog", out.Catalog},
 		{"databricks_schema", out.Schema},
+		{"databricks_volume", out.Volume},
+		{"databricks_connection", out.Connection},
 		{"databricks_grants", out.Grants},
 	}
 

--- a/ucm/deploy/terraform/tfdyn/tfdyn.go
+++ b/ucm/deploy/terraform/tfdyn/tfdyn.go
@@ -21,7 +21,7 @@ const (
 // ordering matters because downstream converters inspect earlier ones
 // (schemas look at Resources.Catalog to decide whether to emit depends_on;
 // grants look at Resources.Catalog and Resources.Schema).
-var convertOrder = []string{"storage_credentials", "catalogs", "schemas", "grants"}
+var convertOrder = []string{"storage_credentials", "external_locations", "catalogs", "schemas", "grants"}
 
 // Convert walks a ucm configuration and produces the Terraform JSON
 // resource tree suitable for writing as a .tf.json file. The returned
@@ -87,6 +87,7 @@ func buildResourceTree(out *Resources) dyn.Value {
 		values map[string]dyn.Value
 	}{
 		{"databricks_storage_credential", out.StorageCredential},
+		{"databricks_external_location", out.ExternalLocation},
 		{"databricks_catalog", out.Catalog},
 		{"databricks_schema", out.Schema},
 		{"databricks_grants", out.Grants},

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -193,6 +193,20 @@ func (*fakeDirectClient) UpdateVolume(_ context.Context, _ catalog.UpdateVolumeR
 
 func (*fakeDirectClient) DeleteVolume(_ context.Context, _ string) error { return nil }
 
+func (*fakeDirectClient) GetConnection(_ context.Context, _ string) (*catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) CreateConnection(_ context.Context, _ catalog.CreateConnection) (*catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) UpdateConnection(_ context.Context, _ catalog.UpdateConnection) (*catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) DeleteConnection(_ context.Context, _ string) error { return nil }
+
 func (*fakeDirectClient) UpdatePermissions(_ context.Context, _ catalog.UpdatePermissions) error {
 	return nil
 }

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -179,6 +179,20 @@ func (*fakeDirectClient) UpdateExternalLocation(_ context.Context, _ catalog.Upd
 
 func (*fakeDirectClient) DeleteExternalLocation(_ context.Context, _ string) error { return nil }
 
+func (*fakeDirectClient) GetVolume(_ context.Context, _ string) (*catalog.VolumeInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) CreateVolume(_ context.Context, _ catalog.CreateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) UpdateVolume(_ context.Context, _ catalog.UpdateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) DeleteVolume(_ context.Context, _ string) error { return nil }
+
 func (*fakeDirectClient) UpdatePermissions(_ context.Context, _ catalog.UpdatePermissions) error {
 	return nil
 }

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -165,6 +165,20 @@ func (*fakeDirectClient) UpdateStorageCredential(_ context.Context, _ catalog.Up
 
 func (*fakeDirectClient) DeleteStorageCredential(_ context.Context, _ string) error { return nil }
 
+func (*fakeDirectClient) GetExternalLocation(_ context.Context, _ string) (*catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) CreateExternalLocation(_ context.Context, _ catalog.CreateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) UpdateExternalLocation(_ context.Context, _ catalog.UpdateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+
+func (*fakeDirectClient) DeleteExternalLocation(_ context.Context, _ string) error { return nil }
+
 func (*fakeDirectClient) UpdatePermissions(_ context.Context, _ catalog.UpdatePermissions) error {
 	return nil
 }


### PR DESCRIPTION
Closes #59
Closes #60
Closes #61
Parent epic: #48

Three resources bundled into one PR per user request — the approval-queue overhead of four sequential PRs (#49 already merged; #59/#60/#61 queued) wasn't worth the isolation benefit once the pattern was proven by the storage_credential PR. One branch, logically-sequenced commits so each resource is still reviewable independently if needed.

## Summary

### external_location (closes #59)

- Config struct, TF converter, direct engine CRUD.
- \`credential_name\` accepts literal or \`\${resources.storage_credentials.<key>.name}\`.
- Apply ordering: storage_credentials → **external_locations** → catalogs.

### volume (closes #60)

- Config struct, TF converter, direct engine CRUD.
- \`volume_type\` ∈ {MANAGED, EXTERNAL}; \`storage_location\` required for EXTERNAL, rejected for MANAGED (enforced in both TF converter and direct input builder).
- Apply ordering: … → schemas → **volumes** → connections → grants.

### connection (closes #61)

- Config struct, TF converter, direct engine CRUD.
- \`options\` required non-empty; per-type key validation delegated to the TF provider / UC API.
- Apply ordering: … → volumes → **connections** → grants.

## Shared infrastructure updates

- \`terraform.GroupToTerraformName\` and \`terraform.terraformToGroupName\` extended with all three resources so \`\${resources.*}\` interpolation and plan-summary aggregation cover them.
- \`tfdyn.convertOrder\` final ordering: \`storage_credentials → external_locations → catalogs → schemas → volumes → connections → grants\`.
- \`tfdyn.buildResourceTree\` emits blocks in that same order for stable output.
- Direct engine \`Apply\` / \`Destroy\` ordering: creates in the order above, deletes in reverse.

## Known limitation — tracked in #62

\`UpdateVolumeRequestContent\` only accepts \`comment\`/\`new_name\`/\`owner\`. \`UpdateConnection\` only accepts \`name\`/\`new_name\`/\`options\`/\`owner\`. Drift on any other field is silently dropped by the SDK. The planner still marks it as Update today — #62 tracks a fail-fast or force-recreate fix. Not blocking.

## Grants on new resources

\`securableField\` in \`convert_grant.go\` and the direct-engine grant reconciliation stay at catalog+schema only. Grants on storage_credentials/external_locations/volumes/connections is a separate, scoped piece of work.

## Test plan

- [x] \`GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...\`
- [x] \`GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...\`
- [x] \`GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...\`
- [x] Unit tests for each converter pin field mapping + validation errors.
- [x] Direct engine has Create/Update/Skip/Delete coverage per resource.
- [x] Apply-order test asserts storage_credentials/external_locations precede catalogs.
- [ ] Acceptance fixtures (\`acceptance/ucm/plan/{external_location,volume,connection}/\`) — \`output.txt\` deferred to CI -update (local env can't reach releases.hashicorp.com, same precedent as 48dc42a10 and d6634d5c1).

## Follow-on

Phase A done. After merge, the user's testing loop (\`ucm deploy\` + \`ucm summary\`) should exercise the full UC workspace-level surface except grants-on-new-resources. The parity audit (\`docs/superpowers/parity-audit-2026-04-22.md\`) lists \`deploy\`/\`summary\`/\`plan\`/\`validate\` gaps against DAB, which I'll walk through next.