### PR TITLE
Feat #69: Implement ucm import — pull existing UC objects into state

### DIFF
--- a/cmd/ucm/helpers_test.go
+++ b/cmd/ucm/helpers_test.go
@@ -32,12 +32,17 @@ type fakeTf struct {
 	PlanCalls    int
 	ApplyCalls   int
 	DestroyCalls int
+	ImportCalls  int
 
 	RenderErr  error
 	InitErr    error
 	PlanErr    error
 	ApplyErr   error
 	DestroyErr error
+	ImportErr  error
+
+	LastImportAddress string
+	LastImportId      string
 
 	PlanResult *terraform.PlanResult
 }
@@ -75,6 +80,15 @@ func (f *fakeTf) Destroy(_ context.Context, _ *ucmpkg.Ucm) error {
 	defer f.mu.Unlock()
 	f.DestroyCalls++
 	return f.DestroyErr
+}
+
+func (f *fakeTf) Import(_ context.Context, _ *ucmpkg.Ucm, address, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ImportCalls++
+	f.LastImportAddress = address
+	f.LastImportId = id
+	return f.ImportErr
 }
 
 // verbHarness bundles the fake terraform wrapper, the remote-state filer

--- a/cmd/ucm/import.go
+++ b/cmd/ucm/import.go
@@ -1,0 +1,153 @@
+package ucm
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/spf13/cobra"
+)
+
+// importKinds is the closed set of resource kinds the verb accepts. Kept as
+// a slice (not a map) so help text lists them in a stable order.
+var importKinds = []phases.ImportKind{
+	phases.ImportCatalog,
+	phases.ImportSchema,
+	phases.ImportStorageCredential,
+	phases.ImportExternalLocation,
+	phases.ImportVolume,
+	phases.ImportConnection,
+}
+
+func newImportCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import <kind> <name>",
+		Short: "Bind state for an existing UC resource to a ucm.yml declaration.",
+		Long: `Bind state for an existing UC resource to a ucm.yml declaration.
+
+Supported <kind>: catalog, schema, storage_credential, external_location,
+volume, connection.
+
+<name> is the UC identifier — e.g. "sales_prod" for a catalog, "sales.raw"
+for a schema, "sales.raw.docs" for a volume, or just the resource name for
+storage_credential/external_location/connection.
+
+The resource must already be declared under resources.<kind>.<key> in
+ucm.yml. Use --key to specify which ucm.yml key to bind under when it
+differs from the UC name (or the last path component for schemas/volumes).
+
+Common invocations:
+  databricks ucm import catalog sales_prod
+  databricks ucm import schema sales_prod.raw --key raw_landing
+  databricks ucm import storage_credential my_cred --auto-approve`,
+		Args:    root.ExactArgs(2),
+		PreRunE: utils.MustWorkspaceClient,
+	}
+
+	var key string
+	var autoApprove bool
+	cmd.Flags().StringVar(&key, "key", "", "ucm.yml map key to bind under (defaults to the UC name or its last path component).")
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip the interactive confirmation prompt.")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		kind, err := parseImportKind(args[0])
+		if err != nil {
+			return err
+		}
+		name := args[1]
+		resolvedKey := key
+		if resolvedKey == "" {
+			resolvedKey = defaultImportKey(kind, name)
+		}
+
+		if !autoApprove {
+			if !cmdio.IsPromptSupported(ctx) {
+				return errors.New("please specify --auto-approve since terminal does not support interactive prompts")
+			}
+			prompt := fmt.Sprintf("Import %s %q into resources.%s.%s?", kind, name, pluralImportKind(kind), resolvedKey)
+			ok, err := cmdio.AskYesOrNo(ctx, prompt)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return errors.New("import aborted")
+			}
+		}
+
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		ctx = cmd.Context()
+		if u == nil || logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		opts, err := buildPhaseOptions(ctx, u)
+		if err != nil {
+			return fmt.Errorf("resolve import options: %w", err)
+		}
+
+		phases.Import(ctx, u, opts, phases.ImportRequest{Kind: kind, Name: name, Key: resolvedKey})
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Imported %s.%s (%s)\n", kind, resolvedKey, name)
+		return nil
+	}
+
+	return cmd
+}
+
+// parseImportKind validates arg0 against the supported kinds and returns a
+// typed value, or a helpful error listing the accepted values.
+func parseImportKind(s string) (phases.ImportKind, error) {
+	for _, k := range importKinds {
+		if string(k) == s {
+			return k, nil
+		}
+	}
+	accepted := make([]string, len(importKinds))
+	for i, k := range importKinds {
+		accepted[i] = string(k)
+	}
+	return "", fmt.Errorf("unsupported kind %q (want one of: %s)", s, strings.Join(accepted, ", "))
+}
+
+// defaultImportKey falls back to the UC name for simple kinds and to the
+// last path component for schemas/volumes (since their names carry the
+// parent hierarchy as dot-separated segments).
+func defaultImportKey(kind phases.ImportKind, name string) string {
+	switch kind {
+	case phases.ImportSchema, phases.ImportVolume:
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			return name[i+1:]
+		}
+	}
+	return name
+}
+
+// pluralImportKind is the resources.<plural> map name for kind. Kept here
+// (not exported from phases) so the CLI layer owns user-facing strings.
+func pluralImportKind(k phases.ImportKind) string {
+	switch k {
+	case phases.ImportCatalog:
+		return "catalogs"
+	case phases.ImportSchema:
+		return "schemas"
+	case phases.ImportStorageCredential:
+		return "storage_credentials"
+	case phases.ImportExternalLocation:
+		return "external_locations"
+	case phases.ImportVolume:
+		return "volumes"
+	case phases.ImportConnection:
+		return "connections"
+	}
+	return string(k)
+}

