### PR TITLE
Feat #68: Implement ucm deployment bind/unbind

### DIFF
--- a/cmd/ucm/deployment/bind.go
+++ b/cmd/ucm/deployment/bind.go
@@ -1,0 +1,109 @@
+package deployment
+
+import (
+	"errors"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/spf13/cobra"
+)
+
+// errBindAborted is the sentinel returned when the user answers "no" to the
+// bind confirmation prompt.
+var errBindAborted = errors.New("bind aborted")
+
+// errNeedsAutoApprove is returned when the terminal cannot prompt and
+// --auto-approve was not supplied.
+var errNeedsAutoApprove = errors.New("this operation requires user confirmation, but the current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed")
+
+// newBindCommand returns `databricks ucm deployment bind KEY UC_NAME`.
+// Records a state entry so subsequent deploys update — rather than recreate —
+// the existing UC object. The ucm.yml config is never modified.
+func newBindCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bind KEY UC_NAME",
+		Short: "Bind a ucm-declared resource to an existing Unity Catalog object",
+		Long: `Bind a ucm-declared resource to an existing Unity Catalog object.
+
+After binding, subsequent deploys reconcile (update) the UC object rather
+than attempt to create a new one.
+
+Arguments:
+  KEY     - The resource key declared in ucm.yml (e.g. team_alpha)
+  UC_NAME - The name/full-name of the existing Unity Catalog object
+
+Examples:
+  # Bind a catalog declaration to an existing UC catalog
+  databricks ucm deployment bind team_alpha team_alpha
+
+  # Bind a schema (UC_NAME must be the schema's full name)
+  databricks ucm deployment bind bronze team_alpha.bronze
+
+  # Bind with automatic approval (CI/CD)
+  databricks ucm deployment bind my_vol team_alpha.bronze.landing --auto-approve
+
+Supported kinds: catalogs, schemas, storage_credentials, external_locations,
+volumes, connections. Grants are not bindable (they reconcile per securable).
+
+WARNING: After binding, the UC object will be managed by ucm. Manual changes
+made outside ucm may be overwritten on the next deploy.`,
+		Args:    root.ExactArgs(2),
+		PreRunE: utils.MustWorkspaceClient,
+	}
+
+	var autoApprove bool
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Automatically approve the binding.")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		key, ucName := args[0], args[1]
+		ctx := cmd.Context()
+
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		es, err := utils.ResolveEngineSetting(ctx, &u.Config.Ucm)
+		if err != nil {
+			return err
+		}
+		if !es.Type.IsDirect() {
+			return notSupportedForEngine(es.Type)
+		}
+
+		kind, err := resolveBindable(u, key)
+		if err != nil {
+			return err
+		}
+
+		if !autoApprove {
+			if !cmdio.IsPromptSupported(ctx) {
+				return errNeedsAutoApprove
+			}
+			ok, err := cmdio.AskYesOrNo(ctx, "Bind "+string(kind)+"."+key+" -> "+ucName+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return errBindAborted
+			}
+		}
+
+		client, err := buildDirectClient(ctx, u)
+		if err != nil {
+			return err
+		}
+
+		if err := bindResourceDirect(ctx, u, client, kind, key, ucName); err != nil {
+			return err
+		}
+
+		cmdio.LogString(ctx, "Successfully bound "+string(kind)+"."+key+" to "+ucName)
+		cmdio.LogString(ctx, "Run 'databricks ucm deploy' to reconcile the bound resource.")
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/deployment/bind_resource.go
+++ b/cmd/ucm/deployment/bind_resource.go
@@ -1,0 +1,247 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+)
+
+// buildDirectClient is the indirection tests patch to inject a fake direct
+// client. The production implementation defers to direct.NewClient against
+// the memoized workspace client on u.
+var buildDirectClient = func(_ context.Context, u *ucm.Ucm) (direct.Client, error) {
+	w, err := u.WorkspaceClientE()
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace client: %w", err)
+	}
+	return direct.NewClient(w), nil
+}
+
+// bindableKind mirrors the plural resource names used in ucm.yml so error
+// messages stay user-facing without translation.
+type bindableKind string
+
+const (
+	kindCatalog           bindableKind = "catalogs"
+	kindSchema            bindableKind = "schemas"
+	kindStorageCredential bindableKind = "storage_credentials"
+	kindExternalLocation  bindableKind = "external_locations"
+	kindVolume            bindableKind = "volumes"
+	kindConnection        bindableKind = "connections"
+)
+
+// resolveBindable returns the kind the given key maps to in the ucm config.
+// Returns an error when the key matches zero or multiple kinds — bind is
+// unambiguous by design.
+func resolveBindable(u *ucm.Ucm, key string) (bindableKind, error) {
+	var matches []bindableKind
+	if _, ok := u.Config.Resources.Catalogs[key]; ok {
+		matches = append(matches, kindCatalog)
+	}
+	if _, ok := u.Config.Resources.Schemas[key]; ok {
+		matches = append(matches, kindSchema)
+	}
+	if _, ok := u.Config.Resources.StorageCredentials[key]; ok {
+		matches = append(matches, kindStorageCredential)
+	}
+	if _, ok := u.Config.Resources.ExternalLocations[key]; ok {
+		matches = append(matches, kindExternalLocation)
+	}
+	if _, ok := u.Config.Resources.Volumes[key]; ok {
+		matches = append(matches, kindVolume)
+	}
+	if _, ok := u.Config.Resources.Connections[key]; ok {
+		matches = append(matches, kindConnection)
+	}
+	if _, ok := u.Config.Resources.Grants[key]; ok {
+		return "", fmt.Errorf("grants are not bindable (they reconcile per securable, not by name)")
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no bindable resource with key %q in ucm.yml", key)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("ambiguous key %q: matches %v", key, matches)
+	}
+}
+
+// bindResourceDirect fetches the live UC object by name and records the
+// equivalent *State entry into direct-engine state. The ucm.yml config
+// itself is not modified — bind only affects recorded state.
+func bindResourceDirect(ctx context.Context, u *ucm.Ucm, client direct.Client, kind bindableKind, key, ucName string) error {
+	state, err := direct.LoadState(direct.StatePath(u))
+	if err != nil {
+		return fmt.Errorf("load direct state: %w", err)
+	}
+
+	switch kind {
+	case kindCatalog:
+		info, err := client.GetCatalog(ctx, ucName)
+		if err != nil {
+			return fmt.Errorf("fetch catalog %q: %w", ucName, err)
+		}
+		state.Catalogs[key] = &direct.CatalogState{
+			Name:        info.Name,
+			Comment:     info.Comment,
+			StorageRoot: info.StorageRoot,
+			Tags:        copyStringMap(info.Properties),
+		}
+	case kindSchema:
+		info, err := client.GetSchema(ctx, ucName)
+		if err != nil {
+			return fmt.Errorf("fetch schema %q: %w", ucName, err)
+		}
+		state.Schemas[key] = &direct.SchemaState{
+			Name:    info.Name,
+			Catalog: info.CatalogName,
+			Comment: info.Comment,
+			Tags:    copyStringMap(info.Properties),
+		}
+	case kindStorageCredential:
+		info, err := client.GetStorageCredential(ctx, ucName)
+		if err != nil {
+			return fmt.Errorf("fetch storage_credential %q: %w", ucName, err)
+		}
+		state.StorageCredentials[key] = storageCredentialStateFromInfo(info)
+	case kindExternalLocation:
+		info, err := client.GetExternalLocation(ctx, ucName)
+		if err != nil {
+			return fmt.Errorf("fetch external_location %q: %w", ucName, err)
+		}
+		state.ExternalLocations[key] = &direct.ExternalLocationState{
+			Name:           info.Name,
+			Url:            info.Url,
+			CredentialName: info.CredentialName,
+			Comment:        info.Comment,
+			ReadOnly:       info.ReadOnly,
+			Fallback:       info.Fallback,
+		}
+	case kindVolume:
+		info, err := client.GetVolume(ctx, ucName)
+		if err != nil {
+			return fmt.Errorf("fetch volume %q: %w", ucName, err)
+		}
+		state.Volumes[key] = &direct.VolumeState{
+			Name:            info.Name,
+			CatalogName:     info.CatalogName,
+			SchemaName:      info.SchemaName,
+			VolumeType:      string(info.VolumeType),
+			StorageLocation: info.StorageLocation,
+			Comment:         info.Comment,
+		}
+	case kindConnection:
+		info, err := client.GetConnection(ctx, ucName)
+		if err != nil {
+			return fmt.Errorf("fetch connection %q: %w", ucName, err)
+		}
+		state.Connections[key] = &direct.ConnectionState{
+			Name:           info.Name,
+			ConnectionType: string(info.ConnectionType),
+			Options:        copyStringMap(info.Options),
+			Comment:        info.Comment,
+			Properties:     copyStringMap(info.Properties),
+			ReadOnly:       info.ReadOnly,
+		}
+	default:
+		return fmt.Errorf("unsupported kind %q", kind)
+	}
+
+	if err := direct.SaveState(direct.StatePath(u), state); err != nil {
+		return fmt.Errorf("save direct state: %w", err)
+	}
+	return nil
+}
+
+// unbindResourceDirect drops the recorded state entry for the given key.
+// Returns a descriptive error if the key isn't currently bound.
+func unbindResourceDirect(u *ucm.Ucm, kind bindableKind, key string) error {
+	path := direct.StatePath(u)
+	state, err := direct.LoadState(path)
+	if err != nil {
+		return fmt.Errorf("load direct state: %w", err)
+	}
+
+	present := false
+	switch kind {
+	case kindCatalog:
+		_, present = state.Catalogs[key]
+		delete(state.Catalogs, key)
+	case kindSchema:
+		_, present = state.Schemas[key]
+		delete(state.Schemas, key)
+	case kindStorageCredential:
+		_, present = state.StorageCredentials[key]
+		delete(state.StorageCredentials, key)
+	case kindExternalLocation:
+		_, present = state.ExternalLocations[key]
+		delete(state.ExternalLocations, key)
+	case kindVolume:
+		_, present = state.Volumes[key]
+		delete(state.Volumes, key)
+	case kindConnection:
+		_, present = state.Connections[key]
+		delete(state.Connections, key)
+	default:
+		return fmt.Errorf("unsupported kind %q", kind)
+	}
+	if !present {
+		return fmt.Errorf("no bound %s with key %q in direct state", kind, key)
+	}
+	return direct.SaveState(path, state)
+}
+
+// storageCredentialStateFromInfo projects the SDK StorageCredentialInfo into
+// the recorded state shape. ClientSecret for Azure SP is never echoed by the
+// UC API — a subsequent deploy re-records it once supplied via config.
+func storageCredentialStateFromInfo(info *catalog.StorageCredentialInfo) *direct.StorageCredentialState {
+	s := &direct.StorageCredentialState{
+		Name:     info.Name,
+		Comment:  info.Comment,
+		ReadOnly: info.ReadOnly,
+	}
+	if info.AwsIamRole != nil {
+		s.AwsIamRole = &direct.AwsIamRoleState{RoleArn: info.AwsIamRole.RoleArn}
+	}
+	if info.AzureManagedIdentity != nil {
+		s.AzureManagedIdentity = &direct.AzureManagedIdentityState{
+			AccessConnectorId: info.AzureManagedIdentity.AccessConnectorId,
+			ManagedIdentityId: info.AzureManagedIdentity.ManagedIdentityId,
+		}
+	}
+	if info.AzureServicePrincipal != nil {
+		s.AzureServicePrincipal = &direct.AzureServicePrincipalState{
+			DirectoryId:   info.AzureServicePrincipal.DirectoryId,
+			ApplicationId: info.AzureServicePrincipal.ApplicationId,
+			ClientSecret:  info.AzureServicePrincipal.ClientSecret,
+		}
+	}
+	if info.DatabricksGcpServiceAccount != nil {
+		s.DatabricksGcpServiceAccount = &direct.DatabricksGcpServiceAccountState{}
+	}
+	return s
+}
+
+// copyStringMap returns a copy of m or nil when m is empty.
+func copyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// notSupportedForEngine is the standard error for the terraform engine.
+// Terraform-engine bind requires wiring `terraform import` through the ucm
+// Terraform wrapper (new tfexec Import method + state pull/push integration)
+// which is out of scope for this commit — tracked separately.
+func notSupportedForEngine(e engine.EngineType) error {
+	return fmt.Errorf("ucm deployment bind/unbind is not yet implemented for the %q engine; set engine: direct in ucm.yml or DATABRICKS_UCM_ENGINE=direct to proceed", e.ThisOrDefault())
+}

