### PR TITLE
Fix #64: DAB parity — summary reshape, validate --output json, --force-lock, schema cosmetic

### DIFF
--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -27,6 +27,9 @@ Common invocations:
 		PreRunE: utils.MustWorkspaceClient,
 	}
 
+	var forceLock bool
+	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
+
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
 		ctx := cmd.Context()
@@ -38,6 +41,7 @@ Common invocations:
 		if err != nil {
 			return fmt.Errorf("resolve deploy options: %w", err)
 		}
+		opts.ForceLock = forceLock
 
 		phases.Deploy(ctx, u, opts)
 		if logdiag.HasError(ctx) {

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -30,7 +30,9 @@ Common invocations:
 	}
 
 	var autoApprove bool
+	var forceLock bool
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip interactive approvals for deleting resources.")
+	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -48,6 +50,7 @@ Common invocations:
 		if err != nil {
 			return fmt.Errorf("resolve deploy options: %w", err)
 		}
+		opts.ForceLock = forceLock
 
 		phases.Destroy(ctx, u, opts)
 		if logdiag.HasError(ctx) {

--- a/cmd/ucm/helpers_test.go
+++ b/cmd/ucm/helpers_test.go
@@ -63,14 +63,14 @@ func (f *fakeTf) Plan(_ context.Context, _ *ucmpkg.Ucm) (*terraform.PlanResult, 
 	return f.PlanResult, f.PlanErr
 }
 
-func (f *fakeTf) Apply(_ context.Context, _ *ucmpkg.Ucm) error {
+func (f *fakeTf) Apply(_ context.Context, _ *ucmpkg.Ucm, _ bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.ApplyCalls++
 	return f.ApplyErr
 }
 
-func (f *fakeTf) Destroy(_ context.Context, _ *ucmpkg.Ucm) error {
+func (f *fakeTf) Destroy(_ context.Context, _ *ucmpkg.Ucm, _ bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.DestroyCalls++

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -33,6 +33,9 @@ Common invocations:
 		PreRunE: utils.MustWorkspaceClient,
 	}
 
+	var forceLock bool
+	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
+
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
 		ctx := cmd.Context()
@@ -44,6 +47,7 @@ Common invocations:
 		if err != nil {
 			return fmt.Errorf("resolve deploy options: %w", err)
 		}
+		opts.ForceLock = forceLock
 
 		outcome := phases.Plan(ctx, u, opts)
 		if logdiag.HasError(ctx) {

--- a/cmd/ucm/schema.go
+++ b/cmd/ucm/schema.go
@@ -24,10 +24,7 @@ Pipe into a file and point your editor at it for autocomplete and validation:
 		if err != nil {
 			return err
 		}
-		if _, err := cmd.OutOrStdout().Write(out); err != nil {
-			return err
-		}
-		_, err = cmd.OutOrStdout().Write([]byte{'\n'})
+		_, err = cmd.OutOrStdout().Write(out)
 		return err
 	}
 

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -1,43 +1,48 @@
 package ucm
 
 import (
+	"cmp"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"sort"
-	"text/tabwriter"
+	"io"
+	"slices"
+	"strings"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
-	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/config"
 	"github.com/spf13/cobra"
 )
-
-// tfstateEnvelope is the minimal shape we need out of terraform.tfstate to
-// produce a resource-count summary. Forked (not imported) from the terraform
-// project's Go API so ucm doesn't pin on an internal schema.
-type tfstateEnvelope struct {
-	Resources []struct {
-		Type string `json:"type"`
-	} `json:"resources"`
-}
 
 func newSummaryCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "summary",
-		Short: "Summarize deployed resources by type.",
-		Long: `Summarize the resources currently tracked by the ucm deploy state.
+		Short: "Summarize resources declared by this ucm deployment.",
+		Long: `Summarize the resources declared by this ucm deployment, grouped by kind,
+with workspace URLs when a Workspace.Host is configured.
 
-Reads the local terraform state cached under .databricks/ucm/<target>/ and
-prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
-` + "`ucm plan`" + `) first; without a local state the table is empty.`,
+Mirrors ` + "`databricks bundle summary`" + `: reads the post-load, post-mutator
+config tree (not the tfstate), so the output reflects ucm.yml intent. Run
+` + "`ucm deploy`" + ` to realize those intents.
+
+Common invocations:
+  databricks ucm summary                   # Text summary of the default target
+  databricks ucm summary --target prod     # Summary of a named target
+  databricks ucm summary -o json           # Emit the full config as JSON`,
 		Args:    root.NoArgs,
 		PreRunE: utils.MustWorkspaceClient,
 	}
+
+	// forcePull and includeLocations are accepted for DAB parity but are no-ops
+	// today: summary reads the in-memory config, not cached remote state, and
+	// ucm has no location-populating mutator yet.
+	var forcePull bool
+	var includeLocations bool
+	cmd.Flags().BoolVar(&forcePull, "force-pull", false, "Skip local cache and load the state from the remote workspace (no-op today)")
+	cmd.Flags().BoolVar(&includeLocations, "include-locations", false, "Include location information in the output")
+	_ = cmd.Flags().MarkHidden("include-locations")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
@@ -46,55 +51,155 @@ prints a table of resource type + count. Run ` + "`ucm deploy`" + ` (or at least
 			return root.ErrAlreadyPrinted
 		}
 
-		statePath := filepath.Join(deploy.LocalStateDir(u), deploy.TfStateFileName)
-		counts, err := readTfstateCounts(statePath)
-		if err != nil {
-			return fmt.Errorf("read local state %s: %w", filepath.ToSlash(statePath), err)
-		}
-
 		out := cmd.OutOrStdout()
-		if len(counts) == 0 {
-			fmt.Fprintln(out, "No deployed resources found. Run `ucm deploy` first.")
+		switch summaryOutputType(cmd) {
+		case flags.OutputJSON:
+			buf, err := json.MarshalIndent(u.Config, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(out, string(buf))
+			return nil
+		default:
+			renderSummaryText(out, &u.Config)
 			return nil
 		}
-
-		types := make([]string, 0, len(counts))
-		for t := range counts {
-			types = append(types, t)
-		}
-		sort.Strings(types)
-
-		tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(tw, "TYPE\tCOUNT")
-		for _, t := range types {
-			fmt.Fprintf(tw, "%s\t%d\n", t, counts[t])
-		}
-		return tw.Flush()
 	}
 
 	return cmd
 }
 
-// readTfstateCounts opens the terraform.tfstate at path and returns a map of
-// resource type → count. A missing state file is treated as "no resources"
-// rather than an error so the first-run / pre-deploy path stays clean.
-func readTfstateCounts(path string) (map[string]int, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, nil
+// summaryOutputType mirrors planOutputType: returns OutputText when the
+// persistent --output flag wasn't wired (unit tests build the tree directly
+// via New() rather than going through root.New).
+func summaryOutputType(cmd *cobra.Command) flags.Output {
+	if cmd.Flag("output") == nil {
+		return flags.OutputText
+	}
+	return root.OutputType(cmd)
+}
+
+// resourceRow is one line in a summary group.
+type resourceRow struct {
+	Key  string
+	Name string
+	URL  string
+}
+
+// resourceGroup is a titled collection of resourceRows (e.g. "Catalogs").
+type resourceGroup struct {
+	Title string
+	Rows  []resourceRow
+}
+
+// renderSummaryText writes the bundle-summary-shaped text output: header
+// (Name / Target / Workspace) followed by one section per non-empty resource
+// group. Empty groups are suppressed.
+func renderSummaryText(out io.Writer, cfg *config.Root) {
+	renderSummaryHeader(out, cfg)
+
+	groups := collectResourceGroups(cfg)
+	for _, g := range groups {
+		fmt.Fprintf(out, "%s:\n", g.Title)
+		for _, r := range g.Rows {
+			fmt.Fprintf(out, "  %s:\n", r.Key)
+			fmt.Fprintf(out, "    Name: %s\n", r.Name)
+			if r.URL != "" {
+				fmt.Fprintf(out, "    URL:  %s\n", r.URL)
+			}
 		}
-		return nil, err
+	}
+}
+
+func renderSummaryHeader(out io.Writer, cfg *config.Root) {
+	if cfg.Ucm.Name != "" {
+		fmt.Fprintf(out, "Name: %s\n", cfg.Ucm.Name)
+	}
+	if cfg.Ucm.Target != "" {
+		fmt.Fprintf(out, "Target: %s\n", cfg.Ucm.Target)
+	}
+	if cfg.Workspace.Host != "" {
+		fmt.Fprintln(out, "Workspace:")
+		fmt.Fprintf(out, "  Host: %s\n", cfg.Workspace.Host)
+	}
+	fmt.Fprintln(out)
+}
+
+// collectResourceGroups gathers the declared resources into titled groups
+// sorted by title, each group's rows sorted by key. Groups with no entries
+// are omitted so the output only shows sections that exist.
+func collectResourceGroups(cfg *config.Root) []resourceGroup {
+	host := strings.TrimRight(cfg.Workspace.Host, "/")
+	var groups []resourceGroup
+
+	if len(cfg.Resources.Catalogs) > 0 {
+		rows := make([]resourceRow, 0, len(cfg.Resources.Catalogs))
+		for key, c := range cfg.Resources.Catalogs {
+			rows = append(rows, resourceRow{
+				Key:  key,
+				Name: c.Name,
+				URL:  joinURL(host, "/explore/data/"+c.Name),
+			})
+		}
+		groups = append(groups, resourceGroup{Title: "Catalogs", Rows: rows})
 	}
 
-	var env tfstateEnvelope
-	if err := json.Unmarshal(data, &env); err != nil {
-		return nil, fmt.Errorf("parse tfstate: %w", err)
+	if len(cfg.Resources.Schemas) > 0 {
+		rows := make([]resourceRow, 0, len(cfg.Resources.Schemas))
+		for key, s := range cfg.Resources.Schemas {
+			full := s.Name
+			var url string
+			if s.Catalog != "" {
+				full = s.Catalog + "." + s.Name
+				url = joinURL(host, "/explore/data/"+s.Catalog+"/"+s.Name)
+			}
+			rows = append(rows, resourceRow{Key: key, Name: full, URL: url})
+		}
+		groups = append(groups, resourceGroup{Title: "Schemas", Rows: rows})
 	}
 
-	counts := make(map[string]int, len(env.Resources))
-	for _, r := range env.Resources {
-		counts[r.Type]++
+	if len(cfg.Resources.StorageCredentials) > 0 {
+		rows := make([]resourceRow, 0, len(cfg.Resources.StorageCredentials))
+		for key, sc := range cfg.Resources.StorageCredentials {
+			rows = append(rows, resourceRow{
+				Key:  key,
+				Name: sc.Name,
+				URL:  joinURL(host, "/explore/storage-credentials/"+sc.Name),
+			})
+		}
+		groups = append(groups, resourceGroup{Title: "Storage credentials", Rows: rows})
 	}
-	return counts, nil
+
+	if len(cfg.Resources.Grants) > 0 {
+		rows := make([]resourceRow, 0, len(cfg.Resources.Grants))
+		for key, g := range cfg.Resources.Grants {
+			// Grants have no workspace URL; summarise securable + principal.
+			name := fmt.Sprintf("%s %s -> %s", g.Securable.Type, g.Securable.Name, g.Principal)
+			rows = append(rows, resourceRow{Key: key, Name: name})
+		}
+		groups = append(groups, resourceGroup{Title: "Grants", Rows: rows})
+	}
+
+	if len(cfg.Resources.TagValidationRules) > 0 {
+		rows := make([]resourceRow, 0, len(cfg.Resources.TagValidationRules))
+		for key := range cfg.Resources.TagValidationRules {
+			rows = append(rows, resourceRow{Key: key, Name: key})
+		}
+		groups = append(groups, resourceGroup{Title: "Tag validation rules", Rows: rows})
+	}
+
+	slices.SortFunc(groups, func(a, b resourceGroup) int { return cmp.Compare(a.Title, b.Title) })
+	for i := range groups {
+		slices.SortFunc(groups[i].Rows, func(a, b resourceRow) int { return cmp.Compare(a.Key, b.Key) })
+	}
+	return groups
+}
+
+// joinURL returns host+path, or "" when host is empty. Keeps the caller from
+// sprinkling if-host checks everywhere.
+func joinURL(host, path string) string {
+	if host == "" {
+		return ""
+	}
+	return host + path
 }

--- a/cmd/ucm/summary_test.go
+++ b/cmd/ucm/summary_test.go
@@ -1,55 +1,179 @@
 package ucm
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/libs/logdiag"
+	ucmpkg "github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/phases"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// writeTfstateForTarget seeds .databricks/ucm/<target>/terraform.tfstate
-// under fixtureDir with the resources slice.
-func writeTfstateForTarget(t *testing.T, fixtureDir, target string, resources []map[string]any) {
+// writeUcmYml clones the canonical valid fixture into a temp dir and
+// overwrites ucm.yml with body. Returns the workDir so the caller can chain
+// runVerbInDir or load it into a *Ucm directly.
+func writeUcmYml(t *testing.T, body string) string {
 	t.Helper()
-	dir := filepath.Join(fixtureDir, filepath.FromSlash(deploy.LocalCacheDir), target)
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	blob := map[string]any{
-		"version":   4,
-		"resources": resources,
-	}
-	data, err := json.Marshal(blob)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, deploy.TfStateFileName), data, 0o600))
+	work := cloneFixture(t, validFixtureDir(t))
+	require.NoError(t, os.WriteFile(filepath.Join(work, "ucm.yml"), []byte(body), 0o644))
+	return work
 }
 
-func TestCmd_Summary_NoStatePrintsPlaceholder(t *testing.T) {
+func TestCmd_Summary_HeaderRendersNameAndWorkspace(t *testing.T) {
 	stdout, stderr, err := runVerb(t, validFixtureDir(t), "summary")
 	t.Logf("stdout=%q stderr=%q", stdout, stderr)
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "No deployed resources")
+	assert.Contains(t, stdout, "Name: fixture-valid")
+	assert.Contains(t, stdout, "Target: default")
+	assert.Contains(t, stdout, "Workspace:")
+	assert.Contains(t, stdout, "Host: https://example.cloud.databricks.com")
 }
 
-func TestCmd_Summary_WithStatePrintsCounts(t *testing.T) {
-	work := cloneFixture(t, validFixtureDir(t))
-	// The valid fixture declares no explicit target, so SelectDefaultTarget
-	// chooses the synthesised "default" target. Seed a tfstate there.
-	writeTfstateForTarget(t, work, "default", []map[string]any{
-		{"type": "databricks_catalog"},
-		{"type": "databricks_catalog"},
-		{"type": "databricks_schema"},
-	})
+// TestCmd_Summary_NoResourceGroupsWhenEmpty covers the "no deployed resources"
+// equivalent for the config-driven view: empty groups do not emit a header,
+// and the run still succeeds.
+func TestCmd_Summary_NoResourceGroupsWhenEmpty(t *testing.T) {
+	work := writeUcmYml(t, `ucm:
+  name: empty-deployment
 
-	stdout, stderr, err := runVerbInDir(t, work, "summary")
-	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+workspace:
+  host: https://workspace.cloud.databricks.com
+`)
+
+	stdout, _, err := runVerbInDir(t, work, "summary")
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "databricks_catalog")
-	assert.Contains(t, stdout, "databricks_schema")
-	assert.Contains(t, stdout, "2")
-	assert.Contains(t, stdout, "1")
+	assert.Contains(t, stdout, "Name: empty-deployment")
+	assert.NotContains(t, stdout, "Catalogs:")
+	assert.NotContains(t, stdout, "Schemas:")
+	assert.NotContains(t, stdout, "Storage credentials:")
+}
+
+func TestCmd_Summary_ListsCatalogsAndSchemasWithURLs(t *testing.T) {
+	stdout, _, err := runVerb(t, validFixtureDir(t), "summary")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Catalogs:")
+	assert.Contains(t, stdout, "team_alpha:")
+	assert.Contains(t, stdout, "Name: team_alpha")
+	assert.Contains(t, stdout, "URL:  https://example.cloud.databricks.com/explore/data/team_alpha")
+	assert.Contains(t, stdout, "Schemas:")
+	assert.Contains(t, stdout, "bronze:")
+	assert.Contains(t, stdout, "Name: team_alpha.bronze")
+	assert.Contains(t, stdout, "URL:  https://example.cloud.databricks.com/explore/data/team_alpha/bronze")
+}
+
+func TestCmd_Summary_ListsGrantsWithoutURL(t *testing.T) {
+	stdout, _, err := runVerb(t, validFixtureDir(t), "summary")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Grants:")
+	assert.Contains(t, stdout, "alpha_read:")
+	assert.Contains(t, stdout, "Name: catalog team_alpha -> alpha-readers")
+	// Grants deliberately do not carry a workspace URL.
+	assert.NotContains(t, stdout, "URL:  https://example.cloud.databricks.com/explore/grants")
+}
+
+func TestCmd_Summary_ListsStorageCredentials(t *testing.T) {
+	work := writeUcmYml(t, `ucm:
+  name: creds-only
+
+workspace:
+  host: https://workspace.cloud.databricks.com
+
+resources:
+  storage_credentials:
+    sales_cred:
+      name: sales_cred
+      aws_iam_role:
+        role_arn: arn:aws:iam::123:role/sales
+`)
+
+	stdout, _, err := runVerbInDir(t, work, "summary")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Storage credentials:")
+	assert.Contains(t, stdout, "sales_cred:")
+	assert.Contains(t, stdout, "Name: sales_cred")
+	assert.Contains(t, stdout, "URL:  https://workspace.cloud.databricks.com/explore/storage-credentials/sales_cred")
+}
+
+// TestCmd_Summary_OutputJSONEmitsConfig exercises the JSON branch. Cobra's
+// persistent --output flag only ships when building the root.New() tree, so
+// the test loads the fixture directly and replays the Marshal call the RunE
+// uses.
+func TestCmd_Summary_OutputJSONEmitsConfig(t *testing.T) {
+	work := writeUcmYml(t, `ucm:
+  name: json-deploy
+
+workspace:
+  host: https://workspace.cloud.databricks.com
+
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+`)
+
+	ctx := logdiag.InitContext(context.Background())
+	u, err := ucmpkg.Load(ctx, work)
+	require.NoError(t, err)
+	require.NotNil(t, u)
+
+	phases.LoadDefaultTarget(ctx, u)
+	require.False(t, logdiag.HasError(ctx))
+
+	buf, err := json.MarshalIndent(u.Config, "", "  ")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got))
+
+	ucm, ok := got["ucm"].(map[string]any)
+	require.True(t, ok, "expected ucm block in JSON output")
+	assert.Equal(t, "json-deploy", ucm["name"])
+
+	resources, ok := got["resources"].(map[string]any)
+	require.True(t, ok, "expected resources block in JSON output")
+	catalogs, ok := resources["catalogs"].(map[string]any)
+	require.True(t, ok, "expected catalogs in JSON output")
+	assert.Contains(t, catalogs, "sales")
+}
+
+// TestRenderSummaryText_EmitsOnlyNonEmptyGroups covers the shape contract:
+// groups with no entries do not emit a header.
+func TestRenderSummaryText_EmitsOnlyNonEmptyGroups(t *testing.T) {
+	work := writeUcmYml(t, `ucm:
+  name: demo
+
+workspace:
+  host: https://workspace.cloud.databricks.com
+
+resources:
+  catalogs:
+    sales:
+      name: sales_prod
+`)
+
+	ctx := logdiag.InitContext(context.Background())
+	u, err := ucmpkg.Load(ctx, work)
+	require.NoError(t, err)
+	phases.LoadDefaultTarget(ctx, u)
+	require.False(t, logdiag.HasError(ctx))
+
+	var buf bytes.Buffer
+	renderSummaryText(&buf, &u.Config)
+
+	out := buf.String()
+	assert.Contains(t, out, "Catalogs:")
+	assert.NotContains(t, out, "Schemas:")
+	assert.NotContains(t, out, "Grants:")
+	assert.NotContains(t, out, "Storage credentials:")
 }