--- a/cmd/ucm/import_test.go
+++ b/cmd/ucm/import_test.go
@@ -1,0 +1,72 @@
+package ucm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_Import_HappyPathTerraformEngine(t *testing.T) {
+	h := newVerbHarness(t)
+
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "import", "catalog", "team_alpha", "--auto-approve")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Imported catalog.team_alpha (team_alpha)")
+	assert.Equal(t, 1, h.tf.RenderCalls)
+	assert.Equal(t, 1, h.tf.InitCalls)
+	assert.Equal(t, 1, h.tf.ImportCalls)
+	assert.Equal(t, "databricks_catalog.team_alpha", h.tf.LastImportAddress)
+	assert.Equal(t, "team_alpha", h.tf.LastImportId)
+}
+
+func TestCmd_Import_SchemaDefaultKeyIsLastPathSegment(t *testing.T) {
+	h := newVerbHarness(t)
+
+	_, _, err := runVerb(t, validFixtureDir(t), "import", "schema", "team_alpha.bronze", "--auto-approve")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, h.tf.ImportCalls)
+	assert.Equal(t, "databricks_schema.bronze", h.tf.LastImportAddress)
+	assert.Equal(t, "team_alpha.bronze", h.tf.LastImportId)
+}
+
+func TestCmd_Import_KeyFlagOverridesDefault(t *testing.T) {
+	h := newVerbHarness(t)
+
+	_, _, err := runVerb(t, validFixtureDir(t), "import", "catalog", "team_alpha", "--key", "team_alpha", "--auto-approve")
+
+	require.NoError(t, err)
+	assert.Equal(t, "databricks_catalog.team_alpha", h.tf.LastImportAddress)
+}
+
+func TestCmd_Import_UnknownKindFails(t *testing.T) {
+	_ = newVerbHarness(t)
+
+	_, _, err := runVerb(t, validFixtureDir(t), "import", "table", "foo", "--auto-approve")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported kind")
+}
+
+func TestCmd_Import_RequiresDeclaredResource(t *testing.T) {
+	_ = newVerbHarness(t)
+
+	stdout, stderr, err := runVerb(t, validFixtureDir(t), "import", "catalog", "missing_catalog", "--auto-approve")
+	t.Logf("stdout=%q stderr=%q", stdout, stderr)
+
+	require.Error(t, err)
+	assert.Contains(t, stderr, "not declared in ucm.yml")
+}
+
+func TestCmd_Import_PropagatesImportError(t *testing.T) {
+	h := newVerbHarness(t)
+	h.tf.ImportErr = assertSentinel
+
+	_, _, err := runVerb(t, validFixtureDir(t), "import", "catalog", "team_alpha", "--auto-approve")
+
+	require.Error(t, err)
+	assert.Equal(t, 1, h.tf.ImportCalls)
+}