--- a/cmd/ucm/deployment/bind_test.go
+++ b/cmd/ucm/deployment/bind_test.go
@@ -1,0 +1,136 @@
+package deployment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindResourceDirect_WritesCatalogStateAndLeavesConfigUntouched(t *testing.T) {
+	u := setupUcmFixture(t)
+	before, err := os.ReadFile(filepath.Join(u.RootPath, "ucm.yml"))
+	require.NoError(t, err)
+
+	client := newFakeDirectClient()
+	client.catalogs["team_alpha"] = &catalog.CatalogInfo{
+		Name:        "team_alpha",
+		Comment:     "adopted",
+		StorageRoot: "s3://b/team_alpha",
+		Properties:  map[string]string{"owner": "alice"},
+	}
+
+	require.NoError(t, bindResourceDirect(t.Context(), u, client, kindCatalog, "my_catalog", "team_alpha"))
+
+	// ucm.yml must not be mutated by bind.
+	after, err := os.ReadFile(filepath.Join(u.RootPath, "ucm.yml"))
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after))
+
+	// The recorded state must reflect the UC response.
+	state, err := direct.LoadState(direct.StatePath(u))
+	require.NoError(t, err)
+	got, ok := state.Catalogs["my_catalog"]
+	require.True(t, ok, "expected catalog state for key my_catalog")
+	assert.Equal(t, "team_alpha", got.Name)
+	assert.Equal(t, "adopted", got.Comment)
+	assert.Equal(t, "s3://b/team_alpha", got.StorageRoot)
+	assert.Equal(t, map[string]string{"owner": "alice"}, got.Tags)
+}
+
+func TestBindResourceDirect_WritesAllKinds(t *testing.T) {
+	u := setupUcmFixture(t)
+	client := newFakeDirectClient()
+	client.catalogs["team_alpha"] = &catalog.CatalogInfo{Name: "team_alpha"}
+	client.schemas["team_alpha.bronze"] = &catalog.SchemaInfo{Name: "bronze", CatalogName: "team_alpha"}
+	client.storageCredentials["sc1"] = &catalog.StorageCredentialInfo{
+		Name:       "sc1",
+		AwsIamRole: &catalog.AwsIamRoleResponse{RoleArn: "arn:aws:iam::1:role/x"},
+	}
+	client.externalLocations["loc1"] = &catalog.ExternalLocationInfo{
+		Name:           "loc1",
+		Url:            "s3://b/x",
+		CredentialName: "sc1",
+	}
+	client.volumes["team_alpha.bronze.vol1"] = &catalog.VolumeInfo{
+		Name:        "vol1",
+		CatalogName: "team_alpha",
+		SchemaName:  "bronze",
+		VolumeType:  catalog.VolumeTypeManaged,
+	}
+	client.connections["conn1"] = &catalog.ConnectionInfo{
+		Name:           "conn1",
+		ConnectionType: catalog.ConnectionTypePostgresql,
+		Options:        map[string]string{"host": "db"},
+	}
+
+	cases := []struct {
+		key, ucName string
+		kind        bindableKind
+	}{
+		{"my_catalog", "team_alpha", kindCatalog},
+		{"my_schema", "team_alpha.bronze", kindSchema},
+		{"my_sc", "sc1", kindStorageCredential},
+		{"my_loc", "loc1", kindExternalLocation},
+		{"my_vol", "team_alpha.bronze.vol1", kindVolume},
+		{"my_conn", "conn1", kindConnection},
+	}
+	for _, c := range cases {
+		require.NoError(t, bindResourceDirect(t.Context(), u, client, c.kind, c.key, c.ucName), c.key)
+	}
+
+	state, err := direct.LoadState(direct.StatePath(u))
+	require.NoError(t, err)
+	assert.NotNil(t, state.Catalogs["my_catalog"])
+	assert.NotNil(t, state.Schemas["my_schema"])
+	assert.NotNil(t, state.StorageCredentials["my_sc"])
+	assert.NotNil(t, state.ExternalLocations["my_loc"])
+	assert.NotNil(t, state.Volumes["my_vol"])
+	assert.NotNil(t, state.Connections["my_conn"])
+	assert.Equal(t, "arn:aws:iam::1:role/x", state.StorageCredentials["my_sc"].AwsIamRole.RoleArn)
+	assert.Equal(t, "MANAGED", state.Volumes["my_vol"].VolumeType)
+}
+
+func TestBindResourceDirect_PropagatesFetchError(t *testing.T) {
+	u := setupUcmFixture(t)
+	client := newFakeDirectClient()
+
+	err := bindResourceDirect(t.Context(), u, client, kindCatalog, "my_catalog", "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch catalog")
+	assert.Contains(t, err.Error(), "missing")
+}
+
+func TestResolveBindable(t *testing.T) {
+	u := setupUcmFixture(t)
+
+	cases := []struct {
+		key     string
+		want    bindableKind
+		wantErr string
+	}{
+		{"my_catalog", kindCatalog, ""},
+		{"my_schema", kindSchema, ""},
+		{"my_sc", kindStorageCredential, ""},
+		{"my_loc", kindExternalLocation, ""},
+		{"my_vol", kindVolume, ""},
+		{"my_conn", kindConnection, ""},
+		{"grant_a", "", "grants are not bindable"},
+		{"does_not_exist", "", "no bindable resource"},
+	}
+
+	for _, c := range cases {
+		got, err := resolveBindable(u, c.key)
+		if c.wantErr != "" {
+			require.Error(t, err, c.key)
+			assert.Contains(t, err.Error(), c.wantErr, c.key)
+			continue
+		}
+		require.NoError(t, err, c.key)
+		assert.Equal(t, c.want, got, c.key)
+	}
+}