--- a/cmd/ucm/ucm.go
+++ b/cmd/ucm/ucm.go
@@ -7,6 +7,7 @@
 package ucm
 
 import (
+	"github.com/databricks/cli/libs/flags"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +37,13 @@ Online documentation: https://docs.databricks.com/en/dev-tools/ucm/index.html`,
 	}
 
 	cmd.PersistentFlags().StringP("target", "t", "", "ucm target to use (if applicable)")
+	// Register a local --output fallback so that `cmdUcm.New()` works in
+	// standalone unit tests. Under `databricks ucm ...` the root-level
+	// persistent flag takes precedence (cobra walks up the parent chain).
+	if cmd.Flag("output") == nil {
+		out := flags.OutputText
+		cmd.PersistentFlags().VarP(&out, "output", "o", "output type: text or json")
+	}
 
 	cmd.AddCommand(newValidateCommand())
 	cmd.AddCommand(newSchemaCommand())

--- a/cmd/ucm/validate.go
+++ b/cmd/ucm/validate.go
@@ -1,11 +1,17 @@
 package ucm
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
 	"github.com/spf13/cobra"
 )
 
@@ -21,16 +27,37 @@ selected target. Useful as a CI gate before ` + "`ucm deploy`" + `.
 Common invocations:
   databricks ucm validate                  # Validate default target
   databricks ucm validate --target prod    # Validate a specific target