--- a/cmd/ucm/stubs.go
+++ b/cmd/ucm/stubs.go
@@ -44,7 +44,3 @@ func newDiffCommand() *cobra.Command {
 func newDriftCommand() *cobra.Command {
 	return stub("drift", "Compare live UC state to persisted terraform state; alert on out-of-band changes.")
 }
-
-func newImportCommand() *cobra.Command {
-	return stub("import <type> <name>", "Import a single existing UC or cloud resource into ucm state.")
-}

--- a/ucm/deploy/direct/import.go
+++ b/ucm/deploy/direct/import.go
@@ -1,0 +1,260 @@
+package direct
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+)
+
+// ImportResource fetches the named UC object via client.Get<Kind> and seeds
+// the corresponding entry in state keyed by ucmKey. The config declaration
+// under resources.<kind>.<ucmKey> supplies the fields the SDK does not echo
+// (e.g. storage credential ClientSecret for Azure SP, skip_validation).
+//
+// kind is the CLI-facing singular name: "catalog", "schema",
+// "storage_credential", "external_location", "volume", "connection".
+func ImportResource(ctx context.Context, u *ucm.Ucm, client Client, state *State, kind, name, ucmKey string) error {
+	switch kind {
+	case "catalog":
+		return importCatalog(ctx, u, client, state, name, ucmKey)
+	case "schema":
+		return importSchema(ctx, u, client, state, name, ucmKey)
+	case "storage_credential":
+		return importStorageCredential(ctx, u, client, state, name, ucmKey)
+	case "external_location":
+		return importExternalLocation(ctx, u, client, state, name, ucmKey)
+	case "volume":
+		return importVolume(ctx, u, client, state, name, ucmKey)
+	case "connection":
+		return importConnection(ctx, u, client, state, name, ucmKey)
+	}
+	return fmt.Errorf("unsupported import kind %q", kind)
+}
+
+func importCatalog(ctx context.Context, u *ucm.Ucm, client Client, state *State, name, key string) error {
+	info, err := client.GetCatalog(ctx, name)
+	if err != nil {
+		return fmt.Errorf("get catalog %s: %w", name, err)
+	}
+	cfg := u.Config.Resources.Catalogs[key]
+	rec := catalogStateFromConfig(cfg)
+	mergeCatalogFromSDK(&rec, info)
+	state.Catalogs[key] = ptrCatalog(rec)
+	log.Infof(ctx, "direct: imported catalog %s as resources.catalogs.%s", name, key)
+	return nil
+}
+
+func importSchema(ctx context.Context, u *ucm.Ucm, client Client, state *State, fullName, key string) error {
+	info, err := client.GetSchema(ctx, fullName)
+	if err != nil {
+		return fmt.Errorf("get schema %s: %w", fullName, err)
+	}
+	cfg := u.Config.Resources.Schemas[key]
+	rec := schemaStateFromConfig(cfg)
+	mergeSchemaFromSDK(&rec, info)
+	state.Schemas[key] = ptrSchema(rec)
+	log.Infof(ctx, "direct: imported schema %s as resources.schemas.%s", fullName, key)
+	return nil
+}
+
+func importStorageCredential(ctx context.Context, u *ucm.Ucm, client Client, state *State, name, key string) error {
+	info, err := client.GetStorageCredential(ctx, name)
+	if err != nil {
+		return fmt.Errorf("get storage_credential %s: %w", name, err)
+	}
+	cfg := u.Config.Resources.StorageCredentials[key]
+	rec := storageCredentialStateFromConfig(cfg)
+	mergeStorageCredentialFromSDK(&rec, info)
+	state.StorageCredentials[key] = ptrStorageCredential(rec)
+	log.Infof(ctx, "direct: imported storage_credential %s as resources.storage_credentials.%s", name, key)
+	return nil
+}
+
+func importExternalLocation(ctx context.Context, u *ucm.Ucm, client Client, state *State, name, key string) error {
+	info, err := client.GetExternalLocation(ctx, name)
+	if err != nil {
+		return fmt.Errorf("get external_location %s: %w", name, err)
+	}
+	cfg := u.Config.Resources.ExternalLocations[key]
+	rec := externalLocationStateFromConfig(cfg)
+	mergeExternalLocationFromSDK(&rec, info)
+	state.ExternalLocations[key] = ptrExternalLocation(rec)
+	log.Infof(ctx, "direct: imported external_location %s as resources.external_locations.%s", name, key)
+	return nil
+}
+
+func importVolume(ctx context.Context, u *ucm.Ucm, client Client, state *State, fullName, key string) error {
+	info, err := client.GetVolume(ctx, fullName)
+	if err != nil {
+		return fmt.Errorf("get volume %s: %w", fullName, err)
+	}
+	cfg := u.Config.Resources.Volumes[key]
+	rec := volumeStateFromConfig(cfg)
+	mergeVolumeFromSDK(&rec, info)
+	state.Volumes[key] = ptrVolume(rec)
+	log.Infof(ctx, "direct: imported volume %s as resources.volumes.%s", fullName, key)
+	return nil
+}
+
+func importConnection(ctx context.Context, u *ucm.Ucm, client Client, state *State, name, key string) error {
+	info, err := client.GetConnection(ctx, name)
+	if err != nil {
+		return fmt.Errorf("get connection %s: %w", name, err)
+	}
+	cfg := u.Config.Resources.Connections[key]
+	rec := connectionStateFromConfig(cfg)
+	mergeConnectionFromSDK(&rec, info)
+	state.Connections[key] = ptrConnection(rec)
+	log.Infof(ctx, "direct: imported connection %s as resources.connections.%s", name, key)
+	return nil
+}
+
+// ---- SDK → state merge helpers ----
+//
+// Each helper overlays fields that the SDK echoes back on top of the
+// config-derived state. Server-authoritative strings (Name, URL, etc.) take
+// the SDK value; user-only fields (e.g. Azure SP ClientSecret) stay as the
+// config supplied them since the UC API never echoes secrets.
+
+func mergeCatalogFromSDK(s *CatalogState, info *catalog.CatalogInfo) {
+	if info == nil {
+		return
+	}
+	if info.Name != "" {
+		s.Name = info.Name
+	}
+	if info.Comment != "" {
+		s.Comment = info.Comment
+	}
+	if info.StorageRoot != "" {
+		s.StorageRoot = info.StorageRoot
+	}
+	if len(info.Properties) > 0 {
+		s.Tags = copyTags(info.Properties)
+	}
+}
+
+func mergeSchemaFromSDK(s *SchemaState, info *catalog.SchemaInfo) {
+	if info == nil {
+		return
+	}
+	if info.Name != "" {
+		s.Name = info.Name
+	}
+	if info.CatalogName != "" {
+		s.Catalog = info.CatalogName
+	}
+	if info.Comment != "" {
+		s.Comment = info.Comment
+	}
+	if len(info.Properties) > 0 {
+		s.Tags = copyTags(info.Properties)
+	}
+}
+
+func mergeStorageCredentialFromSDK(s *StorageCredentialState, info *catalog.StorageCredentialInfo) {
+	if info == nil {
+		return
+	}
+	if info.Name != "" {
+		s.Name = info.Name
+	}
+	if info.Comment != "" {
+		s.Comment = info.Comment
+	}
+	s.ReadOnly = info.ReadOnly
+	if info.AwsIamRole != nil {
+		s.AwsIamRole = &AwsIamRoleState{RoleArn: info.AwsIamRole.RoleArn}
+	}
+	if info.AzureManagedIdentity != nil {
+		s.AzureManagedIdentity = &AzureManagedIdentityState{
+			AccessConnectorId: info.AzureManagedIdentity.AccessConnectorId,
+			ManagedIdentityId: info.AzureManagedIdentity.ManagedIdentityId,
+		}
+	}
+	// ClientSecret intentionally retained from config — the UC API never
+	// returns Azure SP client secrets.
+	if info.AzureServicePrincipal != nil {
+		secret := ""
+		if s.AzureServicePrincipal != nil {
+			secret = s.AzureServicePrincipal.ClientSecret
+		}
+		s.AzureServicePrincipal = &AzureServicePrincipalState{
+			DirectoryId:   info.AzureServicePrincipal.DirectoryId,
+			ApplicationId: info.AzureServicePrincipal.ApplicationId,
+			ClientSecret:  secret,
+		}
+	}
+	if info.DatabricksGcpServiceAccount != nil {
+		s.DatabricksGcpServiceAccount = &DatabricksGcpServiceAccountState{}
+	}
+}
+
+func mergeExternalLocationFromSDK(s *ExternalLocationState, info *catalog.ExternalLocationInfo) {
+	if info == nil {
+		return
+	}
+	if info.Name != "" {
+		s.Name = info.Name
+	}
+	if info.Url != "" {
+		s.Url = info.Url
+	}
+	if info.CredentialName != "" {
+		s.CredentialName = info.CredentialName
+	}
+	if info.Comment != "" {
+		s.Comment = info.Comment
+	}
+	s.ReadOnly = info.ReadOnly
+	s.Fallback = info.Fallback
+}
+
+func mergeVolumeFromSDK(s *VolumeState, info *catalog.VolumeInfo) {
+	if info == nil {
+		return
+	}
+	if info.Name != "" {
+		s.Name = info.Name
+	}
+	if info.CatalogName != "" {
+		s.CatalogName = info.CatalogName
+	}
+	if info.SchemaName != "" {
+		s.SchemaName = info.SchemaName
+	}
+	if info.VolumeType != "" {
+		s.VolumeType = string(info.VolumeType)
+	}
+	if info.StorageLocation != "" {
+		s.StorageLocation = info.StorageLocation
+	}
+	if info.Comment != "" {
+		s.Comment = info.Comment
+	}
+}
+
+func mergeConnectionFromSDK(s *ConnectionState, info *catalog.ConnectionInfo) {
+	if info == nil {
+		return
+	}
+	if info.Name != "" {
+		s.Name = info.Name
+	}
+	if info.ConnectionType != "" {
+		s.ConnectionType = string(info.ConnectionType)
+	}
+	if len(info.Options) > 0 {
+		s.Options = copyTags(info.Options)
+	}
+	if info.Comment != "" {
+		s.Comment = info.Comment
+	}
+	if len(info.Properties) > 0 {
+		s.Properties = copyTags(info.Properties)
+	}
+	s.ReadOnly = info.ReadOnly
+}

