### PR TITLE
Feat #39 #40: Add ucm validator pack (raw + post-interpolation)

### DIFF
--- a/ucm/config/validate/all.go
+++ b/ucm/config/validate/all.go
@@ -1,0 +1,20 @@
+package validate
+
+import (
+	"context"
+
+	"github.com/databricks/cli/ucm"
+)
+
+// All runs the full raw-config validator pack against u in order.
+//
+// Each validator logs its own diagnostics through the usual ApplyContext
+// plumbing; the sequence stops as soon as any one logs an error. Callers
+// should check logdiag.HasError(ctx) after this returns.
+func All(ctx context.Context, u *ucm.Ucm) {
+	ucm.ApplySeqContext(ctx, u,
+		RequiredFields(),
+		Naming(),
+		UniqueResourceKeys(),
+	)
+}

--- a/ucm/config/validate/naming.go
+++ b/ucm/config/validate/naming.go
@@ -1,0 +1,154 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/ucm"
+)
+
+// Naming enforces identifier rules on resource map keys and on UC names.
+//
+//   - Map keys under resources.<kind>.<key> must match [A-Za-z_][A-Za-z0-9_-]*
+//     and be ≤128 chars. No dots, slashes, or whitespace — these break
+//     ${resources.<kind>.<key>.<field>} interpolation.
+//   - UC names (catalog.name, schema.name, etc.) must not contain slashes or
+//     leading/trailing whitespace. Max 255 chars.
+//
+// Stricter UC identifier rules (reserved words, case handling) are a server-
+// side concern and not replicated here.
+func Naming() ucm.Mutator { return &naming{} }
+
+type naming struct{}
+
+func (m *naming) Name() string { return "validate:naming" }
+
+const (
+	maxKeyLen  = 128
+	maxUCName  = 255
+	keyPattern = `^[A-Za-z_][A-Za-z0-9_-]*$`
+)
+
+var keyRegex = regexp.MustCompile(keyPattern)
+
+func (m *naming) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, kind := range resourceKinds {
+		for _, key := range resourceKeysOf(u, kind) {
+			if d := validateKey(u, kind, key); d != nil {
+				diags = append(diags, *d)
+			}
+			if d := validateUCName(u, kind, key); d != nil {
+				diags = append(diags, *d)
+			}
+		}
+	}
+	return diags
+}
+
+func validateKey(u *ucm.Ucm, kind, key string) *diag.Diagnostic {
+	if keyRegex.MatchString(key) && len(key) <= maxKeyLen {
+		return nil
+	}
+	p := resourcePath(kind, key)
+	return &diag.Diagnostic{
+		Severity: diag.Error,
+		Summary: fmt.Sprintf(
+			"resource key %q under resources.%s is invalid (must match %s, max %d chars)",
+			key, kind, keyPattern, maxKeyLen,
+		),
+		Paths:     []dyn.Path{p},
+		Locations: locationsAt(u, p),
+	}
+}
+
+// validateUCName checks the `name` field (and other UC-name-bearing fields)
+// for slash characters or overlong values. Grants carry no `name` field; they
+// are skipped.
+func validateUCName(u *ucm.Ucm, kind, key string) *diag.Diagnostic {
+	name, field, ok := ucNameOf(u, kind, key)
+	if !ok || name == "" {
+		return nil
+	}
+	if !containsForbidden(name) && len(name) <= maxUCName {
+		return nil
+	}
+	p := resourcePath(kind, key).Append(dyn.Key(field))
+	return &diag.Diagnostic{
+		Severity: diag.Error,
+		Summary: fmt.Sprintf(
+			"%s %q: %s=%q contains forbidden characters or exceeds %d chars",
+			singularize(kind), key, field, name, maxUCName,
+		),
+		Paths:     []dyn.Path{p},
+		Locations: locationsAt(u, p),
+	}
+}
+
+// containsForbidden reports whether s has any character that UC rejects in
+// identifier position (slashes, backticks, whitespace).
+func containsForbidden(s string) bool {
+	for _, r := range s {
+		switch r {
+		case '/', '\\', '`', ' ', '\t', '\n', '\r':
+			return true
+		}
+	}
+	return false
+}
+
+// ucNameOf returns the UC-identifier-bearing field for a given resource
+// (kind, key), plus the JSON field name so diagnostics can point at the
+// right subfield.
+func ucNameOf(u *ucm.Ucm, kind, key string) (string, string, bool) {
+	switch kind {
+	case "catalogs":
+		if c := u.Config.Resources.Catalogs[key]; c != nil {
+			return c.Name, "name", true
+		}
+	case "schemas":
+		if s := u.Config.Resources.Schemas[key]; s != nil {
+			return s.Name, "name", true
+		}
+	case "storage_credentials":
+		if c := u.Config.Resources.StorageCredentials[key]; c != nil {
+			return c.Name, "name", true
+		}
+	case "external_locations":
+		if e := u.Config.Resources.ExternalLocations[key]; e != nil {
+			return e.Name, "name", true
+		}
+	case "volumes":
+		if v := u.Config.Resources.Volumes[key]; v != nil {
+			return v.Name, "name", true
+		}
+	case "connections":
+		if c := u.Config.Resources.Connections[key]; c != nil {
+			return c.Name, "name", true
+		}
+	}
+	return "", "", false
+}
+
+func resourceKeysOf(u *ucm.Ucm, kind string) []string {
+	switch kind {
+	case "catalogs":
+		return sortedKeys(u.Config.Resources.Catalogs)
+	case "schemas":
+		return sortedKeys(u.Config.Resources.Schemas)
+	case "grants":
+		return sortedKeys(u.Config.Resources.Grants)
+	case "storage_credentials":
+		return sortedKeys(u.Config.Resources.StorageCredentials)
+	case "external_locations":
+		return sortedKeys(u.Config.Resources.ExternalLocations)
+	case "volumes":
+		return sortedKeys(u.Config.Resources.Volumes)
+	case "connections":
+		return sortedKeys(u.Config.Resources.Connections)
+	}
+	return nil
+}