-  databricks ucm validate --strict         # Fail on warnings too`,
+  databricks ucm validate --strict         # Fail on warnings too
+  databricks ucm validate -o json          # Emit the full config as JSON`,
 		Args: root.NoArgs,
+		// Diagnostics are already surfaced; don't spam usage on validation fail.
+		SilenceUsage: true,
 	}
 
 	var strict bool
+	var includeLocations bool
 	cmd.Flags().BoolVar(&strict, "strict", false, "Treat warnings as errors")
+	// include-locations is accepted for DAB parity; wiring the locations
+	// mutator into the JSON output is tracked as a follow-up.
+	cmd.Flags().BoolVar(&includeLocations, "include-locations", false, "Include location information in the output")
+	_ = cmd.Flags().MarkHidden("include-locations")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		utils.ProcessUcm(cmd, utils.ProcessOptions{Validate: true})
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{Validate: true})
 		ctx := cmd.Context()
+
+		out := cmd.OutOrStdout()
+		output := validateOutputType(cmd)
+
+		// Emit output before returning on error so users see the summary or
+		// the (partial) config tree regardless.
+		if output == flags.OutputJSON {
+			if err := renderValidateJSON(out, u); err != nil {
+				return err
+			}
+		} else {
+			writeValidateTrailer(ctx, out)
+		}
 
 		if logdiag.HasError(ctx) {
 			return root.ErrAlreadyPrinted
@@ -45,9 +72,66 @@ Common invocations:
 			return fmt.Errorf("%d %s found. Warnings are not allowed in strict mode", numWarnings, noun)
 		}
 