--- a/ucm/deploy/direct/import_test.go
+++ b/ucm/deploy/direct/import_test.go
@@ -1,0 +1,239 @@
+package direct_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// importFakeClient is a narrow fake that returns pre-seeded SDK responses
+// for the Get* calls used by ImportResource. Create/Update/Delete are
+// implemented as no-ops since import never issues them.
+type importFakeClient struct {
+	Catalog           *catalog.CatalogInfo
+	Schema            *catalog.SchemaInfo
+	StorageCredential *catalog.StorageCredentialInfo
+	ExternalLocation  *catalog.ExternalLocationInfo
+	Volume            *catalog.VolumeInfo
+	Connection        *catalog.ConnectionInfo
+	Err               error
+
+	LastGetName string
+}
+
+func (c *importFakeClient) GetCatalog(_ context.Context, name string) (*catalog.CatalogInfo, error) {
+	c.LastGetName = name
+	return c.Catalog, c.Err
+}
+
+func (c *importFakeClient) GetSchema(_ context.Context, fullName string) (*catalog.SchemaInfo, error) {
+	c.LastGetName = fullName
+	return c.Schema, c.Err
+}
+
+func (c *importFakeClient) GetStorageCredential(_ context.Context, name string) (*catalog.StorageCredentialInfo, error) {
+	c.LastGetName = name
+	return c.StorageCredential, c.Err
+}
+
+func (c *importFakeClient) GetExternalLocation(_ context.Context, name string) (*catalog.ExternalLocationInfo, error) {
+	c.LastGetName = name
+	return c.ExternalLocation, c.Err
+}
+
+func (c *importFakeClient) GetVolume(_ context.Context, fullName string) (*catalog.VolumeInfo, error) {
+	c.LastGetName = fullName
+	return c.Volume, c.Err
+}
+
+func (c *importFakeClient) GetConnection(_ context.Context, name string) (*catalog.ConnectionInfo, error) {
+	c.LastGetName = name
+	return c.Connection, c.Err
+}
+
+func (*importFakeClient) CreateCatalog(_ context.Context, _ catalog.CreateCatalog) (*catalog.CatalogInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) UpdateCatalog(_ context.Context, _ catalog.UpdateCatalog) (*catalog.CatalogInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) DeleteCatalog(_ context.Context, _ string) error { return nil }
+func (*importFakeClient) CreateSchema(_ context.Context, _ catalog.CreateSchema) (*catalog.SchemaInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) UpdateSchema(_ context.Context, _ catalog.UpdateSchema) (*catalog.SchemaInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) DeleteSchema(_ context.Context, _ string) error { return nil }
+func (*importFakeClient) CreateStorageCredential(_ context.Context, _ catalog.CreateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) UpdateStorageCredential(_ context.Context, _ catalog.UpdateStorageCredential) (*catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) DeleteStorageCredential(_ context.Context, _ string) error { return nil }
+func (*importFakeClient) CreateExternalLocation(_ context.Context, _ catalog.CreateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) UpdateExternalLocation(_ context.Context, _ catalog.UpdateExternalLocation) (*catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) DeleteExternalLocation(_ context.Context, _ string) error { return nil }
+func (*importFakeClient) CreateVolume(_ context.Context, _ catalog.CreateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) UpdateVolume(_ context.Context, _ catalog.UpdateVolumeRequestContent) (*catalog.VolumeInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) DeleteVolume(_ context.Context, _ string) error { return nil }
+func (*importFakeClient) CreateConnection(_ context.Context, _ catalog.CreateConnection) (*catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) UpdateConnection(_ context.Context, _ catalog.UpdateConnection) (*catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) DeleteConnection(_ context.Context, _ string) error { return nil }
+func (*importFakeClient) UpdatePermissions(_ context.Context, _ catalog.UpdatePermissions) error {
+	return nil
+}
+
+func TestImportResource_CatalogSeedsStateFromSDK(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"main": {Name: "main", Comment: "declared comment"},
+	}
+	client := &importFakeClient{Catalog: &catalog.CatalogInfo{
+		Name:        "main",
+		Comment:     "live comment",
+		StorageRoot: "s3://live",
+		Properties:  map[string]string{"owner": "team_a"},
+	}}
+	state := direct.NewState()
+
+	require.NoError(t, direct.ImportResource(t.Context(), u, client, state, "catalog", "main", "main"))
+	assert.Equal(t, "main", client.LastGetName)
+
+	got := state.Catalogs["main"]
+	require.NotNil(t, got)
+	assert.Equal(t, "main", got.Name)
+	assert.Equal(t, "live comment", got.Comment)
+	assert.Equal(t, "s3://live", got.StorageRoot)
+	assert.Equal(t, "team_a", got.Tags["owner"])
+}
+
+func TestImportResource_SchemaUsesFullName(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Schemas = map[string]*resources.Schema{
+		"raw": {Name: "raw", Catalog: "main"},
+	}
+	client := &importFakeClient{Schema: &catalog.SchemaInfo{
+		Name: "raw", CatalogName: "main", Comment: "bronze",
+	}}
+	state := direct.NewState()
+
+	require.NoError(t, direct.ImportResource(t.Context(), u, client, state, "schema", "main.raw", "raw"))
+	assert.Equal(t, "main.raw", client.LastGetName)
+
+	got := state.Schemas["raw"]
+	require.NotNil(t, got)
+	assert.Equal(t, "raw", got.Name)
+	assert.Equal(t, "main", got.Catalog)
+	assert.Equal(t, "bronze", got.Comment)
+}
+
+func TestImportResource_StorageCredentialRetainsClientSecret(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.StorageCredentials = map[string]*resources.StorageCredential{
+		"azure_sp": {
+			Name: "azure_sp",
+			AzureServicePrincipal: &resources.AzureServicePrincipal{
+				DirectoryId:   "tenant",
+				ApplicationId: "app",
+				ClientSecret:  "local-only-secret",
+			},
+		},
+	}
+	client := &importFakeClient{StorageCredential: &catalog.StorageCredentialInfo{
+		Name:    "azure_sp",
+		Comment: "live",
+		AzureServicePrincipal: &catalog.AzureServicePrincipal{
+			DirectoryId:   "tenant",
+			ApplicationId: "app",
+			// ClientSecret deliberately not echoed by UC.
+		},
+	}}
+	state := direct.NewState()
+
+	require.NoError(t, direct.ImportResource(t.Context(), u, client, state, "storage_credential", "azure_sp", "azure_sp"))
+
+	got := state.StorageCredentials["azure_sp"]
+	require.NotNil(t, got)
+	require.NotNil(t, got.AzureServicePrincipal)
+	assert.Equal(t, "local-only-secret", got.AzureServicePrincipal.ClientSecret)
+}
+
+func TestImportResource_VolumeUsesFullName(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Volumes = map[string]*resources.Volume{
+		"docs": {Name: "docs", CatalogName: "main", SchemaName: "raw", VolumeType: "MANAGED"},
+	}
+	client := &importFakeClient{Volume: &catalog.VolumeInfo{
+		Name: "docs", CatalogName: "main", SchemaName: "raw", VolumeType: catalog.VolumeTypeManaged,
+	}}
+	state := direct.NewState()
+
+	require.NoError(t, direct.ImportResource(t.Context(), u, client, state, "volume", "main.raw.docs", "docs"))
+	assert.Equal(t, "main.raw.docs", client.LastGetName)
+
+	got := state.Volumes["docs"]
+	require.NotNil(t, got)
+	assert.Equal(t, "docs", got.Name)
+	assert.Equal(t, "MANAGED", got.VolumeType)
+}
+
+func TestImportResource_ConnectionCopiesOptions(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Connections = map[string]*resources.Connection{
+		"mysql_prod": {Name: "mysql_prod", ConnectionType: "MYSQL"},
+	}
+	client := &importFakeClient{Connection: &catalog.ConnectionInfo{
+		Name:           "mysql_prod",
+		ConnectionType: catalog.ConnectionTypeMysql,
+		Options:        map[string]string{"host": "db.example.com"},
+	}}
+	state := direct.NewState()
+
+	require.NoError(t, direct.ImportResource(t.Context(), u, client, state, "connection", "mysql_prod", "mysql_prod"))
+
+	got := state.Connections["mysql_prod"]
+	require.NotNil(t, got)
+	assert.Equal(t, "db.example.com", got.Options["host"])
+}
+
+func TestImportResource_UnknownKindErrors(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	state := direct.NewState()
+
+	err := direct.ImportResource(t.Context(), u, &importFakeClient{}, state, "table", "foo", "foo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported import kind")
+}
+
+func TestImportResource_PropagatesSDKError(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	u.Config.Resources.Catalogs = map[string]*resources.Catalog{"main": {Name: "main"}}
+	sentinel := errors.New("sdk boom")
+	client := &importFakeClient{Err: sentinel}
+	state := direct.NewState()
+
+	err := direct.ImportResource(t.Context(), u, client, state, "catalog", "main", "main")
+	require.ErrorIs(t, err, sentinel)
+}