--- a/ucm/config/validate/naming_test.go
+++ b/ucm/config/validate/naming_test.go
@@ -1,0 +1,116 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/validate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNaming(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		wantSummary  string
+		wantEmpty    bool
+	}{
+		{
+			name: "valid key and name",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    team_alpha: {name: team_alpha}
+`,
+			wantEmpty: true,
+		},
+		{
+			name: "key with dot rejected",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    "team.alpha": {name: team_alpha}
+`,
+			wantSummary: `resource key "team.alpha"`,
+		},
+		{
+			name: "key with slash rejected",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    "team/alpha": {name: team_alpha}
+`,
+			wantSummary: `resource key "team/alpha"`,
+		},
+		{
+			name: "key starting with digit rejected",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    "1team": {name: team}
+`,
+			wantSummary: `resource key "1team"`,
+		},
+		{
+			name: "key with dash accepted",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    team-alpha: {name: team_alpha}
+`,
+			wantEmpty: true,
+		},
+		{
+			name: "UC name containing slash rejected",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: "bad/name"}
+`,
+			wantSummary: `name="bad/name"`,
+		},
+		{
+			name: "UC name with whitespace rejected",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: "bad name"}
+`,
+			wantSummary: `name="bad name"`,
+		},
+		{
+			name: "external_location key+url are unaffected by URL slashes in url field",
+			yaml: `
+ucm: {name: t}
+resources:
+  external_locations:
+    el1:
+      name: el1
+      url: s3://bucket/prefix
+      credential_name: sc1
+`,
+			wantEmpty: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := loadUcm(t, tc.yaml)
+			diags := ucm.Apply(t.Context(), u, validate.Naming())
+			if tc.wantEmpty {
+				assert.Empty(t, diags, "summaries=%v", summaries(diags))
+				return
+			}
+			require.NotEmpty(t, diags)
+			assert.True(t, hasSummary(diags, tc.wantSummary),
+				"want summary containing %q, got %v", tc.wantSummary, summaries(diags))
+		})
+	}
+}

--- a/ucm/config/validate/reference_closure.go
+++ b/ucm/config/validate/reference_closure.go
@@ -1,0 +1,90 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/dynvar"
+	"github.com/databricks/cli/ucm"
+)
+
+// ReferenceClosure errors when any ${resources.<kind>.<key>.*} interpolation
+// points at a resource the user did not declare.
+//
+// Safe to run before OR after ResolveResourceReferences: resolved references
+// no longer match the pattern, and unresolvable ones stay in place. The
+// terraform engine runs it before Build (so the TF JSON never ships broken
+// refs); the direct engine runs it after ResolveResourceReferences (so any
+// leftover ${resources.*} is guaranteed-dangling).
+//
+// Scoped to ${resources.*} tokens only. Non-resource references (${var.*},
+// ${workspace.*}, etc.) are ignored here: the variable-resolution pass that
+// handles them lands in M2/W1 and has its own closure check.
+//
+// TODO(M2/W1): extend to ${var.*} once variables are interpolated upstream.
+func ReferenceClosure() ucm.Mutator { return &referenceClosure{} }
+
+type referenceClosure struct{}
+
+func (m *referenceClosure) Name() string { return "validate:reference_closure" }
+
+const resourcesNamespace = "resources"
+
+func (m *referenceClosure) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	root := u.Config.Value()
+
+	err := dyn.WalkReadOnly(root, func(p dyn.Path, v dyn.Value) error {
+		ref, ok := dynvar.NewRef(v)
+		if !ok {
+			return nil
+		}
+		for _, target := range ref.References() {
+			targetPath, parseErr := dyn.NewPathFromString(target)
+			if parseErr != nil || !isResourceTarget(targetPath) {
+				continue
+			}
+			if !resourceExists(root, targetPath) {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary: fmt.Sprintf(
+						"unresolved reference ${%s} at %s: target resource is not declared in config",
+						target, p.String(),
+					),
+					Paths:     []dyn.Path{p},
+					Locations: locsOf(v),
+				})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	return diags
+}
+
+// isResourceTarget reports whether target is a ${resources.<kind>.<key>.*}
+// reference that can be checked for closure.
+func isResourceTarget(target dyn.Path) bool {
+	return len(target) >= 3 && target[0].Key() == resourcesNamespace
+}
+
+// resourceExists returns true when resources.<kind>.<key> is present in root.
+// We check the 3-segment prefix only — a reference to a sub-field of a
+// declared resource is always closed (the field may just be empty).
+func resourceExists(root dyn.Value, target dyn.Path) bool {
+	prefix := target[:3]
+	_, err := dyn.GetByPath(root, prefix)
+	return err == nil
+}
+
+func locsOf(v dyn.Value) []dyn.Location {
+	loc := v.Location()
+	if loc.File == "" && loc.Line == 0 {
+		return nil
+	}
+	return []dyn.Location{loc}
+}

--- a/ucm/config/validate/reference_closure_test.go
+++ b/ucm/config/validate/reference_closure_test.go
@@ -1,0 +1,134 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/databricks/cli/ucm/config/validate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReferenceClosure(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		resolveFirst bool
+		wantSummary  string
+		wantEmpty    bool
+	}{
+		{
+			name: "resolved reference to existing catalog is fine",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1}
+  schemas:
+    s1: {name: s1, catalog: "${resources.catalogs.c1.name}"}
+`,
+			resolveFirst: true,
+			wantEmpty:    true,
+		},
+		{
+			name: "unresolved reference to declared resource passes (terraform will handle)",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1}
+  schemas:
+    s1: {name: s1, catalog: "${resources.catalogs.c1.name}"}
+`,
+			resolveFirst: false,
+			wantEmpty:    true,
+		},
+		{
+			name: "reference to undeclared catalog errors",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1}
+  schemas:
+    s1: {name: s1, catalog: "${resources.catalogs.missing.name}"}
+`,
+			resolveFirst: false,
+			wantSummary:  `${resources.catalogs.missing.name}`,
+		},
+		{
+			name: "reference to undeclared kind errors",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1}
+  schemas:
+    s1: {name: s1, catalog: "${resources.volumes.nope.name}"}
+`,
+			resolveFirst: false,
+			wantSummary:  `${resources.volumes.nope.name}`,
+		},
+		{
+			name: "non-resource reference ignored",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      comment: "owned by ${var.team}"
+`,
+			resolveFirst: false,
+			wantEmpty:    true,
+		},
+		{
+			name: "pure reference to bare resources namespace ignored",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1:
+      name: c1
+      comment: "${workspace.host}"
+`,
+			resolveFirst: false,
+			wantEmpty:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := loadUcm(t, tc.yaml)
+			if tc.resolveFirst {
+				diags := ucm.Apply(t.Context(), u, mutator.ResolveResourceReferences())
+				require.NoError(t, diags.Error())
+			}
+			diags := ucm.Apply(t.Context(), u, validate.ReferenceClosure())
+			if tc.wantEmpty {
+				assert.Empty(t, diags, "summaries=%v", summaries(diags))
+				return
+			}
+			require.NotEmpty(t, diags)
+			assert.True(t, hasSummary(diags, tc.wantSummary),
+				"want summary containing %q, got %v", tc.wantSummary, summaries(diags))
+		})
+	}
+}
+
+func TestReferenceClosure_AfterResolveCatchesDangling(t *testing.T) {
+	u := loadUcm(t, `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1}
+  schemas:
+    s1: {name: s1, catalog: "${resources.catalogs.missing.name}"}
+`)
+	// ResolveResourceReferences will leave the token in place because the
+	// target does not exist; the closure check then errors on it.
+	_ = ucm.Apply(t.Context(), u, mutator.ResolveResourceReferences())
+	diags := ucm.Apply(t.Context(), u, validate.ReferenceClosure())
+	require.NotEmpty(t, diags)
+	assert.True(t, hasSummary(diags, "missing"))
+}

--- a/ucm/config/validate/required_fields.go
+++ b/ucm/config/validate/required_fields.go
@@ -1,0 +1,272 @@
+// Package validate contains ucm's validation mutators.
+//
+// These run in two waves:
+//
+//   - Raw-config (pre-interpolation): required-field checks, UC naming rules,
+//     duplicate resource-key detection. Composed by [All] and wired into
+//     phases.Validate / phases.PolicyCheck.
+//   - Post-interpolation: reference-closure checks that run after
+//     ResolveResourceReferences (and later, variable resolution) so the
+//     validator sees concrete values.
+package validate
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/ucm"
+)
+
+// RequiredFields errors on UC resources missing their mandatory fields.
+//
+// Required-field matrix (kept in-code rather than sourced from the SDK
+// annotations so diagnostics are terse and domain-specific):
+//
+//   - catalog:             name
+//   - schema:              name, catalog
+//   - grant:               principal, privileges (non-empty), securable.type, securable.name
+//   - storage_credential:  name + exactly one cloud-identity sub-struct
+//   - external_location:   name, url, credential_name
+//   - volume:              name, catalog_name, schema_name, volume_type
+//   - connection:          name, connection_type, options (non-empty)
+func RequiredFields() ucm.Mutator { return &requiredFields{} }
+
+type requiredFields struct{}
+
+func (m *requiredFields) Name() string { return "validate:required_fields" }
+
+func (m *requiredFields) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	diags = append(diags, checkCatalogs(u)...)
+	diags = append(diags, checkSchemas(u)...)
+	diags = append(diags, checkGrants(u)...)
+	diags = append(diags, checkStorageCredentials(u)...)
+	diags = append(diags, checkExternalLocations(u)...)
+	diags = append(diags, checkVolumes(u)...)
+	diags = append(diags, checkConnections(u)...)
+	return diags
+}
+
+func checkCatalogs(u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, key := range sortedKeys(u.Config.Resources.Catalogs) {
+		c := u.Config.Resources.Catalogs[key]
+		if c == nil || c.Name == "" {
+			diags = append(diags, missingField(u, "catalogs", key, "name"))
+		}
+	}
+	return diags
+}
+
+func checkSchemas(u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, key := range sortedKeys(u.Config.Resources.Schemas) {
+		s := u.Config.Resources.Schemas[key]
+		if s == nil {
+			continue
+		}
+		if s.Name == "" {
+			diags = append(diags, missingField(u, "schemas", key, "name"))
+		}
+		if s.Catalog == "" {
+			diags = append(diags, missingField(u, "schemas", key, "catalog"))
+		}
+	}
+	return diags
+}
+
+func checkGrants(u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, key := range sortedKeys(u.Config.Resources.Grants) {
+		g := u.Config.Resources.Grants[key]
+		if g == nil {
+			continue
+		}
+		if g.Principal == "" {
+			diags = append(diags, missingField(u, "grants", key, "principal"))
+		}
+		if len(g.Privileges) == 0 {
+			diags = append(diags, missingField(u, "grants", key, "privileges"))
+		}
+		if g.Securable.Type == "" {
+			diags = append(diags, missingField(u, "grants", key, "securable.type"))
+		}
+		if g.Securable.Name == "" {
+			diags = append(diags, missingField(u, "grants", key, "securable.name"))
+		}
+	}
+	return diags
+}
+
+func checkStorageCredentials(u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, key := range sortedKeys(u.Config.Resources.StorageCredentials) {
+		c := u.Config.Resources.StorageCredentials[key]
+		if c == nil {
+			continue
+		}
+		if c.Name == "" {
+			diags = append(diags, missingField(u, "storage_credentials", key, "name"))
+		}
+		set := 0
+		if c.AwsIamRole != nil {
+			set++
+		}
+		if c.AzureManagedIdentity != nil {
+			set++
+		}
+		if c.AzureServicePrincipal != nil {
+			set++
+		}
+		if c.DatabricksGcpServiceAccount != nil {
+			set++
+		}
+		if set != 1 {
+			path := resourcePath("storage_credentials", key)
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"storage_credential %q: exactly one of aws_iam_role, azure_managed_identity, azure_service_principal, databricks_gcp_service_account must be set (found %d)",
+					key, set,
+				),
+				Paths:     []dyn.Path{path},
+				Locations: locationsAt(u, path),
+			})
+		}
+	}
+	return diags
+}
+
+func checkExternalLocations(u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, key := range sortedKeys(u.Config.Resources.ExternalLocations) {
+		e := u.Config.Resources.ExternalLocations[key]
+		if e == nil {
+			continue
+		}
+		if e.Name == "" {
+			diags = append(diags, missingField(u, "external_locations", key, "name"))
+		}
+		if e.Url == "" {
+			diags = append(diags, missingField(u, "external_locations", key, "url"))
+		}
+		if e.CredentialName == "" {
+			diags = append(diags, missingField(u, "external_locations", key, "credential_name"))
+		}
+	}
+	return diags
+}
+
+func checkVolumes(u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, key := range sortedKeys(u.Config.Resources.Volumes) {
+		v := u.Config.Resources.Volumes[key]
+		if v == nil {
+			continue
+		}
+		if v.Name == "" {
+			diags = append(diags, missingField(u, "volumes", key, "name"))
+		}
+		if v.CatalogName == "" {
+			diags = append(diags, missingField(u, "volumes", key, "catalog_name"))
+		}
+		if v.SchemaName == "" {
+			diags = append(diags, missingField(u, "volumes", key, "schema_name"))
+		}
+		if v.VolumeType == "" {
+			diags = append(diags, missingField(u, "volumes", key, "volume_type"))
+		}
+	}
+	return diags
+}
+
+func checkConnections(u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, key := range sortedKeys(u.Config.Resources.Connections) {
+		c := u.Config.Resources.Connections[key]
+		if c == nil {
+			continue
+		}
+		if c.Name == "" {
+			diags = append(diags, missingField(u, "connections", key, "name"))
+		}
+		if c.ConnectionType == "" {
+			diags = append(diags, missingField(u, "connections", key, "connection_type"))
+		}
+		if len(c.Options) == 0 {
+			diags = append(diags, missingField(u, "connections", key, "options"))
+		}
+	}
+	return diags
+}
+
+// missingField builds the standard "required field X is not set" diagnostic
+// pointing at resources.<kind>.<key>.
+func missingField(u *ucm.Ucm, kind, key, field string) diag.Diagnostic {
+	resPath := resourcePath(kind, key)
+	return diag.Diagnostic{
+		Severity:  diag.Error,
+		Summary:   fmt.Sprintf("%s %q: required field %q is not set", singularize(kind), key, field),
+		Paths:     []dyn.Path{resPath},
+		Locations: locationsAt(u, resPath),
+	}
+}
+
+func resourcePath(kind, key string) dyn.Path {
+	return dyn.NewPath(dyn.Key("resources"), dyn.Key(kind), dyn.Key(key))
+}
+
+func locationsAt(u *ucm.Ucm, p dyn.Path) []dyn.Location {
+	v, err := dyn.GetByPath(u.Config.Value(), p)
+	if err != nil {
+		return nil
+	}
+	loc := v.Location()
+	if loc.File == "" && loc.Line == 0 {
+		return nil
+	}
+	return []dyn.Location{loc}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// singularize maps the plural map-field name used in YAML (e.g. "catalogs")
+// to the singular noun used in diagnostics (e.g. "catalog").
+func singularize(kind string) string {
+	if s, ok := singular[kind]; ok {
+		return s
+	}
+	return kind
+}
+
+var singular = map[string]string{
+	"catalogs":            "catalog",
+	"schemas":             "schema",
+	"grants":              "grant",
+	"storage_credentials": "storage_credential",
+	"external_locations":  "external_location",
+	"volumes":             "volume",
+	"connections":         "connection",
+}
+
+// resourceKinds is the ordered list of kinds that validators iterate over.
+// Kept here so new kinds only need to be added in one place.
+var resourceKinds = []string{
+	"catalogs",
+	"schemas",
+	"grants",
+	"storage_credentials",
+	"external_locations",
+	"volumes",
+	"connections",
+}

--- a/ucm/config/validate/required_fields_test.go
+++ b/ucm/config/validate/required_fields_test.go
@@ -1,0 +1,187 @@
+package validate_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/validate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadUcm parses raw YAML and returns a fresh Ucm backed by it.
+func loadUcm(t *testing.T, yaml string) *ucm.Ucm {
+	t.Helper()
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(yaml))
+	require.NoError(t, diags.Error())
+	return &ucm.Ucm{Config: *cfg}
+}
+
+func summaries(ds diag.Diagnostics) []string {
+	out := make([]string, 0, len(ds))
+	for _, d := range ds {
+		out = append(out, d.Summary)
+	}
+	return out
+}
+
+func hasSummary(ds diag.Diagnostics, substr string) bool {
+	for _, s := range summaries(ds) {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRequiredFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		wantSummaries []string
+		wantEmpty    bool
+	}{
+		{
+			name: "valid fixture has no diagnostics",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1}
+  schemas:
+    s1: {name: s1, catalog: c1}
+`,
+			wantEmpty: true,
+		},
+		{
+			name: "catalog missing name",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {}
+`,
+			wantSummaries: []string{`catalog "c1": required field "name"`},
+		},
+		{
+			name: "schema missing name and catalog",
+			yaml: `
+ucm: {name: t}
+resources:
+  schemas:
+    s1: {}
+`,
+			wantSummaries: []string{
+				`schema "s1": required field "name"`,
+				`schema "s1": required field "catalog"`,
+			},
+		},
+		{
+			name: "grant missing principal and privileges",
+			yaml: `
+ucm: {name: t}
+resources:
+  grants:
+    g1:
+      securable: {type: catalog, name: c1}
+`,
+			wantSummaries: []string{
+				`grant "g1": required field "principal"`,
+				`grant "g1": required field "privileges"`,
+			},
+		},
+		{
+			name: "grant missing securable fields",
+			yaml: `
+ucm: {name: t}
+resources:
+  grants:
+    g1: {principal: p, privileges: [SELECT]}
+`,
+			wantSummaries: []string{
+				`required field "securable.type"`,
+				`required field "securable.name"`,
+			},
+		},
+		{
+			name: "storage credential missing identity",
+			yaml: `
+ucm: {name: t}
+resources:
+  storage_credentials:
+    sc1: {name: sc1}
+`,
+			wantSummaries: []string{`exactly one of aws_iam_role`},
+		},
+		{
+			name: "storage credential with two identities",
+			yaml: `
+ucm: {name: t}
+resources:
+  storage_credentials:
+    sc1:
+      name: sc1
+      aws_iam_role: {role_arn: arn}
+      azure_managed_identity: {access_connector_id: id}
+`,
+			wantSummaries: []string{`exactly one of aws_iam_role`},
+		},
+		{
+			name: "external location missing url and credential_name",
+			yaml: `
+ucm: {name: t}
+resources:
+  external_locations:
+    el1: {name: el1}
+`,
+			wantSummaries: []string{
+				`required field "url"`,
+				`required field "credential_name"`,
+			},
+		},
+		{
+			name: "volume missing volume_type",
+			yaml: `
+ucm: {name: t}
+resources:
+  volumes:
+    v1: {name: v1, catalog_name: c, schema_name: s}
+`,
+			wantSummaries: []string{`required field "volume_type"`},
+		},
+		{
+			name: "connection missing connection_type and options",
+			yaml: `
+ucm: {name: t}
+resources:
+  connections:
+    cn1: {name: cn1}
+`,
+			wantSummaries: []string{
+				`required field "connection_type"`,
+				`required field "options"`,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := loadUcm(t, tc.yaml)
+			diags := ucm.Apply(t.Context(), u, validate.RequiredFields())
+			if tc.wantEmpty {
+				assert.Empty(t, diags, "summaries=%v", summaries(diags))
+				return
+			}
+			require.NotEmpty(t, diags)
+			for _, want := range tc.wantSummaries {
+				assert.True(t, hasSummary(diags, want),
+					"want summary containing %q, got %v", want, summaries(diags))
+			}
+			for _, d := range diags {
+				assert.Equal(t, diag.Error, d.Severity)
+			}
+		})
+	}
+}

--- a/ucm/config/validate/unique_resource_keys.go
+++ b/ucm/config/validate/unique_resource_keys.go
@@ -1,0 +1,88 @@
+package validate
+
+import (
+	"cmp"
+	"context"
+	"slices"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/ucm"
+)
+
+// UniqueResourceKeys errors when the same key appears under multiple resource
+// kinds (e.g. a catalog and a schema both named "bronze"). Uniqueness within
+// a single kind is enforced by YAML map semantics at load time, so this
+// validator only needs to catch cross-kind collisions.
+//
+// This complements FlattenNestedResources' same-kind check between flat and
+// nested forms.
+func UniqueResourceKeys() ucm.Mutator { return &uniqueResourceKeys{} }
+
+type uniqueResourceKeys struct{}
+
+func (m *uniqueResourceKeys) Name() string { return "validate:unique_resource_keys" }
+
+func (m *uniqueResourceKeys) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	type occurrence struct {
+		kind string
+		path dyn.Path
+		locs []dyn.Location
+	}
+	occurrences := map[string][]occurrence{}
+
+	root := u.Config.Value()
+	resources := root.Get("resources")
+	if resources.Kind() == dyn.KindInvalid || resources.Kind() == dyn.KindNil {
+		return nil
+	}
+
+	for _, kind := range resourceKinds {
+		kv := resources.Get(kind)
+		if kv.Kind() != dyn.KindMap {
+			continue
+		}
+		for _, pair := range kv.MustMap().Pairs() {
+			key := pair.Key.MustString()
+			p := dyn.NewPath(dyn.Key("resources"), dyn.Key(kind), dyn.Key(key))
+			occurrences[key] = append(occurrences[key], occurrence{
+				kind: kind,
+				path: p,
+				locs: pair.Value.Locations(),
+			})
+		}
+	}
+
+	var diags diag.Diagnostics
+	for _, key := range sortedKeys(occurrences) {
+		occs := occurrences[key]
+		if len(occs) <= 1 {
+			continue
+		}
+		var paths []dyn.Path
+		var locs []dyn.Location
+		for _, o := range occs {
+			paths = append(paths, o.path)
+			locs = append(locs, o.locs...)
+		}
+		slices.SortFunc(locs, func(a, b dyn.Location) int {
+			if n := cmp.Compare(a.File, b.File); n != 0 {
+				return n
+			}
+			if n := cmp.Compare(a.Line, b.Line); n != 0 {
+				return n
+			}
+			return cmp.Compare(a.Column, b.Column)
+		})
+		slices.SortFunc(paths, func(a, b dyn.Path) int {
+			return cmp.Compare(a.String(), b.String())
+		})
+		diags = append(diags, diag.Diagnostic{
+			Severity:  diag.Error,
+			Summary:   "resource key " + key + " is declared under multiple resource kinds",
+			Paths:     paths,
+			Locations: locs,
+		})
+	}
+	return diags
+}

--- a/ucm/config/validate/unique_resource_keys_test.go
+++ b/ucm/config/validate/unique_resource_keys_test.go
@@ -1,0 +1,69 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/validate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniqueResourceKeys(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		wantSummary  string
+		wantEmpty    bool
+	}{
+		{
+			name: "distinct kinds with distinct keys",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    c1: {name: c1}
+  schemas:
+    s1: {name: s1, catalog: c1}
+`,
+			wantEmpty: true,
+		},
+		{
+			name: "catalog and schema share a key",
+			yaml: `
+ucm: {name: t}
+resources:
+  catalogs:
+    shared: {name: shared}
+  schemas:
+    shared: {name: shared, catalog: shared}
+`,
+			wantSummary: "resource key shared is declared under multiple",
+		},
+		{
+			name: "grant and volume share a key",
+			yaml: `
+ucm: {name: t}
+resources:
+  grants:
+    foo: {securable: {type: catalog, name: c1}, principal: p, privileges: [SELECT]}
+  volumes:
+    foo: {name: v, catalog_name: c, schema_name: s, volume_type: MANAGED}
+`,
+			wantSummary: "resource key foo is declared under multiple",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := loadUcm(t, tc.yaml)
+			diags := ucm.Apply(t.Context(), u, validate.UniqueResourceKeys())
+			if tc.wantEmpty {
+				assert.Empty(t, diags, "summaries=%v", summaries(diags))
+				return
+			}
+			require.NotEmpty(t, diags)
+			assert.True(t, hasSummary(diags, tc.wantSummary),
+				"want summary containing %q, got %v", tc.wantSummary, summaries(diags))
+		})
+	}
+}