--- a/cmd/ucm/deployment/deployment.go
+++ b/cmd/ucm/deployment/deployment.go
@@ -1,0 +1,35 @@
+// Package deployment wires the `databricks ucm deployment` subcommand group:
+// `bind` attaches a ucm-declared resource to an existing UC object; `unbind`
+// drops that recorded binding. Mirrors cmd/bundle/deployment in shape, but
+// forks rather than imports so the bundle package can evolve upstream
+// independently of ucm.
+package deployment
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// New returns the cobra group registered under `databricks ucm deployment`.
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deployment",
+		Short: "Deployment related commands",
+		Long: `Deployment related commands for managing ucm resource bindings.
+
+Use these commands to bind / unbind ucm definitions to existing Unity Catalog
+objects so that subsequent deploys update — rather than recreate — them.
+
+Common workflow:
+1. Author a ucm.yml that declares the resource with the desired target state.
+
+2. Bind the ucm key to the existing Unity Catalog object:
+   databricks ucm deployment bind my_catalog team_alpha
+
+3. Deploy updates — the bound resource is reconciled in place:
+   databricks ucm deploy`,
+	}
+
+	cmd.AddCommand(newBindCommand())
+	cmd.AddCommand(newUnbindCommand())
+	return cmd
+}

--- a/cmd/ucm/deployment/deployment_test.go
+++ b/cmd/ucm/deployment/deployment_test.go
@@ -1,0 +1,29 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew_RegistersBindAndUnbind(t *testing.T) {
+	cmd := New()
+	got := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		got[sub.Name()] = true
+	}
+	assert.True(t, got["bind"], "bind subcommand missing")
+	assert.True(t, got["unbind"], "unbind subcommand missing")
+}
+
+func TestBind_And_Unbind_AutoApproveFlag(t *testing.T) {
+	cmd := New()
+	for _, name := range []string{"bind", "unbind"} {
+		sub, _, err := cmd.Find([]string{name})
+		if err != nil || sub == nil {
+			t.Fatalf("subcommand %q not found", name)
+		}
+		flag := sub.Flags().Lookup("auto-approve")
+		assert.NotNil(t, flag, "%s missing --auto-approve flag", name)
+	}
+}