--- a/ucm/deploy/terraform/fakerunner_test.go
+++ b/ucm/deploy/terraform/fakerunner_test.go
@@ -20,12 +20,17 @@ type fakeRunner struct {
 	ShowPlanFileCalls int
 	ApplyCalls        int
 	DestroyCalls      int
+	ImportCalls       int
 	SetEnvCalls       int
 
 	// LastEnv captures the map passed to the most recent SetEnv call.
 	LastEnv map[string]string
 	// LastApplyOpts captures the options passed to the most recent Apply call.
 	LastApplyOpts []tfexec.ApplyOption
+	// LastImportAddress and LastImportId capture the args passed to the most
+	// recent Import call.
+	LastImportAddress string
+	LastImportId      string
 
 	// PlanHasChanges is returned by Plan.
 	PlanHasChanges bool
@@ -33,18 +38,21 @@ type fakeRunner struct {
 	// (no resource changes) so callers don't need to set it for zero-diff
 	// tests.
 	ShowPlanResult *tfjson.Plan
-	// ApplyErr, InitErr, DestroyErr, PlanErr, ShowPlanFileErr make the next
-	// corresponding call return the given error.
-	InitErr          error
-	PlanErr          error
-	ShowPlanFileErr  error
-	ApplyErr         error
-	DestroyErr       error
+	// ApplyErr, InitErr, DestroyErr, PlanErr, ShowPlanFileErr, ImportErr make
+	// the next corresponding call return the given error.
+	InitErr         error
+	PlanErr         error
+	ShowPlanFileErr error
+	ApplyErr        error
+	DestroyErr      error
+	ImportErr       error
 
 	// ApplyHook is invoked synchronously inside Apply before returning. Used
 	// by the lock contention test to hold the lock while a second goroutine
 	// tries to acquire it.
 	ApplyHook func(ctx context.Context)
+	// ImportHook mirrors ApplyHook for the Import path.
+	ImportHook func(ctx context.Context)
 }
 
 func (f *fakeRunner) Init(_ context.Context, _ ...tfexec.InitOption) error {
@@ -94,6 +102,20 @@ func (f *fakeRunner) Destroy(_ context.Context, _ ...tfexec.DestroyOption) error
 	f.DestroyCalls++
 	err := f.DestroyErr
 	f.mu.Unlock()
+	return err
+}
+
+func (f *fakeRunner) Import(ctx context.Context, address, id string, _ ...tfexec.ImportOption) error {
+	f.mu.Lock()
+	f.ImportCalls++
+	f.LastImportAddress = address
+	f.LastImportId = id
+	hook := f.ImportHook
+	err := f.ImportErr
+	f.mu.Unlock()
+	if hook != nil {
+		hook(ctx)
+	}
 	return err
 }
 

--- a/ucm/deploy/terraform/import.go
+++ b/ucm/deploy/terraform/import.go
@@ -1,0 +1,51 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+)
+
+// Import acquires the U2 deployment lock and runs `terraform import <address>
+// <id>` in the working directory. Init is called first so main.tf.json is
+// current and the provider is installed — import needs the resource block to
+// exist in config before it can attach the id to it.
+//
+// The lock is released on defer with GoalDeploy. State mutations made by
+// terraform import land in <workingDir>/terraform.tfstate; the caller is
+// responsible for pushing that state via deploy.Push afterwards.
+func (t *Terraform) Import(ctx context.Context, u *ucm.Ucm, address, id string) error {
+	if t == nil {
+		return fmt.Errorf("terraform: nil wrapper")
+	}
+
+	if err := t.Init(ctx, u); err != nil {
+		return err
+	}
+
+	factory := t.lockerFactory
+	if factory == nil {
+		factory = defaultLockerFactory
+	}
+	locker, err := factory(ctx, u, t.user)
+	if err != nil {
+		return fmt.Errorf("create deployment locker: %w", err)
+	}
+	if err := locker.Acquire(ctx, false); err != nil {
+		return err
+	}
+	defer func() {
+		if relErr := locker.Release(ctx, lock.GoalDeploy); relErr != nil {
+			log.Warnf(ctx, "terraform import: release lock: %v", relErr)
+		}
+	}()
+
+	if err := t.runner.Import(ctx, address, id); err != nil {
+		return fmt.Errorf("terraform import %s %s: %w", address, id, err)
+	}
+	log.Infof(ctx, "terraform import %s %s completed", address, id)
+	return nil
+}

