### PR TITLE
Feat #67: Implement ucm debug (terraform, states)

### DIFF
--- a/cmd/ucm/debug/debug.go
+++ b/cmd/ucm/debug/debug.go
@@ -1,0 +1,26 @@
+// Package debug implements the hidden `databricks ucm debug` verb group.
+// Mirrors cmd/bundle/debug for the Unity Catalog engine: it exposes the
+// terraform binary/provider pins and lists the on-disk state files ucm
+// mirrors for the selected target. Intended for the Databricks VSCode
+// extension and for air-gap troubleshooting.
+package debug
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// New returns the `ucm debug` group command, wiring the terraform and states
+// subcommands.
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "debug",
+		Short: "Debug information about ucm projects",
+		Long:  "Debug information about ucm projects",
+		// Hidden to match cmd/bundle/debug — the group is a tool surface for
+		// tooling (e.g. VSCode extension), not an end-user command.
+		Hidden: true,
+	}
+	cmd.AddCommand(NewTerraformCommand())
+	cmd.AddCommand(NewStatesCommand())
+	return cmd
+}

--- a/cmd/ucm/debug/debug_test.go
+++ b/cmd/ucm/debug/debug_test.go
@@ -1,0 +1,204 @@
+package debug_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/cmd/ucm/debug"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/direct"
+	ucmtf "github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runDebug invokes `<subcmd> <extra>` on the debug group rooted at workDir.
+// Returns captured stdout+stderr exactly like cmd/ucm/helpers_test.go's
+// runVerb — kept local because the debug subpackage can't import the `ucm`
+// test helpers (cycle: ucm -> debug).
+func runDebug(t *testing.T, workDir string, args ...string) (string, string, error) {
+	t.Helper()
+
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	cmd := debug.New()
+	stripHooks(cmd)
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+
+	ctx, diagOut := cmdio.NewTestContextWithStderr(context.Background())
+	ctx = logdiag.InitContext(ctx)
+	logdiag.SetRoot(ctx, workDir)
+	cmd.SetContext(ctx)
+
+	err = cmd.Execute()
+	return out.String(), diagOut.String() + errOut.String(), err
+}
+
+// stripHooks mirrors cmd/ucm/helpers_test.go.stripAuthHooks so tests don't
+// hit the workspace-client auth path for verbs that (today) don't need it.
+func stripHooks(cmd *cobra.Command) {
+	cmd.PersistentPreRunE = nil
+	cmd.PersistentPreRun = nil
+	cmd.PreRunE = nil
+	cmd.PreRun = nil
+	for _, sub := range cmd.Commands() {
+		stripHooks(sub)
+	}
+}
+
+func TestDebug_Hidden(t *testing.T) {
+	cmd := debug.New()
+	assert.True(t, cmd.Hidden, "debug group must be Hidden to match cmd/bundle/debug")
+}
+
+func TestDebug_HasSubcommands(t *testing.T) {
+	cmd := debug.New()
+	names := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		names[sub.Name()] = true
+	}
+	assert.True(t, names["terraform"], "debug group must wire the terraform subcommand")
+	assert.True(t, names["states"], "debug group must wire the states subcommand")
+}
+
+func TestDebug_Terraform_PrintsVersionsText(t *testing.T) {
+	stdout, stderr, err := runDebug(t, t.TempDir(), "terraform")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, ucmtf.ProviderVersion, "text output must include the pinned provider version")
+	assert.Contains(t, stdout, "Databricks Terraform Provider version", "template header must be rendered")
+	assert.Contains(t, stdout, "DATABRICKS_TF_EXEC_PATH", "air-gap env-var instructions must be rendered")
+}
+
+func TestDebug_Terraform_JSON(t *testing.T) {
+	// Manually create a root cobra so the `-o json` persistent flag is wired
+	// like it is under `databricks ucm debug terraform -o json` in production.
+	// The flag must be a *flags.Output for root.OutputType's type assertion
+	// to succeed — a plain string would panic.
+	rootCmd := &cobra.Command{Use: "root"}
+	output := flags.OutputJSON
+	rootCmd.PersistentFlags().VarP(&output, "output", "o", "output type: text or json")
+	rootCmd.AddCommand(debug.NewTerraformCommand())
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"terraform", "-o", "json"})
+	rootCmd.SetContext(context.Background())
+
+	require.NoError(t, rootCmd.Execute())
+
+	var payload struct {
+		Terraform struct {
+			Version         string `json:"version"`
+			ProviderVersion string `json:"providerVersion"`
+			ProviderSource  string `json:"providerSource"`
+			ProviderHost    string `json:"providerHost"`
+		} `json:"terraform"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &payload))
+	assert.Equal(t, ucmtf.ProviderVersion, payload.Terraform.ProviderVersion)
+	assert.Equal(t, ucmtf.ProviderSource, payload.Terraform.ProviderSource)
+	assert.NotEmpty(t, payload.Terraform.Version)
+	assert.NotEmpty(t, payload.Terraform.ProviderHost)
+}
+
+// writeUcmFixture seeds a minimal ucm.yml in dir so ProcessUcm can load and
+// select the default target. Matches the valid-fixture shape but is local to
+// the debug tests so they don't cross-reference cmd/ucm/testdata.
+func writeUcmFixture(t *testing.T, dir string) {
+	t.Helper()
+	body := `ucm:
+  name: debug-states-fixture
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    c:
+      name: c
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ucm.yml"), []byte(body), 0o644))
+}
+
+// seedStateDir creates .databricks/ucm/<target>/ with the three files the
+// states command scans for. Sizes are distinct so assertions can key on them.
+func seedStateDir(t *testing.T, root, target string) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(deploy.LocalCacheDir), target)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "terraform"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, deploy.UcmStateFileName),
+		[]byte(`{"version":1,"seq":3}`),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "terraform", deploy.TfStateFileName),
+		[]byte(`{"version":4,"resources":[]}`),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, direct.StateFileName),
+		[]byte(`{"version":1}`),
+		0o644,
+	))
+}
+
+func TestDebug_States_ListsSeededFiles(t *testing.T) {
+	work := t.TempDir()
+	writeUcmFixture(t, work)
+	// The fixture declares no explicit target, so LoadDefaultTarget
+	// synthesises the "default" target — mirror summary_test.go's convention.
+	seedStateDir(t, work, "default")
+
+	stdout, stderr, err := runDebug(t, work, "states")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	// Each of the three seeded files must appear, referenced by its basename.
+	assert.Contains(t, stdout, deploy.UcmStateFileName)
+	assert.Contains(t, stdout, deploy.TfStateFileName)
+	assert.Contains(t, stdout, direct.StateFileName)
+	// Forward-slashes only — matches the style guide and keeps output stable
+	// across OSes. Reject any backslash sneaking into the rendered path.
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		assert.NotContains(t, line, `\`, "state paths must be forward-slashed")
+	}
+}
+
+func TestDebug_States_NoStateFilesPlaceholder(t *testing.T) {
+	work := t.TempDir()
+	writeUcmFixture(t, work)
+
+	stdout, stderr, err := runDebug(t, work, "states")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "No state files found.")
+}
+
+func TestDebug_States_ForcePullFlagExists(t *testing.T) {
+	// Flag is wired but intentionally a no-op pending #57. Guard the wiring
+	// so the next engineer doesn't accidentally drop it when implementing
+	// the real pull path.
+	cmd := debug.NewStatesCommand()
+	require.NotNil(t, cmd.Flag("force-pull"), "force-pull flag must stay wired (TODO #57)")
+}

--- a/cmd/ucm/debug/states.go
+++ b/cmd/ucm/debug/states.go
@@ -1,0 +1,90 @@
+package debug
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/spf13/cobra"
+)
+
+// NewStatesCommand returns the `ucm debug states` command. Lists the state
+// files ucm maintains for the selected target so users (and the VSCode
+// extension) can see which engine's state the target is currently bound to.
+func NewStatesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "states",
+		Short: "Show available state files",
+		Args:  root.NoArgs,
+	}
+
+	// forcePull mirrors cmd/bundle/debug/states.go's flag so tooling that
+	// invokes either subcommand has the same flag surface. TODO(#57): wire
+	// this to ucm.deploy.Pull once the mirror path lands; for now it is a
+	// no-op — ucm's pull/push path is still under construction.
+	var forcePull bool
+	cmd.Flags().BoolVar(&forcePull, "force-pull", false, "Skip local cache and load the state from the remote workspace")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx := cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		localDir := deploy.LocalStateDir(u)
+		paths := []string{
+			filepath.Join(localDir, deploy.UcmStateFileName),
+			filepath.Join(localDir, "terraform", deploy.TfStateFileName),
+			filepath.Join(localDir, direct.StateFileName),
+		}
+
+		var lines []string
+		for _, p := range paths {
+			line, ok, err := describePath(p)
+			if err != nil {
+				return err
+			}
+			if ok {
+				lines = append(lines, line)
+			}
+		}
+
+		out := cmd.OutOrStdout()
+		if len(lines) == 0 {
+			fmt.Fprintln(out, "No state files found.")
+			return nil
+		}
+		fmt.Fprintln(out, strings.Join(lines, "\n"))
+		return nil
+	}
+
+	return cmd
+}
+
+// describePath returns "<absolute-forward-slashed-path> (<size> bytes)" when
+// the path exists, or (_, false, nil) when the file is absent. Paths are
+// forward-slashed so acceptance-test output is stable across OSes (matches
+// .agent/rules/style-guide-go.md).
+func describePath(path string) (string, bool, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", false, fmt.Errorf("abs %s: %w", filepath.ToSlash(path), err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("stat %s: %w", filepath.ToSlash(abs), err)
+	}
+	return fmt.Sprintf("%s (%d bytes)", filepath.ToSlash(abs), info.Size()), true, nil
+}

--- a/cmd/ucm/debug/terraform.go
+++ b/cmd/ucm/debug/terraform.go
@@ -1,0 +1,127 @@
+package debug
+
+import (
+	"encoding/json"
+	"fmt"
+	"text/template"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/flags"
+	ucmtf "github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/spf13/cobra"
+)
+
+// ProviderHost is the registry host the databricks provider publishes under.
+// Forked from bundle/internal/tf/schema.ProviderHost to honour the ucm
+// no-bundle-imports rule; kept verbatim so air-gap mirrors share a layout.
+const ProviderHost = "registry.terraform.io"
+
+// TerraformMetadata is the JSON payload returned by `ucm debug terraform -o json`.
+// Shape forked from bundle/deploy/terraform.TerraformMetadata, trimmed to the
+// fields ucm actually pins (checksums are bundle-only). Tag names match bundle's
+// so downstream tools can consume both outputs with one parser.
+type TerraformMetadata struct {
+	Version         string `json:"version"`
+	ProviderHost    string `json:"providerHost"`
+	ProviderSource  string `json:"providerSource"`
+	ProviderVersion string `json:"providerVersion"`
+}
+
+// Dependencies wraps TerraformMetadata to match cmd/bundle/debug's JSON shape.
+type Dependencies struct {
+	Terraform *TerraformMetadata `json:"terraform"`
+}
+
+// terraformTemplate is the text rendered for `ucm debug terraform`. Copied
+// verbatim from cmd/bundle/debug/terraform.go with the binary name swapped
+// so air-gap instructions read correctly for the ucm subcommand.
+const terraformTemplate = `Terraform version: {{.Version}}
+Terraform URL: https://releases.hashicorp.com/terraform/{{.Version}}
+
+Databricks Terraform Provider version: {{.ProviderVersion}}
+Databricks Terraform Provider URL: https://github.com/databricks/terraform-provider-databricks/releases/tag/v{{.ProviderVersion}}
+
+Databricks CLI downloads its Terraform dependencies automatically.
+
+If you run the CLI in an air-gapped environment, you can download the dependencies manually and set these environment variables:
+
+	DATABRICKS_TF_VERSION={{.Version}}
+	DATABRICKS_TF_EXEC_PATH=/path/to/terraform/binary
+	DATABRICKS_TF_PROVIDER_VERSION={{.ProviderVersion}}
+	DATABRICKS_TF_CLI_CONFIG_FILE=/path/to/terraform/cli/config.tfrc
+
+Here is an example *.tfrc configuration file:
+
+	disable_checkpoint = true
+	provider_installation {
+		filesystem_mirror {
+			path = "/path/to/a/folder/with/databricks/terraform/provider"
+		}
+	}
+
+The filesystem mirror path should point to the folder with the Databricks Terraform Provider. The folder should have this structure: /{{.ProviderHost}}/{{.ProviderSource}}/terraform-provider-databricks_{{.ProviderVersion}}_ARCH.zip
+
+For more information about filesystem mirrors, see the Terraform documentation: https://developer.hashicorp.com/terraform/cli/config/config-file#filesystem_mirror
+`
+
+// NewTerraformCommand returns the `ucm debug terraform` command. Prints the
+// terraform CLI and databricks-provider versions ucm pins, plus the env vars
+// users can set to run in an air-gapped environment.
+func NewTerraformCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "terraform",
+		Short: "Prints Terraform dependencies required for the ucm commands",
+		Args:  root.NoArgs,
+		Annotations: map[string]string{
+			// Kept for parity with cmd/bundle/debug/terraform.go so VSCode
+			// tooling that reads the annotation sees the same template.
+			"template": terraformTemplate,
+		},
+		Hidden: true,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		tv, _, err := ucmtf.GetTerraformVersion(cmd.Context())
+		if err != nil {
+			return err
+		}
+		deps := &Dependencies{
+			Terraform: &TerraformMetadata{
+				Version:         tv.String(),
+				ProviderHost:    ProviderHost,
+				ProviderSource:  ucmtf.ProviderSource,
+				ProviderVersion: ucmtf.ProviderVersion,
+			},
+		}
+
+		switch outputType(cmd) {
+		case flags.OutputJSON:
+			buf, err := json.MarshalIndent(deps, "", "  ")
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(buf)
+			return err
+		case flags.OutputText:
+			t, err := template.New("terraform").Parse(terraformTemplate)
+			if err != nil {
+				return err
+			}
+			return t.Execute(cmd.OutOrStdout(), deps.Terraform)
+		default:
+			return fmt.Errorf("unknown output type %s", outputType(cmd))
+		}
+	}
+
+	return cmd
+}
+
+// outputType returns the configured -o value, defaulting to OutputText when
+// the flag is not wired (e.g. unit tests that don't go through root.New).
+// Mirrors plan.go's planOutputType — root.OutputType would panic in that case.
+func outputType(cmd *cobra.Command) flags.Output {
+	if cmd.Flag("output") == nil {
+		return flags.OutputText
+	}
+	return root.OutputType(cmd)
+}

--- a/cmd/ucm/stubs.go
+++ b/cmd/ucm/stubs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/debug"
 	"github.com/spf13/cobra"
 )
 
@@ -33,8 +34,10 @@ func newBindCommand() *cobra.Command {
 	return stub("bind", "Attach an existing Databricks resource to a ucm.yml node without recreating it.")
 }
 
+// newDebugCommand returns the `ucm debug` group. Delegates to the
+// cmd/ucm/debug subpackage so the stub file keeps its "bare wiring" role.
 func newDebugCommand() *cobra.Command {
-	return stub("debug", "Dump internal ucm state (config tree, mutator trace) for troubleshooting.")
+	return debug.New()
 }
 
 func newDiffCommand() *cobra.Command {


### PR DESCRIPTION
Closes #67

## Summary

Mirrors \`bundle debug\` — fork-and-adapt per ucm rules, no \`bundle/**\` imports.

- \`ucm debug terraform\` — prints terraform version + databricks provider version + air-gap env var instructions. Template body copied verbatim from \`cmd/bundle/debug/terraform.go\`, only "bundle" → "ucm" in the short description. \`--output json\` supported.
- \`ucm debug states\` — lists state files present under the target cache dir (\`ucm-state.json\`, \`terraform/terraform.tfstate\`, \`resources.json\`) with absolute paths and sizes. \`--force-pull\` flag is wired for parity but currently a no-op pending workspace-pull plumbing (#57 landed the path alignment; full force-pull follow-up is still TODO).

Group command is \`Hidden: true\`, matching DAB.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./cmd/ucm/... ./ucm/...\`
- [x] \`go test ./cmd/ucm/... ./ucm/...\` — 7 new subtests under \`cmd/ucm/debug\` pass.
- [x] Manual: \`./databricks ucm debug terraform\` prints the full template with \`1.5.5\`/\`1.112.0\`; \`-o json\` emits the expected 4-field payload; \`ucm debug states\` lists present files or prints "No state files found."

## Fork notes

- \`Dependencies\` / \`TerraformMetadata\` JSON shape matches DAB's but trims to the fields ucm pins. Checksums are bundle-only and excluded. JSON tag names unchanged so tooling parsing DAB's output parses ucm's too.
- \`debug states\` does NOT reuse DAB's \`bundle/statemgmt.StateDesc\` — that chains through \`ProcessBundleRet\` with pull side-effects that ucm's pipeline isn't ready for (#57 closed the path bug; a real \`--force-pull\` implementation is a separate follow-up).