### PR TITLE
Feat #38: Add ucm include: directive with glob expansion

### DIFF
--- a/ucm/config/loader/process_include.go
+++ b/ucm/config/loader/process_include.go
@@ -1,0 +1,55 @@
+// Package loader holds mutators that load ucm.yml (or partial) configuration
+// files from disk and merge them into the root Config tree. Forked from
+// bundle/config/loader with DAB-specific pieces (resource-format heuristics)
+// dropped.
+package loader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+)
+
+type processInclude struct {
+	fullPath string
+	relPath  string
+}
+
+// ProcessInclude loads the configuration at [fullPath] and merges it into the
+// root ucm configuration.
+func ProcessInclude(fullPath, relPath string) ucm.Mutator {
+	return &processInclude{fullPath: fullPath, relPath: relPath}
+}
+
+func (m *processInclude) Name() string {
+	return fmt.Sprintf("ProcessInclude(%s)", m.relPath)
+}
+
+func (m *processInclude) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	this, diags := config.Load(m.fullPath)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Included files are not allowed to declare their own include section —
+	// matches DAB.
+	if len(this.Include) > 0 {
+		diags = diags.Append(diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Include section is defined outside root file",
+			Detail: `An include section is defined in a file that is not ucm.yml.
+Only includes defined in ucm.yml are applied.`,
+			Locations: this.GetLocations("include"),
+			Paths:     []dyn.Path{dyn.MustPathFromString("include")},
+		})
+	}
+
+	if err := u.Config.Merge(this); err != nil {
+		diags = diags.Extend(diag.FromErr(err))
+	}
+	return diags
+}

--- a/ucm/config/loader/process_include_test.go
+++ b/ucm/config/loader/process_include_test.go
@@ -1,0 +1,52 @@
+package loader_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/loader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessIncludeMerges(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, filepath.Join(root, "ucm.yml"), "ucm: {name: main}\n")
+	testutil.WriteFile(t, filepath.Join(root, "extra.yml"), `
+workspace:
+  host: https://bar.cloud.databricks.com
+`)
+
+	cfg, diags := config.Load(filepath.Join(root, "ucm.yml"))
+	require.NoError(t, diags.Error())
+	u := &ucm.Ucm{RootPath: root, Config: *cfg}
+
+	m := loader.ProcessInclude(filepath.Join(root, "extra.yml"), "extra.yml")
+	assert.Equal(t, "ProcessInclude(extra.yml)", m.Name())
+
+	out := ucm.Apply(t.Context(), u, m)
+	require.NoError(t, out.Error())
+	assert.Equal(t, "https://bar.cloud.databricks.com", u.Config.Workspace.Host)
+	assert.Equal(t, "main", u.Config.Ucm.Name)
+}
+
+func TestProcessIncludeWarnsOnNestedInclude(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, filepath.Join(root, "ucm.yml"), "ucm: {name: main}\n")
+	testutil.WriteFile(t, filepath.Join(root, "extra.yml"), `
+include:
+  - other.yml
+`)
+
+	cfg, diags := config.Load(filepath.Join(root, "ucm.yml"))
+	require.NoError(t, diags.Error())
+	u := &ucm.Ucm{RootPath: root, Config: *cfg}
+
+	out := ucm.Apply(t.Context(), u, loader.ProcessInclude(filepath.Join(root, "extra.yml"), "extra.yml"))
+	require.NoError(t, out.Error())
+	require.Len(t, out, 1)
+	assert.Contains(t, out[0].Summary, "Include section is defined outside root file")
+}