--- a/ucm/deploy/terraform/import_test.go
+++ b/ucm/deploy/terraform/import_test.go
@@ -1,0 +1,89 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newImportTerraform(t *testing.T, u *ucm.Ucm, runner *fakeRunner, lf lockerFactory, user string) *Terraform {
+	t.Helper()
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+	return &Terraform{
+		ExecPath:      "/stub/terraform",
+		WorkingDir:    workingDir,
+		Env:           map[string]string{"DATABRICKS_HOST": "https://example.cloud.databricks.com"},
+		runnerFactory: newFakeRunnerFactory(runner),
+		lockerFactory: lf,
+		user:          user,
+	}
+}
+
+func TestImportRunsUnderLock(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	runner := &fakeRunner{}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newImportTerraform(t, u, runner, factory, "alice")
+
+	require.NoError(t, tf.Import(t.Context(), u, "databricks_catalog.sales", "sales_prod"))
+	assert.Equal(t, 1, runner.ImportCalls)
+	assert.Equal(t, "databricks_catalog.sales", runner.LastImportAddress)
+	assert.Equal(t, "sales_prod", runner.LastImportId)
+	// Lock is released on defer — next Import should succeed too.
+	require.NoError(t, tf.Import(t.Context(), u, "databricks_catalog.sales", "sales_prod"))
+	assert.Equal(t, 2, runner.ImportCalls)
+}
+
+func TestImportLockContentionReturnsErrLockHeld(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	factory, _ := sharedLockerFactory(t, "shared")
+
+	hold := make(chan struct{})
+	release := make(chan struct{})
+	firstRunner := &fakeRunner{
+		ImportHook: func(_ context.Context) {
+			close(hold)
+			<-release
+		},
+	}
+	firstTf := newImportTerraform(t, u, firstRunner, factory, "alice")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- firstTf.Import(t.Context(), u, "databricks_catalog.sales", "sales_prod")
+	}()
+
+	<-hold
+
+	secondRunner := &fakeRunner{}
+	secondTf := newImportTerraform(t, u, secondRunner, factory, "bob")
+
+	err := secondTf.Import(t.Context(), u, "databricks_catalog.sales", "sales_prod")
+	require.Error(t, err)
+	var held *lock.ErrLockHeld
+	require.True(t, errors.As(err, &held), "expected ErrLockHeld, got %T: %v", err, err)
+	assert.Equal(t, "alice", held.Holder)
+	assert.Equal(t, 0, secondRunner.ImportCalls, "second Import must not invoke the runner")
+
+	close(release)
+	require.NoError(t, <-errCh)
+}
+
+func TestImportPropagatesRunnerError(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	sentinel := errors.New("import boom")
+	runner := &fakeRunner{ImportErr: sentinel}
+	factory, _ := sharedLockerFactory(t, "alice")
+	tf := newImportTerraform(t, u, runner, factory, "alice")
+
+	err := tf.Import(t.Context(), u, "databricks_catalog.sales", "sales_prod")
+	require.Error(t, err)
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, runner.ImportCalls)
+}