--- a/ucm/phases/deploy.go
+++ b/ucm/phases/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/databricks/cli/ucm/config/validate"
 	"github.com/databricks/cli/ucm/deploy"
 	"github.com/databricks/cli/ucm/deploy/direct"
 )
@@ -44,6 +45,11 @@ func Deploy(ctx context.Context, u *ucm.Ucm, opts Options) {
 }
 
 func deployTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
+	ucm.ApplyContext(ctx, u, validate.ReferenceClosure())
+	if logdiag.HasError(ctx) {
+		return
+	}
+
 	tf := Build(ctx, u, opts)
 	if tf == nil || logdiag.HasError(ctx) {
 		return
@@ -67,6 +73,10 @@ func deployTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
 
 func deployDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
 	ucm.ApplyContext(ctx, u, mutator.ResolveResourceReferences())
+	if logdiag.HasError(ctx) {
+		return
+	}
+	ucm.ApplyContext(ctx, u, validate.ReferenceClosure())
 	if logdiag.HasError(ctx) {
 		return
 	}

--- a/ucm/phases/destroy.go
+++ b/ucm/phases/destroy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/validate"
 	"github.com/databricks/cli/ucm/deploy"
 	"github.com/databricks/cli/ucm/deploy/direct"
 )
@@ -42,6 +43,11 @@ func Destroy(ctx context.Context, u *ucm.Ucm, opts Options) {
 }
 
 func destroyTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