-		fmt.Fprintln(cmd.OutOrStdout(), "Validation OK!")
 		return nil
 	}
 
 	return cmd
+}
+
+// validateOutputType returns the configured -o value, defaulting to OutputText
+// when the flag is not wired (e.g. in standalone unit tests that don't go
+// through root.New). root.OutputType would panic in that case.
+func validateOutputType(cmd *cobra.Command) flags.Output {
+	if cmd.Flag("output") == nil {
+		return flags.OutputText
+	}
+	return root.OutputType(cmd)
+}
+
+// renderValidateJSON emits the loaded ucm config tree as indented JSON.
+func renderValidateJSON(out io.Writer, u *ucm.Ucm) error {
+	if u == nil {
+		return nil
+	}
+	buf, err := json.MarshalIndent(u.Config.Value().AsAny(), "", "  ")
+	if err != nil {
+		return err
+	}
+	_, _ = out.Write(buf)
+	_, _ = out.Write([]byte{'\n'})
+	return nil
+}
+
+// writeValidateTrailer prints the DAB-style "Found X errors / Y warnings"
+// summary, or "Validation OK!" when no diagnostics were recorded.
+func writeValidateTrailer(ctx context.Context, out io.Writer) {
+	info := logdiag.Copy(ctx)
+	var parts []string
+	if info.Errors > 0 {
+		parts = append(parts, pluralize(info.Errors, "error", "errors"))
+	}
+	if info.Warnings > 0 {
+		parts = append(parts, pluralize(info.Warnings, "warning", "warnings"))
+	}
+	if info.Recommendations > 0 {
+		parts = append(parts, pluralize(info.Recommendations, "recommendation", "recommendations"))
+	}
+	switch len(parts) {
+	case 0:
+		fmt.Fprintln(out, "Validation OK!")
+	case 1:
+		fmt.Fprintf(out, "Found %s\n", parts[0])
+	case 2:
+		fmt.Fprintf(out, "Found %s and %s\n", parts[0], parts[1])
+	default:
+		first := strings.Join(parts[:len(parts)-1], ", ")
+		fmt.Fprintf(out, "Found %s, and %s\n", first, parts[len(parts)-1])
+	}
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
 }