--- a/cmd/ucm/deployment/helpers_test.go
+++ b/cmd/ucm/deployment/helpers_test.go
@@ -1,0 +1,215 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDirectClient is an in-memory stand-in for direct.Client used by
+// bind/unbind tests. Only the Get* methods used by the bind path are
+// populated — the mutating methods panic if called unexpectedly.
+type fakeDirectClient struct {
+	catalogs           map[string]*catalog.CatalogInfo
+	schemas            map[string]*catalog.SchemaInfo
+	storageCredentials map[string]*catalog.StorageCredentialInfo
+	externalLocations  map[string]*catalog.ExternalLocationInfo
+	volumes            map[string]*catalog.VolumeInfo
+	connections        map[string]*catalog.ConnectionInfo
+}
+
+func newFakeDirectClient() *fakeDirectClient {
+	return &fakeDirectClient{
+		catalogs:           map[string]*catalog.CatalogInfo{},
+		schemas:            map[string]*catalog.SchemaInfo{},
+		storageCredentials: map[string]*catalog.StorageCredentialInfo{},
+		externalLocations:  map[string]*catalog.ExternalLocationInfo{},
+		volumes:            map[string]*catalog.VolumeInfo{},
+		connections:        map[string]*catalog.ConnectionInfo{},
+	}
+}
+
+func (f *fakeDirectClient) GetCatalog(_ context.Context, name string) (*catalog.CatalogInfo, error) {
+	v, ok := f.catalogs[name]
+	if !ok {
+		return nil, fmt.Errorf("catalog %q not found", name)
+	}
+	return v, nil
+}
+
+func (f *fakeDirectClient) GetSchema(_ context.Context, fullName string) (*catalog.SchemaInfo, error) {
+	v, ok := f.schemas[fullName]
+	if !ok {
+		return nil, fmt.Errorf("schema %q not found", fullName)
+	}
+	return v, nil
+}
+
+func (f *fakeDirectClient) GetStorageCredential(_ context.Context, name string) (*catalog.StorageCredentialInfo, error) {
+	v, ok := f.storageCredentials[name]
+	if !ok {
+		return nil, fmt.Errorf("storage_credential %q not found", name)
+	}
+	return v, nil
+}
+
+func (f *fakeDirectClient) GetExternalLocation(_ context.Context, name string) (*catalog.ExternalLocationInfo, error) {
+	v, ok := f.externalLocations[name]
+	if !ok {
+		return nil, fmt.Errorf("external_location %q not found", name)
+	}
+	return v, nil
+}
+
+func (f *fakeDirectClient) GetVolume(_ context.Context, name string) (*catalog.VolumeInfo, error) {
+	v, ok := f.volumes[name]
+	if !ok {
+		return nil, fmt.Errorf("volume %q not found", name)
+	}
+	return v, nil
+}
+
+func (f *fakeDirectClient) GetConnection(_ context.Context, name string) (*catalog.ConnectionInfo, error) {
+	v, ok := f.connections[name]
+	if !ok {
+		return nil, fmt.Errorf("connection %q not found", name)
+	}
+	return v, nil
+}
+
+// Mutating methods panic: bind/unbind must only read from UC, never write.
+func (f *fakeDirectClient) CreateCatalog(context.Context, catalog.CreateCatalog) (*catalog.CatalogInfo, error) {
+	panic("bind/unbind should not call CreateCatalog")
+}
+
+func (f *fakeDirectClient) UpdateCatalog(context.Context, catalog.UpdateCatalog) (*catalog.CatalogInfo, error) {
+	panic("bind/unbind should not call UpdateCatalog")
+}
+func (f *fakeDirectClient) DeleteCatalog(context.Context, string) error {
+	panic("bind/unbind should not call DeleteCatalog")
+}
+
+func (f *fakeDirectClient) CreateSchema(context.Context, catalog.CreateSchema) (*catalog.SchemaInfo, error) {
+	panic("bind/unbind should not call CreateSchema")
+}
+
+func (f *fakeDirectClient) UpdateSchema(context.Context, catalog.UpdateSchema) (*catalog.SchemaInfo, error) {
+	panic("bind/unbind should not call UpdateSchema")
+}
+func (f *fakeDirectClient) DeleteSchema(context.Context, string) error {
+	panic("bind/unbind should not call DeleteSchema")
+}
+
+func (f *fakeDirectClient) CreateStorageCredential(context.Context, catalog.CreateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	panic("bind/unbind should not call CreateStorageCredential")
+}
+
+func (f *fakeDirectClient) UpdateStorageCredential(context.Context, catalog.UpdateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	panic("bind/unbind should not call UpdateStorageCredential")
+}
+func (f *fakeDirectClient) DeleteStorageCredential(context.Context, string) error {
+	panic("bind/unbind should not call DeleteStorageCredential")
+}
+
+func (f *fakeDirectClient) CreateExternalLocation(context.Context, catalog.CreateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	panic("bind/unbind should not call CreateExternalLocation")
+}
+
+func (f *fakeDirectClient) UpdateExternalLocation(context.Context, catalog.UpdateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	panic("bind/unbind should not call UpdateExternalLocation")
+}
+func (f *fakeDirectClient) DeleteExternalLocation(context.Context, string) error {
+	panic("bind/unbind should not call DeleteExternalLocation")
+}
+
+func (f *fakeDirectClient) CreateVolume(context.Context, catalog.CreateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	panic("bind/unbind should not call CreateVolume")
+}
+
+func (f *fakeDirectClient) UpdateVolume(context.Context, catalog.UpdateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	panic("bind/unbind should not call UpdateVolume")
+}
+func (f *fakeDirectClient) DeleteVolume(context.Context, string) error {
+	panic("bind/unbind should not call DeleteVolume")
+}
+
+func (f *fakeDirectClient) CreateConnection(context.Context, catalog.CreateConnection) (*catalog.ConnectionInfo, error) {
+	panic("bind/unbind should not call CreateConnection")
+}
+
+func (f *fakeDirectClient) UpdateConnection(context.Context, catalog.UpdateConnection) (*catalog.ConnectionInfo, error) {
+	panic("bind/unbind should not call UpdateConnection")
+}
+func (f *fakeDirectClient) DeleteConnection(context.Context, string) error {
+	panic("bind/unbind should not call DeleteConnection")
+}
+
+func (f *fakeDirectClient) UpdatePermissions(context.Context, catalog.UpdatePermissions) error {
+	panic("bind/unbind should not call UpdatePermissions")
+}
+
+var _ direct.Client = (*fakeDirectClient)(nil)
+
+// setupUcmFixture writes a ucm.yml with every supported resource kind into a
+// fresh temp dir, loads it via ucm.Load, and selects the default target. The
+// returned *ucm.Ucm is ready for a direct-engine bind/unbind call against.
+func setupUcmFixture(t *testing.T) *ucm.Ucm {
+	t.Helper()
+	dir := t.TempDir()
+	yml := `ucm:
+  name: test-bind
+  engine: direct
+
+workspace:
+  host: https://example.cloud.databricks.com
+
+resources:
+  catalogs:
+    my_catalog:
+      name: team_alpha
+  schemas:
+    my_schema:
+      catalog: team_alpha
+      name: bronze
+  storage_credentials:
+    my_sc:
+      name: sc1
+      aws_iam_role:
+        role_arn: arn:aws:iam::1:role/x
+  external_locations:
+    my_loc:
+      name: loc1
+      url: s3://b/x
+      credential_name: sc1
+  volumes:
+    my_vol:
+      name: vol1
+      catalog_name: team_alpha
+      schema_name: bronze
+      volume_type: MANAGED
+  connections:
+    my_conn:
+      name: conn1
+      connection_type: POSTGRESQL
+      options: { host: db }
+  grants:
+    grant_a:
+      securable: { type: catalog, name: team_alpha }
+      principal: g
+      privileges: [USE_CATALOG]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ucm.yml"), []byte(yml), 0o644))
+
+	u, err := ucm.Load(t.Context(), dir)
+	require.NoError(t, err)
+	// Direct-engine state paths depend on Config.Ucm.Target being set.
+	u.Config.Ucm.Target = "default"
+	return u
+}

--- a/cmd/ucm/deployment/unbind.go
+++ b/cmd/ucm/deployment/unbind.go
@@ -1,0 +1,89 @@
+package deployment
+
+import (
+	"errors"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/spf13/cobra"
+)
+
+// errUnbindAborted is returned when the user answers "no" to the unbind prompt.
+var errUnbindAborted = errors.New("unbind aborted")
+
+// newUnbindCommand returns `databricks ucm deployment unbind KEY`. Drops the
+// recorded state entry so the next deploy will treat the resource as newly
+// declared (creating it if absent, adopting if present — engine-dependent).
+func newUnbindCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unbind KEY",
+		Short: "Drop the recorded binding for a ucm-declared resource",
+		Long: `Drop the recorded binding for a ucm-declared resource.
+
+After unbinding, the ucm-managed state no longer references the live UC
+object. The next deploy will attempt to create or adopt the object as if it
+had never been deployed.
+
+Arguments:
+  KEY - The resource key declared in ucm.yml to unbind
+
+Examples:
+  databricks ucm deployment unbind team_alpha
+  databricks ucm deployment unbind bronze --auto-approve
+
+To re-bind later, use:
+  databricks ucm deployment bind <KEY> <UC_NAME>`,
+		Args:    root.ExactArgs(1),
+		PreRunE: utils.MustWorkspaceClient,
+	}
+
+	var autoApprove bool
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Automatically approve the unbind.")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		ctx := cmd.Context()
+
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		es, err := utils.ResolveEngineSetting(ctx, &u.Config.Ucm)
+		if err != nil {
+			return err
+		}
+		if !es.Type.IsDirect() {
+			return notSupportedForEngine(es.Type)
+		}
+
+		kind, err := resolveBindable(u, key)
+		if err != nil {
+			return err
+		}
+
+		if !autoApprove {
+			if !cmdio.IsPromptSupported(ctx) {
+				return errNeedsAutoApprove
+			}
+			ok, err := cmdio.AskYesOrNo(ctx, "Unbind "+string(kind)+"."+key+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return errUnbindAborted
+			}
+		}
+
+		if err := unbindResourceDirect(u, kind, key); err != nil {
+			return err
+		}
+
+		cmdio.LogString(ctx, "Successfully unbound "+string(kind)+"."+key)
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/ucm/deployment/unbind_test.go
+++ b/cmd/ucm/deployment/unbind_test.go
@@ -1,0 +1,44 @@
+package deployment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnbindResourceDirect_RemovesStateAndLeavesConfigUntouched(t *testing.T) {
+	u := setupUcmFixture(t)
+	before, err := os.ReadFile(filepath.Join(u.RootPath, "ucm.yml"))
+	require.NoError(t, err)
+
+	// Seed a recorded state so unbind has something to remove.
+	client := newFakeDirectClient()
+	client.catalogs["team_alpha"] = &catalog.CatalogInfo{Name: "team_alpha"}
+	require.NoError(t, bindResourceDirect(t.Context(), u, client, kindCatalog, "my_catalog", "team_alpha"))
+
+	require.NoError(t, unbindResourceDirect(u, kindCatalog, "my_catalog"))
+
+	state, err := direct.LoadState(direct.StatePath(u))
+	require.NoError(t, err)
+	_, ok := state.Catalogs["my_catalog"]
+	assert.False(t, ok, "catalog should be removed from state")
+
+	// ucm.yml must remain untouched.
+	after, err := os.ReadFile(filepath.Join(u.RootPath, "ucm.yml"))
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after))
+}
+
+func TestUnbindResourceDirect_ErrorsWhenKeyNotBound(t *testing.T) {
+	u := setupUcmFixture(t)
+
+	err := unbindResourceDirect(u, kindCatalog, "my_catalog")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no bound")
+	assert.Contains(t, err.Error(), "my_catalog")
+}

--- a/cmd/ucm/stubs.go
+++ b/cmd/ucm/stubs.go
@@ -29,10 +29,6 @@ func newGenerateCommand() *cobra.Command {
 	return stub("generate", "Scan an existing account+metastore+workspace and emit ucm.yml + seed state.")
 }
 
-func newBindCommand() *cobra.Command {
-	return stub("bind", "Attach an existing Databricks resource to a ucm.yml node without recreating it.")
-}
-
 func newDebugCommand() *cobra.Command {
 	return stub("debug", "Dump internal ucm state (config tree, mutator trace) for troubleshooting.")
 }

--- a/cmd/ucm/ucm.go
+++ b/cmd/ucm/ucm.go
@@ -7,6 +7,7 @@
 package ucm
 
 import (
+	"github.com/databricks/cli/cmd/ucm/deployment"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,7 @@ Online documentation: https://docs.databricks.com/en/dev-tools/ucm/index.html`,
 	cmd.AddCommand(newSummaryCommand())
 	cmd.AddCommand(newInitCommand())
 	cmd.AddCommand(newGenerateCommand())
-	cmd.AddCommand(newBindCommand())
+	cmd.AddCommand(deployment.New())
 	cmd.AddCommand(newDebugCommand())
 	cmd.AddCommand(newDiffCommand())
 	cmd.AddCommand(newDriftCommand())


### PR DESCRIPTION
Closes #68

## Summary

Mirrors `bundle deployment bind/unbind` — fork-and-adapt, no `bundle/**` imports.

- `ucm deployment bind KEY UC_NAME` — attaches a ucm-declared resource (in ucm.yml) to an existing UC object. Fetches via SDK Get, projects into the corresponding `*State`, persists to `resources.json`. Next deploy will not recreate it.
- `ucm deployment unbind KEY` — removes the binding from state. Next deploy will try to create or adopt.
- `--auto-approve` on both. `deployment` group command is visible (DAB's is too).

Supports: catalogs, schemas, storage_credentials, external_locations, volumes, connections. Grants are not bindable (reconcile by securable, not by identity).

## Direct engine only in this PR

Terraform-engine bind/unbind requires extending the tf runner with `Import` / `StateRm`, plumbing through a new `terraform.Terraform.Import` method, and wiring push/pull — more than one commit. Both verbs return a descriptive error in terraform-engine mode asking the user to switch to `engine: direct`. Follow-up issue filed for the terraform-engine path.

## Test plan

- [x] `go build ./...` / `go vet` / `go test ./cmd/ucm/... ./ucm/...` — all clean.
- [x] New tests in `cmd/ucm/deployment/`: all six kinds covered, ucm.yml-not-mutated invariant, grants/unknown-keys error, both verbs register `--auto-approve`.

## Files

`cmd/ucm/deployment/{deployment,bind,unbind,bind_resource,deployment_test,bind_test,unbind_test,helpers_test}.go` — new package.
`cmd/ucm/ucm.go` — swapped `newBindCommand()` → `deployment.New()`.
`cmd/ucm/stubs.go` — removed `newBindCommand` stub.