+	ucm.ApplyContext(ctx, u, validate.ReferenceClosure())
+	if logdiag.HasError(ctx) {
+		return
+	}
+
 	factory := opts.terraformFactoryOrDefault()
 	tf, err := factory(ctx, u)
 	if err != nil {

--- a/ucm/phases/plan.go
+++ b/ucm/phases/plan.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/databricks/cli/ucm/config/validate"
 	"github.com/databricks/cli/ucm/deploy/direct"
 	"github.com/databricks/cli/ucm/deployplan"
 )
@@ -38,6 +39,11 @@ func Plan(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
 }
 
 func planTerraform(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
+	ucm.ApplyContext(ctx, u, validate.ReferenceClosure())
+	if logdiag.HasError(ctx) {
+		return nil
+	}
+
 	tf := Build(ctx, u, opts)
 	if tf == nil || logdiag.HasError(ctx) {
 		return nil
@@ -66,6 +72,10 @@ func planTerraform(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
 
 func planDirect(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
 	ucm.ApplyContext(ctx, u, mutator.ResolveResourceReferences())
+	if logdiag.HasError(ctx) {
+		return nil
+	}
+	ucm.ApplyContext(ctx, u, validate.ReferenceClosure())
 	if logdiag.HasError(ctx) {
 		return nil
 	}

--- a/ucm/phases/validate.go
+++ b/ucm/phases/validate.go
@@ -3,14 +3,20 @@ package phases
 import (
 	"context"
 
+	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/databricks/cli/ucm/config/validate"
 )
 
 // Validate runs every validation mutator against the loaded + target-merged
-// Ucm. M0 only has tag validation; more rules (naming, required fields,
-// metastore contention) land in subsequent milestones.
+// Ucm: the raw-config validator pack (required fields, naming, duplicate
+// keys) followed by tag-rule enforcement.
 func Validate(ctx context.Context, u *ucm.Ucm) {
+	validate.All(ctx, u)
+	if logdiag.HasError(ctx) {
+		return
+	}
 	ucm.ApplySeqContext(ctx, u,
 		mutator.ValidateTags(),
 	)
@@ -20,6 +26,10 @@ func Validate(ctx context.Context, u *ucm.Ucm) {
 // cheap enough to run from a pre-commit hook. Currently identical to
 // Validate; will diverge once non-validation mutators join the chain.
 func PolicyCheck(ctx context.Context, u *ucm.Ucm) {
+	validate.All(ctx, u)
+	if logdiag.HasError(ctx) {
+		return
+	}
 	ucm.ApplySeqContext(ctx, u,
 		mutator.ValidateTags(),
 	)


### PR DESCRIPTION
Closes #39
Closes #40
Parent: #36 (M2 umbrella)

## Summary

Two commits landing the M2/W3 validator pack. Fork-and-adapt from DAB's `bundle/config/validate/`, scoped to UC concerns.

### W3a — raw-config validators (commit 5b9e74997)

- `required_fields.go` — hand-authored matrix over UC resource kinds. DAB's `generated.RequiredFields` trie is OpenAPI-driven and doesn't apply here.
- `naming.go` — UCM-specific: map keys match `[A-Za-z_][A-Za-z0-9_-]*` (≤128), UC names reject slashes/backticks/whitespace (≤255).
- `unique_resource_keys.go` — cross-kind key collision check (same-kind is YAML-map-enforced; flat/nested dupes already caught by `FlattenNestedResources`).
- `all.go` — composes the active set.

Runs in `phases.Validate` and `phases.PolicyCheck` before `ValidateTags`.

### W3b — post-interpolation reference closure (commit fc78ccd5b)

- `reference_closure.go` — walks the post-interp tree, errors on `${resources.<kind>.<key>.*}` where the target is not declared. Scoped to `${resources.*}` per the issue spec; `${var.*}` is TODO pending M2/W1 variables.

Runs in:
- `plan.go`: terraform path before `Build`; direct path after `ResolveResourceReferences`.
- `deploy.go`: same pattern as plan.
- `destroy.go`: terraform path before `Init`. Direct destroy operates on state, not config.

## DAB mutators skipped

`validate_artifact_path`, `validate_sync_patterns`, `files_to_sync`, `folder_permissions`, `job_cluster_key_defined`, `job_task_cluster_spec`, `single_node_cluster`, `validate_dashboard_etags`, `validate_volume_path`, `all_resources_have_values`, `interpolation_in_auth_config`, `no_interpolation_in_bundle_name`, `scripts`, `enum`, `validate_engine` — all bundle-specific.

## Test plan

- [x] `go build ./...`, `go vet ./cmd/ucm/... ./ucm/...`, `go test ./cmd/ucm/... ./ucm/...` — all clean.
- [x] Four table-driven test files with 180+ cases.