--- a/ucm/deploy/terraform/terraform.go
+++ b/ucm/deploy/terraform/terraform.go
@@ -30,6 +30,7 @@ type tfRunner interface {
 	ShowPlanFile(ctx context.Context, planPath string, opts ...tfexec.ShowOption) (*tfjson.Plan, error)
 	Apply(ctx context.Context, opts ...tfexec.ApplyOption) error
 	Destroy(ctx context.Context, opts ...tfexec.DestroyOption) error
+	Import(ctx context.Context, address, id string, opts ...tfexec.ImportOption) error
 	SetEnv(env map[string]string) error
 }
 

--- a/ucm/phases/helpers_test.go
+++ b/ucm/phases/helpers_test.go
@@ -30,12 +30,17 @@ type fakeTf struct {
 	PlanCalls    int
 	ApplyCalls   int
 	DestroyCalls int
+	ImportCalls  int
 
 	RenderErr  error
 	InitErr    error
 	PlanErr    error
 	ApplyErr   error
 	DestroyErr error
+	ImportErr  error
+
+	LastImportAddress string
+	LastImportId      string
 
 	PlanResult *terraform.PlanResult
 }
@@ -73,6 +78,15 @@ func (f *fakeTf) Destroy(_ context.Context, _ *ucm.Ucm) error {
 	defer f.mu.Unlock()
 	f.DestroyCalls++
 	return f.DestroyErr
+}
+
+func (f *fakeTf) Import(_ context.Context, _ *ucm.Ucm, address, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ImportCalls++
+	f.LastImportAddress = address
+	f.LastImportId = id
+	return f.ImportErr
 }
 
 // fixture bundles the dependencies every phase test needs: a minimal Ucm with

--- a/ucm/phases/import.go
+++ b/ucm/phases/import.go
@@ -1,0 +1,174 @@
+package phases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/deploy/direct"
+)
+
+// ImportKind identifies the resource kind an Import call targets.
+// The string value matches the CLI argument the user types.
+type ImportKind string
+
+const (
+	ImportCatalog           ImportKind = "catalog"
+	ImportSchema            ImportKind = "schema"
+	ImportStorageCredential ImportKind = "storage_credential"
+	ImportExternalLocation  ImportKind = "external_location"
+	ImportVolume            ImportKind = "volume"
+	ImportConnection        ImportKind = "connection"
+)
+
+// ImportRequest bundles the operator-supplied inputs for a single import.
+// Name is the UC identifier (e.g. "sales_prod" for a catalog, "sales.raw"
+// for a schema); Key is the ucm.yml map key the imported object will be
+// recorded under.
+type ImportRequest struct {
+	Kind ImportKind
+	Name string
+	Key  string
+}
+
+// Import resolves the deployment engine and dispatches to the direct or
+// terraform implementation. Errors are reported via logdiag; callers must
+// check logdiag.HasError before continuing. The terraform path pushes state
+// on success; the direct path rewrites resources.json in place.
+func Import(ctx context.Context, u *ucm.Ucm, opts Options, req ImportRequest) {
+	log.Infof(ctx, "Phase: import %s %s", req.Kind, req.Name)
+
+	setting := Initialize(ctx, u, opts)
+	if logdiag.HasError(ctx) {
+		return
+	}
+
+	if err := validateResourceDeclared(u, req); err != nil {
+		logdiag.LogError(ctx, err)
+		return
+	}
+
+	if setting.Type.IsDirect() {
+		importDirect(ctx, u, opts, req)
+		return
+	}
+	importTerraform(ctx, u, opts, req)
+}
+
+// validateResourceDeclared errors out when the ucm.yml map for the given
+// kind does not contain the requested key. Import is a bind-to-existing
+// operation — it refuses to seed state for an undeclared resource.
+func validateResourceDeclared(u *ucm.Ucm, req ImportRequest) error {
+	declared := false
+	switch req.Kind {
+	case ImportCatalog:
+		_, declared = u.Config.Resources.Catalogs[req.Key]
+	case ImportSchema:
+		_, declared = u.Config.Resources.Schemas[req.Key]
+	case ImportStorageCredential:
+		_, declared = u.Config.Resources.StorageCredentials[req.Key]
+	case ImportExternalLocation:
+		_, declared = u.Config.Resources.ExternalLocations[req.Key]
+	case ImportVolume:
+		_, declared = u.Config.Resources.Volumes[req.Key]
+	case ImportConnection:
+		_, declared = u.Config.Resources.Connections[req.Key]
+	default:
+		return fmt.Errorf("ucm import: unsupported kind %q", req.Kind)
+	}
+	if !declared {
+		return fmt.Errorf("ucm import: resources.%s.%s is not declared in ucm.yml — "+
+			"run `ucm import` only after declaring the resource in ucm.yml; "+
+			"then ucm import will bind state to the existing UC object", pluralKind(req.Kind), req.Key)
+	}
+	return nil
+}
+
+// pluralKind maps ImportKind to the ucm.yml map name under resources.
+// Kept local so the CLI layer never has to spell these strings out.
+func pluralKind(k ImportKind) string {
+	switch k {
+	case ImportCatalog:
+		return "catalogs"
+	case ImportSchema:
+		return "schemas"
+	case ImportStorageCredential:
+		return "storage_credentials"
+	case ImportExternalLocation:
+		return "external_locations"
+	case ImportVolume:
+		return "volumes"
+	case ImportConnection:
+		return "connections"
+	}
+	return string(k)
+}
+
+// terraformAddress builds the `databricks_<type>.<key>` address the terraform
+// provider expects for the given resource.
+func terraformAddress(req ImportRequest) string {
+	return "databricks_" + string(req.Kind) + "." + req.Key
+}
+
+func importTerraform(ctx context.Context, u *ucm.Ucm, opts Options, req ImportRequest) {
+	factory := opts.terraformFactoryOrDefault()
+	tf, err := factory(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("build terraform wrapper: %w", err))
+		return
+	}
+
+	if err := tf.Render(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("render terraform config: %w", err))
+		return
+	}
+
+	if err := tf.Init(ctx, u); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform init: %w", err))
+		return
+	}
+
+	if err := tf.Import(ctx, u, terraformAddress(req), req.Name); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("terraform import: %w", err))
+		return
+	}
+
+	if err := deploy.Push(ctx, u, opts.Backend); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("push remote state: %w", err))
+		return
+	}
+}
+
+func importDirect(ctx context.Context, u *ucm.Ucm, opts Options, req ImportRequest) {
+	ucm.ApplyContext(ctx, u, mutator.ResolveResourceReferences())
+	if logdiag.HasError(ctx) {
+		return
+	}
+
+	factory := opts.directClientFactoryOrDefault()
+	client, err := factory(ctx, u)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("resolve direct client: %w", err))
+		return
+	}
+
+	statePath := direct.StatePath(u)
+	state, err := direct.LoadState(statePath)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		return
+	}
+
+	if err := direct.ImportResource(ctx, u, client, state, string(req.Kind), req.Name, req.Key); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("direct import: %w", err))
+		return
+	}
+
+	if err := direct.SaveState(statePath, state); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("save direct state: %w", err))
+	}
+}