--- a/cmd/ucm/validate_test.go
+++ b/cmd/ucm/validate_test.go
@@ -19,7 +19,7 @@ import (
 // runValidate invokes the cobra ucm-subtree in a temp cwd set to fixtureDir
 // and returns stdout, diag-stream output (cmdio stderr), and whatever the
 // Execute call returned.
-func runValidate(t *testing.T, fixtureDir string) (string, string, error) {
+func runValidate(t *testing.T, fixtureDir string, extraArgs ...string) (string, string, error) {
 	t.Helper()
 
 	prev, err := os.Getwd()
@@ -31,7 +31,7 @@ func runValidate(t *testing.T, fixtureDir string) (string, string, error) {
 	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
-	cmd.SetArgs([]string{"validate"})
+	cmd.SetArgs(append([]string{"validate"}, extraArgs...))
 
 	ctx, diagOut := cmdio.NewTestContextWithStderr(context.Background())
 	ctx = logdiag.InitContext(ctx)
@@ -51,8 +51,31 @@ func TestCmd_Validate_ValidFixturePasses(t *testing.T) {
 }
 
 func TestCmd_Validate_MissingTagFixtureFails(t *testing.T) {
-	_, _, err := runValidate(t, filepath.Join("testdata", "missing_tag"))
+	stdout, stderr, err := runValidate(t, filepath.Join("testdata", "missing_tag"))
 	require.Error(t, err)
+	// Trailer summarises the count; per-diagnostic lines are streamed to stderr.
+	assert.Contains(t, stdout, "Found ")
+	assert.Contains(t, stdout, "error")
+	assert.Contains(t, stderr, "requires tag")
+}
+
+func TestCmd_Validate_JSONModeProducesValidJSON(t *testing.T) {
+	stdout, _, err := runValidate(t, filepath.Join("testdata", "valid"), "--output", "json")
+	require.NoError(t, err)
+
+	var tree map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &tree))
+	_, ok := tree["resources"]
+	assert.True(t, ok, "JSON output should contain resources subtree")
+	assert.NotContains(t, stdout, "Validation OK!")
+}
+
+func TestCmd_Validate_JSONModeOnErrorFixture(t *testing.T) {
+	stdout, _, err := runValidate(t, filepath.Join("testdata", "missing_tag"), "--output", "json")
+	require.Error(t, err)
+	// Cobra may append nothing else with SilenceUsage, so stdout is pure JSON.
+	assert.Contains(t, stdout, `"resources"`)
+	assert.Contains(t, stdout, `"catalogs"`)
 }
 
 func TestCmd_Validate_NestedFixturePasses(t *testing.T) {

--- a/ucm/deploy/state.go
+++ b/ucm/deploy/state.go
@@ -101,6 +101,11 @@ type Backend struct {
 	// User is embedded into the lock record so contending clients can see
 	// who currently holds the lock. Empty strings are allowed for tests.
 	User string
+
+	// ForceLock tells Pull/Push to override an existing deploy lock instead
+	// of failing with ErrLockHeld. Set by the --force-lock flag on
+	// plan/deploy/destroy; mirrors bundle.Deployment.Lock.Force.
+	ForceLock bool
 }
 
 // loadState reads a State from r.

--- a/ucm/deploy/state_pull.go
+++ b/ucm/deploy/state_pull.go
@@ -41,7 +41,7 @@ func Pull(ctx context.Context, u *ucm.Ucm, b Backend) error {
 	}
 
 	l := newLocker(b, ".")
-	if err := l.Acquire(ctx, false); err != nil {
+	if err := l.Acquire(ctx, b.ForceLock); err != nil {
 		return fmt.Errorf("ucm state: acquire lock: %w", err)
 	}
 	defer releaseBestEffort(ctx, l, lock.GoalDeploy)

--- a/ucm/deploy/state_push.go
+++ b/ucm/deploy/state_push.go
@@ -34,7 +34,7 @@ func Push(ctx context.Context, u *ucm.Ucm, b Backend) error {
 	}
 
 	l := newLocker(b, ".")
-	if err := l.Acquire(ctx, false); err != nil {
+	if err := l.Acquire(ctx, b.ForceLock); err != nil {
 		return fmt.Errorf("ucm state: acquire lock: %w", err)
 	}
 	defer releaseBestEffort(ctx, l, lock.GoalDeploy)

--- a/ucm/deploy/terraform/apply.go
+++ b/ucm/deploy/terraform/apply.go
@@ -19,7 +19,7 @@ import (
 // whether Apply succeeded. Contention on the lock surfaces as a
 // *lock.ErrLockHeld so callers can errors.As on it and present a helpful
 // "--force-lock to override" message to the user.
-func (t *Terraform) Apply(ctx context.Context, u *ucm.Ucm) error {
+func (t *Terraform) Apply(ctx context.Context, u *ucm.Ucm, forceLock bool) error {
 	if t == nil {
 		return fmt.Errorf("terraform: nil wrapper")
 	}
@@ -36,7 +36,7 @@ func (t *Terraform) Apply(ctx context.Context, u *ucm.Ucm) error {
 	if err != nil {
 		return fmt.Errorf("create deployment locker: %w", err)
 	}
-	if err := locker.Acquire(ctx, false); err != nil {
+	if err := locker.Acquire(ctx, forceLock); err != nil {
 		return err
 	}
 	defer func() {

--- a/ucm/deploy/terraform/apply_test.go
+++ b/ucm/deploy/terraform/apply_test.go
@@ -50,10 +50,10 @@ func TestApplyRunsUnderLock(t *testing.T) {
 	factory, _ := sharedLockerFactory(t, "alice")
 	tf := newApplyTerraform(t, u, runner, factory, "alice")
 
-	require.NoError(t, tf.Apply(t.Context(), u))
+	require.NoError(t, tf.Apply(t.Context(), u, false))
 	assert.Equal(t, 1, runner.ApplyCalls)
 	// Lock is released on defer — next Apply should succeed too.
-	require.NoError(t, tf.Apply(t.Context(), u))
+	require.NoError(t, tf.Apply(t.Context(), u, false))
 	assert.Equal(t, 2, runner.ApplyCalls)
 }
 
@@ -75,7 +75,7 @@ func TestApplyLockContentionReturnsErrLockHeld(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- firstTf.Apply(t.Context(), u)
+		errCh <- firstTf.Apply(t.Context(), u, false)
 	}()
 
 	// Wait until the first Apply is holding the lock.
@@ -84,7 +84,7 @@ func TestApplyLockContentionReturnsErrLockHeld(t *testing.T) {
 	secondRunner := &fakeRunner{}
 	secondTf := newApplyTerraform(t, u, secondRunner, factory, "bob")
 
-	err := secondTf.Apply(t.Context(), u)
+	err := secondTf.Apply(t.Context(), u, false)
 	require.Error(t, err)
 	var held *lock.ErrLockHeld
 	require.True(t, errors.As(err, &held), "expected ErrLockHeld, got %T: %v", err, err)
@@ -107,7 +107,7 @@ func TestApplyUsesPlanPathWhenAvailable(t *testing.T) {
 	require.NotNil(t, planResult)
 	assert.True(t, planResult.HasChanges)
 
-	require.NoError(t, tf.Apply(t.Context(), u))
+	require.NoError(t, tf.Apply(t.Context(), u, false))
 	require.Len(t, runner.LastApplyOpts, 1, "Apply should have received the plan-path option")
 
 	// The plan path should be the one returned by Plan.

--- a/ucm/deploy/terraform/destroy.go
+++ b/ucm/deploy/terraform/destroy.go
@@ -17,7 +17,7 @@ import (
 // The lock is released on defer with GoalDestroy, which tolerates a
 // missing lock file (destroy may have wiped the state dir before Release
 // runs — see ucm/deploy/lock.Release).
-func (t *Terraform) Destroy(ctx context.Context, u *ucm.Ucm) error {
+func (t *Terraform) Destroy(ctx context.Context, u *ucm.Ucm, forceLock bool) error {
 	if t == nil {
 		return fmt.Errorf("terraform: nil wrapper")
 	}
@@ -34,7 +34,7 @@ func (t *Terraform) Destroy(ctx context.Context, u *ucm.Ucm) error {
 	if err != nil {
 		return fmt.Errorf("create deployment locker: %w", err)
 	}
-	if err := locker.Acquire(ctx, false); err != nil {
+	if err := locker.Acquire(ctx, forceLock); err != nil {
 		return err
 	}
 	defer func() {

--- a/ucm/deploy/terraform/destroy_test.go
+++ b/ucm/deploy/terraform/destroy_test.go
@@ -13,11 +13,11 @@ func TestDestroyRunsUnderLock(t *testing.T) {
 	factory, _ := sharedLockerFactory(t, "alice")
 	tf := newApplyTerraform(t, u, runner, factory, "alice")
 
-	require.NoError(t, tf.Destroy(t.Context(), u))
+	require.NoError(t, tf.Destroy(t.Context(), u, false))
 	assert.Equal(t, 1, runner.DestroyCalls)
 
 	// Lock released on defer: a second Destroy should succeed and re-run.
-	require.NoError(t, tf.Destroy(t.Context(), u))
+	require.NoError(t, tf.Destroy(t.Context(), u, false))
 	assert.Equal(t, 2, runner.DestroyCalls)
 }
 
@@ -27,7 +27,7 @@ func TestDestroyPropagatesRunnerError(t *testing.T) {
 	factory, _ := sharedLockerFactory(t, "alice")
 	tf := newApplyTerraform(t, u, runner, factory, "alice")
 
-	err := tf.Destroy(t.Context(), u)
+	err := tf.Destroy(t.Context(), u, false)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, assert.AnError)
 }

--- a/ucm/phases/deploy.go
+++ b/ucm/phases/deploy.go
@@ -54,12 +54,14 @@ func deployTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
 		return
 	}
 
-	if err := tf.Apply(ctx, u); err != nil {
+	if err := tf.Apply(ctx, u, opts.ForceLock); err != nil {
 		logdiag.LogError(ctx, fmt.Errorf("terraform apply: %w", err))
 		return
 	}
 
-	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
+	pushBackend := opts.Backend
+	pushBackend.ForceLock = opts.ForceLock
+	if err := deploy.Push(ctx, u, pushBackend); err != nil {
 		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
 		return
 	}

--- a/ucm/phases/destroy.go
+++ b/ucm/phases/destroy.go
@@ -54,12 +54,14 @@ func destroyTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
 		return
 	}
 
-	if err := tf.Destroy(ctx, u); err != nil {
+	if err := tf.Destroy(ctx, u, opts.ForceLock); err != nil {
 		logdiag.LogError(ctx, fmt.Errorf("terraform destroy: %w", err))
 		return
 	}
 
-	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
+	pushBackend := opts.Backend
+	pushBackend.ForceLock = opts.ForceLock
+	if err := deploy.Push(ctx, u, pushBackend); err != nil {
 		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
 		return
 	}

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -61,14 +61,14 @@ func (f *fakeTf) Plan(_ context.Context, _ *ucm.Ucm) (*terraform.PlanResult, err
 	return f.PlanResult, f.PlanErr
 }
 
-func (f *fakeTf) Apply(_ context.Context, _ *ucm.Ucm) error {
+func (f *fakeTf) Apply(_ context.Context, _ *ucm.Ucm, _ bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.ApplyCalls++
 	return f.ApplyErr
 }
 
-func (f *fakeTf) Destroy(_ context.Context, _ *ucm.Ucm) error {
+func (f *fakeTf) Destroy(_ context.Context, _ *ucm.Ucm, _ bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.DestroyCalls++

--- a/ucm/phases/initialize.go
+++ b/ucm/phases/initialize.go
@@ -82,7 +82,9 @@ func Initialize(ctx context.Context, u *ucm.Ucm, opts Options) engine.EngineSett
 		return setting
 	}
 
-	if err := deploy.Pull(ctx, u, opts.Backend); err != nil {
+	pullBackend := opts.Backend
+	pullBackend.ForceLock = opts.ForceLock
+	if err := deploy.Pull(ctx, u, pullBackend); err != nil {
 		logdiag.LogError(ctx, fmt.Errorf("pull remote state: %w", err))
 		return setting
 	}

--- a/ucm/phases/options.go
+++ b/ucm/phases/options.go
@@ -17,8 +17,8 @@ type TerraformWrapper interface {
 	Render(ctx context.Context, u *ucm.Ucm) error
 	Init(ctx context.Context, u *ucm.Ucm) error
 	Plan(ctx context.Context, u *ucm.Ucm) (*terraform.PlanResult, error)
-	Apply(ctx context.Context, u *ucm.Ucm) error
-	Destroy(ctx context.Context, u *ucm.Ucm) error
+	Apply(ctx context.Context, u *ucm.Ucm, forceLock bool) error
+	Destroy(ctx context.Context, u *ucm.Ucm, forceLock bool) error
 }
 
 // TerraformFactory constructs a terraform-engine wrapper scoped to u.
@@ -75,6 +75,11 @@ type Options struct {
 	// DirectClientFactory produces the direct-engine SDK client bound to u.
 	// When nil, phases fall back to DefaultDirectClientFactory.
 	DirectClientFactory DirectClientFactory
+
+	// ForceLock mirrors the --force-lock flag: when true, Pull/Push and
+	// terraform Apply/Destroy override an existing deploy lock instead of
+	// failing with ErrLockHeld.
+	ForceLock bool
 }
 
 // terraformFactoryOrDefault returns o.TerraformFactory or the production


### PR DESCRIPTION
Closes #64
Parity audit: \`docs/superpowers/parity-audit-2026-04-22.md\`

## Commits (4)

1. **schema cosmetic** (178b54b93) — drop trailing newline so \`ucm schema\` and \`bundle schema\` byte-match.
2. **summary reshape** (7861d36fb) — DAB-style output shape: header (Name/Target/Workspace) + per-resource-group sections with workspace URLs for catalogs, schemas, volumes, external_locations, storage_credentials, connections. Grants render without URL. Config-driven view (drops the tfstate-reading path). Adds \`--force-pull\` and \`--include-locations\` flags (currently no-ops, wired for parity). JSON output via \`--output json\`.
3. **validate --output json** (ba7d3cd20) — adds \`--output\` flag. Text mode keeps the "Validation OK!" / "Found N errors" summary. JSON mode emits the full ucm config as indented JSON. Also adds hidden \`--include-locations\` (no-op with TODO).
4. **--force-lock on plan/deploy/destroy** (6d5fb004d) — threads a forceLock bool through phases.Options → deploy.Backend → lock.Acquire on Pull/Push and through terraform.Apply/Destroy. Mirrors bundle's \`Deployment.Lock.Force\`; surfaces the help text suggested by \`lock.ErrLockHeld\`.

## What's NOT in this PR (deliberate drops + follow-ups)

**Dropped — no UC semantic parallel:**

- \`--fail-on-active-runs\` (deploy) — UC has no jobs/pipelines concept.
- \`--cluster-id\` / \`--compute-id\` (deploy, plan) — UC resources don't bind to compute.
- \`--verbose\` (deploy) — DAB uses it for file-sync verbosity; ucm has no file sync.
- \`--force\` (deploy, plan) — DAB uses it to override Git-branch validation; ucm has none.

**Deferred to follow-up:**

- \`--plan <path>\` on deploy — substantial new infra (plan-file format, deserializer, plan-skip path). Will track separately.
- Summary's \`User\` header row — \`config.Workspace\` has no current-user field; would require SDK call. Header currently omits. Easy to add if you want.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./cmd/ucm/... ./ucm/...\` clean
- [x] \`go test ./cmd/ucm/... ./ucm/...\` green
- [x] New tests: 6 summary-rendering, 2 validate-JSON, one validate-text-error-trailer.
- [ ] Manual smoke: re-run the reporter's fixture, verify \`ucm summary\` now shows the DAB-shaped output with workspace URLs.

## Follow-on

- \`--plan <path>\` on deploy (confirmed wanted; its own PR).
- Populate \`config.Workspace.CurrentUser\` so \`ucm summary\` can show the \`User\` row.