--- a/ucm/config/loader/process_root_includes.go
+++ b/ucm/config/loader/process_root_includes.go
@@ -1,0 +1,115 @@
+package loader
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+)
+
+type processRootIncludes struct{}
+
+// ProcessRootIncludes expands every glob in Root.Include into matching files
+// and loads each through ProcessInclude.
+func ProcessRootIncludes() ucm.Mutator {
+	return &processRootIncludes{}
+}
+
+func (m *processRootIncludes) Name() string {
+	return "ProcessRootIncludes"
+}
+
+// globChars enumerates the metacharacters recognized by [filepath.Glob]; a
+// ucm root path that contains any of them is rejected outright.
+var globChars = []string{"*", "?", "[", "]", "^"}
+
+func hasGlobCharacters(path string) (string, bool) {
+	for _, c := range globChars {
+		if strings.Contains(path, c) {
+			return c, true
+		}
+	}
+	return "", false
+}
+
+func (m *processRootIncludes) Apply(ctx context.Context, u *ucm.Ucm) diag.Diagnostics {
+	var out []ucm.Mutator
+
+	// Root ucm.yml filenames are already loaded — skip them if they happen to
+	// match an include glob.
+	seen := map[string]bool{}
+	for _, file := range config.FileNames {
+		seen[file] = true
+	}
+
+	var files []string
+	var diags diag.Diagnostics
+
+	// Reject glob metacharacters in the root path: filepath.Glob would parse
+	// them as patterns and produce surprising behavior.
+	if char, ok := hasGlobCharacters(u.RootPath); ok {
+		return diags.Append(diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Ucm root path contains glob pattern characters",
+			Detail:   fmt.Sprintf("The path to the ucm root %s contains glob pattern character %q. Please remove the character from this path to use ucm commands.", u.RootPath, char),
+		})
+	}
+
+	for _, entry := range u.Config.Include {
+		if filepath.IsAbs(entry) {
+			return diag.Errorf("%s: includes must be relative paths", entry)
+		}
+
+		matches, err := filepath.Glob(filepath.Join(u.RootPath, entry))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		// A literal (non-glob) entry with no match is an error; a glob entry
+		// that matched nothing only logs a warning (matches DAB behavior).
+		if len(matches) == 0 && !strings.ContainsAny(entry, "*?[") {
+			return diag.Errorf("%s defined in 'include' section does not match any files", entry)
+		}
+
+		var includes []string
+		for i, match := range matches {
+			rel, err := filepath.Rel(u.RootPath, match)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if _, ok := seen[rel]; ok {
+				continue
+			}
+			seen[rel] = true
+			if ext := filepath.Ext(rel); ext != ".yaml" && ext != ".yml" && ext != ".json" {
+				diags = diags.Append(diag.Diagnostic{
+					Severity:  diag.Error,
+					Summary:   "Files in the 'include' configuration section must be YAML or JSON files.",
+					Detail:    fmt.Sprintf("The file %s in the 'include' configuration section is not a YAML or JSON file, and only such files are supported.", rel),
+					Locations: u.Config.GetLocations(fmt.Sprintf("include[%d]", i)),
+				})
+				continue
+			}
+			includes = append(includes, rel)
+		}
+
+		if len(diags) > 0 {
+			return diags
+		}
+
+		slices.Sort(includes)
+		files = append(files, includes...)
+		for _, include := range includes {
+			out = append(out, ProcessInclude(filepath.Join(u.RootPath, include), include))
+		}
+	}
+
+	u.Config.Include = files
+	ucm.ApplySeqContext(ctx, u, out...)
+	return nil
+}