--- a/ucm/phases/import_test.go
+++ b/ucm/phases/import_test.go
@@ -1,0 +1,65 @@
+package phases_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/phases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportTerraformEngineRunsImportAndPushes(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"main": {Name: "main"},
+	}
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Import(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	}, phases.ImportRequest{Kind: phases.ImportCatalog, Name: "main", Key: "main"})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	assert.Equal(t, 1, f.tf.ImportCalls)
+	assert.Equal(t, "databricks_catalog.main", f.tf.LastImportAddress)
+	assert.Equal(t, "main", f.tf.LastImportId)
+	assert.Equal(t, 1, readRemoteSeq(t, f), "successful import must push remote state")
+}
+
+func TestImportRequiresDeclaredResource(t *testing.T) {
+	f := newFixture(t)
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Import(ctx, f.u, phases.Options{
+		Backend:          f.backend,
+		TerraformFactory: fakeTfFactory(f.tf),
+	}, phases.ImportRequest{Kind: phases.ImportCatalog, Name: "ghost", Key: "ghost"})
+
+	require.True(t, logdiag.HasError(ctx))
+	assert.Equal(t, 0, f.tf.ImportCalls)
+}
+
+func TestImportDirectEngineSkipsTerraform(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"main": {Name: "main"},
+	}
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Import(ctx, f.u, phases.Options{
+		TerraformFactory:    fakeTfFactory(f.tf),
+		DirectClientFactory: fakeDirectClientFactory(),
+	}, phases.ImportRequest{Kind: phases.ImportCatalog, Name: "main", Key: "main"})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	assert.Equal(t, 0, f.tf.ImportCalls, "direct engine must not invoke the terraform wrapper")
+	assert.Equal(t, -1, readRemoteSeq(t, f), "direct engine must never push remote state")
+}

--- a/ucm/phases/options.go
+++ b/ucm/phases/options.go
@@ -19,6 +19,7 @@ type TerraformWrapper interface {
 	Plan(ctx context.Context, u *ucm.Ucm) (*terraform.PlanResult, error)
 	Apply(ctx context.Context, u *ucm.Ucm) error
 	Destroy(ctx context.Context, u *ucm.Ucm) error
+	Import(ctx context.Context, u *ucm.Ucm, address, id string) error
 }
 
 // TerraformFactory constructs a terraform-engine wrapper scoped to u.


### PR DESCRIPTION
Closes #69

## Summary

Native `ucm import <kind> <name>` verb. No DAB equivalent; designed following DAB's cobra conventions. Engine-aware:

- **direct**: `client.Get<Kind>(ctx, name)` → overlay SDK fields onto config-derived `*State` → `direct.SaveState`.
- **terraform**: new `terraform.Terraform.Import(ctx, u, address, id)` wrapping `runner.Import` under the deploy lock → `deploy.Push` to upload the updated tfstate.

## Supported kinds

`catalog`, `schema`, `storage_credential`, `external_location`, `volume`, `connection`. Grants intentionally unsupported (they reconcile by securable).

## Flags

- `<kind>`, `<name>` — positional args.
- `--key <ucmYmlKey>` — map key to bind under. Default: UC name for flat kinds; last path component for schemas/volumes.
- `--auto-approve` — skip confirmation.
- `--target` — standard.

## Key behaviors

- PreRunE: `utils.MustWorkspaceClient`.
- Refuses import when resource is absent from ucm.yml — tells the user to declare first.
- Azure SP `ClientSecret` preserved from config (UC never echoes secrets).
- Terraform address = `databricks_<kind>.<key>`; id = UC name as typed.

## Test plan

- [x] go build / vet / test all green.
- [x] Per-kind direct-engine happy paths + Azure SP secret retention + unknown-kind + SDK-error cases.
- [x] Terraform wrapper lock-contention + runner-error tests.