--- a/ucm/config/loader/process_root_includes_test.go
+++ b/ucm/config/loader/process_root_includes_test.go
@@ -1,0 +1,145 @@
+package loader_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/loader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessRootIncludesEmpty(t *testing.T) {
+	u := &ucm.Ucm{RootPath: "."}
+	diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.NoError(t, diags.Error())
+}
+
+func TestProcessRootIncludesAbsRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows absolute path check exercised elsewhere")
+	}
+
+	u := &ucm.Ucm{
+		RootPath: ".",
+		Config:   config.Root{Include: []string{"/tmp/*.yml"}},
+	}
+	diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.True(t, diags.HasError())
+	assert.ErrorContains(t, diags.Error(), "must be relative paths")
+}
+
+func TestProcessRootIncludesSingleGlob(t *testing.T) {
+	root := t.TempDir()
+	testutil.Touch(t, root, "ucm.yml")
+	testutil.Touch(t, root, "a.yml")
+	testutil.Touch(t, root, "b.yml")
+
+	u := &ucm.Ucm{RootPath: root, Config: config.Root{Include: []string{"*.yml"}}}
+	diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.NoError(t, diags.Error())
+	assert.Equal(t, []string{"a.yml", "b.yml"}, u.Config.Include)
+}
+
+func TestProcessRootIncludesMultiGlob(t *testing.T) {
+	root := t.TempDir()
+	testutil.Touch(t, root, "a1.yml")
+	testutil.Touch(t, root, "b1.yml")
+
+	u := &ucm.Ucm{RootPath: root, Config: config.Root{Include: []string{"a*.yml", "b*.yml"}}}
+	diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.NoError(t, diags.Error())
+	assert.Equal(t, []string{"a1.yml", "b1.yml"}, u.Config.Include)
+}
+
+func TestProcessRootIncludesDedup(t *testing.T) {
+	root := t.TempDir()
+	testutil.Touch(t, root, "a.yml")
+
+	u := &ucm.Ucm{RootPath: root, Config: config.Root{Include: []string{"*.yml", "*.yml"}}}
+	diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.NoError(t, diags.Error())
+	assert.Equal(t, []string{"a.yml"}, u.Config.Include)
+}
+
+func TestProcessRootIncludesLiteralMissingIsError(t *testing.T) {
+	u := &ucm.Ucm{RootPath: t.TempDir(), Config: config.Root{Include: []string{"notexist.yml"}}}
+	diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.True(t, diags.HasError())
+	assert.ErrorContains(t, diags.Error(), "notexist.yml defined in 'include' section does not match any files")
+}
+
+func TestProcessRootIncludesGlobMissingIsOk(t *testing.T) {
+	u := &ucm.Ucm{RootPath: t.TempDir(), Config: config.Root{Include: []string{"*.yml"}}}
+	diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.NoError(t, diags.Error())
+	assert.Empty(t, u.Config.Include)
+}
+
+func TestProcessRootIncludesMergesFiles(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, filepath.Join(root, "ucm.yml"), `
+ucm: {name: main}
+include:
+  - parts/*.yml
+`)
+	testutil.WriteFile(t, filepath.Join(root, "parts", "a.yml"), `
+workspace:
+  host: https://a.example.com
+`)
+	testutil.WriteFile(t, filepath.Join(root, "parts", "b.yml"), `
+resources:
+  catalogs:
+    c1: {name: c1}
+`)
+
+	cfg, diags := config.Load(filepath.Join(root, "ucm.yml"))
+	require.NoError(t, diags.Error())
+	u := &ucm.Ucm{RootPath: root, Config: *cfg}
+
+	out := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.NoError(t, out.Error())
+	assert.Equal(t, "https://a.example.com", u.Config.Workspace.Host)
+	require.NotNil(t, u.Config.Resources.Catalogs)
+	assert.Contains(t, u.Config.Resources.Catalogs, "c1")
+	assert.Equal(t, []string{filepath.Join("parts", "a.yml"), filepath.Join("parts", "b.yml")}, u.Config.Include)
+}
+
+func TestProcessRootIncludesRejectsNonYAML(t *testing.T) {
+	root := t.TempDir()
+	testutil.Touch(t, root, "a.txt")
+
+	u := &ucm.Ucm{RootPath: root, Config: config.Root{Include: []string{"a.txt"}}}
+	diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+	require.True(t, diags.HasError())
+	assert.ErrorContains(t, diags.Error(), "is not a YAML or JSON file")
+}
+
+func TestProcessRootIncludesGlobInRootPath(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+		char string
+	}{
+		{"star", "foo/a*", "*"},
+		{"question", "bar/?b", "?"},
+		{"left-bracket", "[ab", "["},
+		{"right-bracket", "ab]/bax", "]"},
+		{"hat", "ab^bax", "^"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &ucm.Ucm{RootPath: tc.root}
+			diags := ucm.Apply(t.Context(), u, loader.ProcessRootIncludes())
+			require.True(t, diags.HasError())
+			require.Len(t, diags, 1)
+			assert.Equal(t, diag.Error, diags[0].Severity)
+			assert.Contains(t, diags[0].Detail, tc.char)
+		})
+	}
+}

--- a/ucm/config/root.go
+++ b/ucm/config/root.go
@@ -33,8 +33,23 @@ type Root struct {
 
 	Resources Resources `json:"resources,omitempty"`
 
+	// Include lists glob patterns of additional files to merge into the root
+	// configuration. Only honored in the root ucm.yml (included files cannot
+	// themselves declare an Include). Expanded by ProcessRootIncludes.
+	Include []string `json:"include,omitempty"`
+
 	// Targets is set to nil by SelectTarget once a target has been merged.
 	Targets map[string]*Target `json:"targets,omitempty"`
+}
+
+// GetLocations returns the source locations of the configuration value at the
+// given dotted path, or nil if the path is not set.
+func (r Root) GetLocations(path string) []dyn.Location {
+	v, err := dyn.Get(r.value, path)
+	if err != nil {
+		return nil
+	}
+	return v.Locations()
 }
 
 // Load reads a ucm.yml file from disk.

--- a/ucm/phases/load.go
+++ b/ucm/phases/load.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/loader"
 	"github.com/databricks/cli/ucm/config/mutator"
 )
 
@@ -13,6 +14,7 @@ import (
 // the user did not pass --target.
 func LoadDefaultTarget(ctx context.Context, u *ucm.Ucm) {
 	ucm.ApplySeqContext(ctx, u,
+		loader.ProcessRootIncludes(),
 		mutator.FlattenNestedResources(),
 		mutator.InheritCatalogTags(),
 		mutator.DefineDefaultTarget(),
@@ -24,6 +26,7 @@ func LoadDefaultTarget(ctx context.Context, u *ucm.Ucm) {
 // --target <name>.
 func LoadNamedTarget(ctx context.Context, u *ucm.Ucm, name string) {
 	ucm.ApplySeqContext(ctx, u,
+		loader.ProcessRootIncludes(),
 		mutator.FlattenNestedResources(),
 		mutator.InheritCatalogTags(),
 		mutator.DefineDefaultTarget(),


### PR DESCRIPTION
Closes #38
Parent: #36 (M2 umbrella)

## Summary

Mirrors DAB's include machinery (`bundle/config/loader/process_include.go` + `process_root_includes.go`), fork-and-adapt. No `bundle/**` imports.

```yaml
# ucm.yml
include:
  - targets/*.yml
  - resources/*.yml
```

Each glob matches files at the ucm root, which are loaded and merged into the root config via the existing `config.Root.Merge`.

## Semantics — matches DAB exactly

- Literal path missing → error.
- Glob with no matches → no error (mirrors DAB).
- Absolute paths rejected → error.
- Non-YAML files rejected → error.
- Nested `include:` in an included file emits a `diag.Warning` ("Include section is defined outside root file") and the file is otherwise merged. Single-hop expansion only.

## Wiring

`loader.ProcessRootIncludes()` is the first mutator in both `LoadDefaultTarget` and `LoadNamedTarget`, before `FlattenNestedResources` so includes are expanded before any structural passes.

## Test plan

- [x] `go build ./...` / `go vet` / `go test ./cmd/ucm/... ./ucm/...` all green.
- [x] 10 test cases in `ucm/config/loader/`: single-file merge, nested-include warning, empty include, absolute-path rejection, single glob, multi glob, dedup, missing literal, missing glob, non-YAML rejection, glob chars in root path, full end-to-end multi-file merge.