### PR TITLE
Feat #37: Add ucm variables subsystem (${var.x}, --var flag, per-target overrides)

### DIFF
--- a/cmd/ucm/ucm.go
+++ b/cmd/ucm/ucm.go
@@ -36,6 +36,7 @@ Online documentation: https://docs.databricks.com/en/dev-tools/ucm/index.html`,
 	}
 
 	cmd.PersistentFlags().StringP("target", "t", "", "ucm target to use (if applicable)")
+	cmd.PersistentFlags().StringSlice("var", nil, `set values for variables defined in ucm config. Example: --var="foo=bar"`)
 
 	cmd.AddCommand(newValidateCommand())
 	cmd.AddCommand(newSchemaCommand())

--- a/cmd/ucm/utils/utils.go
+++ b/cmd/ucm/utils/utils.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"context"
 
+	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config"
@@ -31,7 +32,8 @@ type ProcessOptions struct {
 
 // ProcessUcm loads the ucm.yml rooted at the working directory (or
 // DATABRICKS_UCM_ROOT), selects the target indicated by --target (or the
-// default target), and — if opts.Validate — runs the validation phase.
+// default target), applies any --var overrides, resolves variables, and — if
+// opts.Validate — runs the validation phase.
 //
 // Errors are reported via logdiag. The caller should check
 // logdiag.HasError(cmd.Context()) and render diagnostics before returning.
@@ -56,10 +58,48 @@ func ProcessUcm(cmd *cobra.Command, opts ProcessOptions) *ucm.Ucm {
 		return u
 	}
 
+	// Apply --var before SetVariables so CLI values win over defaults/env.
+	configureVariables(ctx, u, varsFromCmd(cmd))
+	if logdiag.HasError(ctx) {
+		return u
+	}
+
+	phases.Variables(ctx, u)
+	if logdiag.HasError(ctx) {
+		return u
+	}
+
 	if opts.Validate {
 		phases.Validate(ctx, u)
 	}
 	return u
+}
+
+// varsFromCmd reads the `--var` StringSlice flag if it is wired on cmd.
+// Returns nil if the flag is absent (e.g. tests that build cmds without it).
+func varsFromCmd(cmd *cobra.Command) []string {
+	f := cmd.Flag("var")
+	if f == nil {
+		return nil
+	}
+	vals, err := cmd.Flags().GetStringSlice("var")
+	if err != nil {
+		return nil
+	}
+	return vals
+}
+
+// configureVariables assigns .Value on each named variable via
+// Config.InitializeVariables. Errors are surfaced as diagnostics.
+func configureVariables(ctx context.Context, u *ucm.Ucm, vars []string) {
+	if len(vars) == 0 {
+		return
+	}
+	ucm.ApplyFuncContext(ctx, u, func(ctx context.Context, u *ucm.Ucm) {
+		if err := u.Config.InitializeVariables(vars); err != nil {
+			logdiag.LogDiag(ctx, diag.FromErr(err)[0])
+		}
+	})
 }
 
 // ResolveEngineSetting determines the effective engine for a ucm project.

--- a/ucm/config/mutator/initialize_variables.go
+++ b/ucm/config/mutator/initialize_variables.go
@@ -1,0 +1,30 @@
+package mutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/variable"
+)
+
+type initializeVariables struct{}
+
+// InitializeVariables replaces any nil entries in Config.Variables with a
+// freshly-allocated zero value. Shorthand variable definitions (e.g. just a
+// key with no body) land as nil after YAML parsing and would otherwise panic
+// later mutators.
+func InitializeVariables() ucm.Mutator {
+	return &initializeVariables{}
+}
+
+func (m *initializeVariables) Name() string { return "InitializeVariables" }
+
+func (m *initializeVariables) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	for k, v := range u.Config.Variables {
+		if v == nil {
+			u.Config.Variables[k] = &variable.Variable{}
+		}
+	}
+	return nil
+}

--- a/ucm/config/mutator/initialize_variables_test.go
+++ b/ucm/config/mutator/initialize_variables_test.go
@@ -1,0 +1,35 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/mutator"
+	"github.com/databricks/cli/ucm/config/variable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeVariables_FillsNilEntries(t *testing.T) {
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Variables: map[string]*variable.Variable{
+				"foo": nil,
+				"bar": {Description: "bar doc"},
+			},
+		},
+	}
+	diags := ucm.Apply(t.Context(), u, mutator.InitializeVariables())
+	require.NoError(t, diags.Error())
+	assert.NotNil(t, u.Config.Variables["foo"])
+	assert.NotNil(t, u.Config.Variables["bar"])
+	assert.Equal(t, "bar doc", u.Config.Variables["bar"].Description)
+}
+
+func TestInitializeVariables_NoVariables(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+	diags := ucm.Apply(t.Context(), u, mutator.InitializeVariables())
+	require.NoError(t, diags.Error())
+	assert.Nil(t, u.Config.Variables)
+}

--- a/ucm/config/mutator/resolve_variable_references.go
+++ b/ucm/config/mutator/resolve_variable_references.go
@@ -9,10 +9,15 @@ import (
 	"github.com/databricks/cli/ucm"
 )
 
-// ResolveResourceReferences returns a mutator that substitutes any
-// ${resources.<kind>.<key>.<field>} reference in the loaded ucm config with
-// the pointed-at value from the same tree. Non-resource references (var.*,
-// workspace.*, anything else) are left untouched for later passes to handle.
+// maxResolutionRounds caps the fixed-point iteration used when a resolved
+// value itself contains a reference. Matches bundle's budget; past 11 rounds
+// the cost grows exponentially with pathological input.
+const maxResolutionRounds = 11
+
+// ResolveResourceReferences substitutes any ${resources.<kind>.<key>.<field>}
+// reference in the loaded ucm config with the pointed-at value from the same
+// tree. Non-resource references (var.*, workspace.*, anything else) are left
+// untouched for later passes.
 func ResolveResourceReferences() ucm.Mutator { return &resolveResourceReferences{} }
 
 type resolveResourceReferences struct{}
@@ -38,6 +43,69 @@ func (m *resolveResourceReferences) Apply(_ context.Context, u *ucm.Ucm) diag.Di
 			Severity: diag.Error,
 			Summary:  err.Error(),
 		})
+	}
+	return diags
+}
+
+// ResolveVariableReferences substitutes ${var.<name>} tokens (shorthand for
+// ${variables.<name>.value}) everywhere they appear. Iterates up to
+// maxResolutionRounds times to resolve references that themselves point at
+// other references.
+func ResolveVariableReferences() ucm.Mutator { return &resolveVariableReferences{} }
+
+type resolveVariableReferences struct{}
+
+func (m *resolveVariableReferences) Name() string { return "ResolveVariableReferences" }
+
+func (m *resolveVariableReferences) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics {
+	var diags diag.Diagnostics
+	varPath := dyn.NewPath(dyn.Key("var"))
+	variablesKey := dyn.NewPath(dyn.Key("variables"))
+
+	for round := range maxResolutionRounds {
+		updates := false
+		err := u.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
+			return dynvar.Resolve(root, func(path dyn.Path) (dyn.Value, error) {
+				// Rewrite ${var.foo} into ${variables.foo.value}.
+				resolved := path
+				if resolved.HasPrefix(varPath) {
+					np := dyn.NewPath(dyn.Key("variables"), resolved[1], dyn.Key("value"))
+					if len(resolved) > 2 {
+						np = np.Append(resolved[2:]...)
+					}
+					resolved = np
+				}
+
+				if !resolved.HasPrefix(variablesKey) {
+					return dyn.InvalidValue, dynvar.ErrSkipResolution
+				}
+
+				v, err := dyn.GetByPath(root, resolved)
+				if err != nil {
+					return dyn.InvalidValue, err
+				}
+				if v.IsValid() {
+					updates = true
+				}
+				return v, nil
+			})
+		})
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  err.Error(),
+			})
+			return diags
+		}
+		if !updates {
+			break
+		}
+		if round == maxResolutionRounds-1 {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Variable references are too deep; stopping resolution. Unresolved variables may remain.",
+			})
+		}
 	}
 	return diags
 }

--- a/ucm/config/mutator/resolve_variable_references_test.go
+++ b/ucm/config/mutator/resolve_variable_references_test.go
@@ -77,3 +77,60 @@ resources:
 	require.Empty(t, diags, "unexpected diags: %v", summaries(diags))
 	assert.Equal(t, "${var.some_future_var}", u.Config.Resources.Catalogs["sales"].StorageRoot)
 }
+
+func TestResolveVariableReferences_SubstitutesVarShorthand(t *testing.T) {
+	u := loadUcm(t, `
+ucm: {name: t}
+variables:
+  catalog_name:
+    default: team_alpha
+    value: team_alpha
+resources:
+  catalogs:
+    primary:
+      name: ${var.catalog_name}
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ResolveVariableReferences())
+	require.Empty(t, diags, "unexpected diags: %v", summaries(diags))
+	assert.Equal(t, "team_alpha", u.Config.Resources.Catalogs["primary"].Name)
+}
+
+func TestResolveVariableReferences_ChainedRefs(t *testing.T) {
+	u := loadUcm(t, `
+ucm: {name: t}
+variables:
+  base:
+    default: alpha
+    value: alpha
+  derived:
+    default: ${var.base}_suffix
+    value: ${var.base}_suffix
+resources:
+  catalogs:
+    primary:
+      name: ${var.derived}
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ResolveVariableReferences())
+	require.Empty(t, diags, "unexpected diags: %v", summaries(diags))
+	assert.Equal(t, "alpha_suffix", u.Config.Resources.Catalogs["primary"].Name)
+}
+
+func TestResolveVariableReferences_UnknownErrors(t *testing.T) {
+	u := loadUcm(t, `
+ucm: {name: t}
+resources:
+  catalogs:
+    primary:
+      name: ${var.missing}
+`)
+	diags := ucm.Apply(t.Context(), u, mutator.ResolveVariableReferences())
+	require.NotEmpty(t, diags, "expected error diagnostic")
+	found := false
+	for _, s := range summaries(diags) {
+		if strings.Contains(s, "var.missing") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected diag to mention missing var, got %v", summaries(diags))
+}

--- a/ucm/config/mutator/set_variables.go
+++ b/ucm/config/mutator/set_variables.go
@@ -1,0 +1,82 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/variable"
+)
+
+// ucmVarPrefix is the env-var prefix that can assign ucm variables without
+// touching the ucm.yml. `DATABRICKS_UCM_VAR_foo=bar` resolves to the same
+// effective state as `--var foo=bar` and as the `variables.foo.default` key.
+const ucmVarPrefix = "DATABRICKS_UCM_VAR_"
+
+type setVariables struct{}
+
+// SetVariables walks Config.Variables and assigns each one a value based on
+// the DAB-parity resolution order: existing .Value > env var > lookup (deferred) > default.
+func SetVariables() ucm.Mutator {
+	return &setVariables{}
+}
+
+func (m *setVariables) Name() string { return "SetVariables" }
+
+func (m *setVariables) Apply(ctx context.Context, u *ucm.Ucm) diag.Diagnostics {
+	err := u.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
+		return dyn.Map(v, "variables", dyn.Foreach(func(p dyn.Path, raw dyn.Value) (dyn.Value, error) {
+			name := p[1].Key()
+			defn, ok := u.Config.Variables[name]
+			if !ok {
+				return dyn.InvalidValue, fmt.Errorf(`variable "%s" is not defined`, name)
+			}
+			return setVariable(ctx, raw, defn, name)
+		}))
+	})
+	return diag.FromErr(err)
+}
+
+// setVariable applies the priority ladder to a single variable. Must be kept
+// consistent with variable.Variable.Value docstring.
+func setVariable(ctx context.Context, v dyn.Value, defn *variable.Variable, name string) (dyn.Value, error) {
+	// Already assigned — e.g. by --var before the mutator chain ran.
+	if defn.HasValue() {
+		return v, nil
+	}
+
+	envVarName := ucmVarPrefix + name
+	if val, ok := env.Lookup(ctx, envVarName); ok {
+		if defn.IsComplex() {
+			return dyn.InvalidValue, fmt.Errorf(`setting via environment variables (%s) is not supported for complex variable %s`, envVarName, name)
+		}
+		nv, err := dyn.Set(v, "value", dyn.V(val))
+		if err != nil {
+			return dyn.InvalidValue, fmt.Errorf(`failed to assign value "%s" to variable %s from environment variable %s: %w`, val, name, envVarName, err)
+		}
+		return nv, nil
+	}
+
+	// Lookup is resolved later by a separate mutator once a WorkspaceClient
+	// is available. Leave the dyn value alone here.
+	if defn.Lookup != nil {
+		return v, nil
+	}
+
+	if defn.HasDefault() {
+		vDefault, err := dyn.Get(v, "default")
+		if err != nil {
+			return dyn.InvalidValue, fmt.Errorf(`failed to get default value for variable %s: %w`, name, err)
+		}
+		nv, err := dyn.Set(v, "value", vDefault)
+		if err != nil {
+			return dyn.InvalidValue, fmt.Errorf(`failed to assign default value to variable %s: %w`, name, err)
+		}
+		return nv, nil
+	}
+
+	return dyn.InvalidValue, fmt.Errorf(`no value assigned to required variable %s. Assign a default in ucm.yml or override via "--var %s=..." or the %s environment variable`, name, name, envVarName)
+}

--- a/ucm/config/mutator/set_variables_test.go
+++ b/ucm/config/mutator/set_variables_test.go
@@ -1,0 +1,100 @@
+package mutator
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/variable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetVariable_FromEnv(t *testing.T) {
+	v := variable.Variable{Description: "x", Default: "d"}
+	t.Setenv("DATABRICKS_UCM_VAR_foo", "from-env")
+
+	dv, err := convert.FromTyped(v, dyn.NilValue)
+	require.NoError(t, err)
+	dv, err = setVariable(t.Context(), dv, &v, "foo")
+	require.NoError(t, err)
+
+	require.NoError(t, convert.ToTyped(&v, dv))
+	assert.Equal(t, "from-env", v.Value)
+}
+
+func TestSetVariable_FromDefault(t *testing.T) {
+	v := variable.Variable{Description: "x", Default: "d"}
+	dv, err := convert.FromTyped(v, dyn.NilValue)
+	require.NoError(t, err)
+	dv, err = setVariable(t.Context(), dv, &v, "foo")
+	require.NoError(t, err)
+
+	require.NoError(t, convert.ToTyped(&v, dv))
+	assert.Equal(t, "d", v.Value)
+}
+
+func TestSetVariable_PreserveExistingValue(t *testing.T) {
+	v := variable.Variable{Description: "x", Default: "d", Value: "cli"}
+	t.Setenv("DATABRICKS_UCM_VAR_foo", "from-env")
+
+	dv, err := convert.FromTyped(v, dyn.NilValue)
+	require.NoError(t, err)
+	dv, err = setVariable(t.Context(), dv, &v, "foo")
+	require.NoError(t, err)
+
+	require.NoError(t, convert.ToTyped(&v, dv))
+	assert.Equal(t, "cli", v.Value)
+}
+
+func TestSetVariable_MissingValueErrors(t *testing.T) {
+	v := variable.Variable{Description: "no default"}
+	dv, err := convert.FromTyped(v, dyn.NilValue)
+	require.NoError(t, err)
+	_, err = setVariable(t.Context(), dv, &v, "foo")
+	assert.ErrorContains(t, err, `no value assigned to required variable foo`)
+	assert.ErrorContains(t, err, `DATABRICKS_UCM_VAR_foo`)
+}
+
+func TestSetVariable_ComplexEnvRejected(t *testing.T) {
+	v := variable.Variable{Description: "x", Default: "d", Type: variable.VariableTypeComplex}
+	t.Setenv("DATABRICKS_UCM_VAR_foo", "scalar")
+
+	dv, err := convert.FromTyped(v, dyn.NilValue)
+	require.NoError(t, err)
+	_, err = setVariable(t.Context(), dv, &v, "foo")
+	assert.ErrorContains(t, err, "not supported for complex variable foo")
+}
+
+func TestSetVariable_LookupLeftUntouched(t *testing.T) {
+	v := variable.Variable{Lookup: &variable.Lookup{Metastore: "main"}}
+	dv, err := convert.FromTyped(v, dyn.NilValue)
+	require.NoError(t, err)
+	dv2, err := setVariable(t.Context(), dv, &v, "foo")
+	require.NoError(t, err)
+
+	// Nothing assigned — lookup mutator resolves later.
+	require.NoError(t, convert.ToTyped(&v, dv2))
+	assert.Nil(t, v.Value)
+}
+
+func TestSetVariablesMutator_ResolutionLadder(t *testing.T) {
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Variables: map[string]*variable.Variable{
+				"a": {Description: "default path", Default: "def-a"},
+				"b": {Description: "env path", Default: "def-b"},
+				"c": {Description: "pre-set", Value: "cli-c"},
+			},
+		},
+	}
+	t.Setenv("DATABRICKS_UCM_VAR_b", "env-b")
+
+	diags := ucm.Apply(t.Context(), u, SetVariables())
+	require.NoError(t, diags.Error())
+	assert.Equal(t, "def-a", u.Config.Variables["a"].Value)
+	assert.Equal(t, "env-b", u.Config.Variables["b"].Value)
+	assert.Equal(t, "cli-c", u.Config.Variables["c"].Value)
+}

--- a/ucm/config/root.go
+++ b/ucm/config/root.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
@@ -14,6 +15,7 @@ import (
 	"github.com/databricks/cli/libs/dyn/merge"
 	"github.com/databricks/cli/libs/dyn/yamlloader"
 	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm/config/variable"
 )
 
 // Root is the root of the ucm.yml configuration tree.
@@ -32,6 +34,9 @@ type Root struct {
 	Account   Account   `json:"account,omitempty"`
 
 	Resources Resources `json:"resources,omitempty"`
+
+	// Variables declared under the top-level `variables:` block.
+	Variables map[string]*variable.Variable `json:"variables,omitempty"`
 
 	// Targets is set to nil by SelectTarget once a target has been merged.
 	Targets map[string]*Target `json:"targets,omitempty"`
@@ -197,5 +202,61 @@ func (r *Root) MergeTargetOverrides(name string) error {
 		}
 	}
 
+	// Merge `variables`. Per-variable: target override replaces default or
+	// lookup on the root definition (never deep-merged) so SetVariables sees
+	// a consistent view.
+	if v := target.Get("variables"); v.Kind() != dyn.KindInvalid {
+		_, err = dyn.Map(v, ".", dyn.Foreach(func(p dyn.Path, tv dyn.Value) (dyn.Value, error) {
+			varPath := dyn.MustPathFromString("variables").Append(p...)
+
+			if d := tv.Get("default"); d.Kind() != dyn.KindInvalid {
+				if root, err = dyn.SetByPath(root, varPath.Append(dyn.Key("default")), d); err != nil {
+					return root, err
+				}
+				// Clear any root-level lookup when target pins a default.
+				if root, err = dyn.SetByPath(root, varPath.Append(dyn.Key("lookup")), dyn.NilValue); err != nil {
+					return root, err
+				}
+			}
+
+			if l := tv.Get("lookup"); l.Kind() != dyn.KindInvalid {
+				if root, err = dyn.SetByPath(root, varPath.Append(dyn.Key("lookup")), l); err != nil {
+					return root, err
+				}
+				if root, err = dyn.SetByPath(root, varPath.Append(dyn.Key("default")), dyn.NilValue); err != nil {
+					return root, err
+				}
+			}
+			return root, nil
+		}))
+		if err != nil {
+			return fmt.Errorf("failed to merge target=%s variables: %w", name, err)
+		}
+	}
+
 	return r.updateWithDynamicValue(root)
+}
+
+// InitializeVariables assigns variable values from CLI-flag pairs of the form
+// "key=value". Mirrors bundle.config.Root.InitializeVariables: called from the
+// CLI layer after the target merge so --var always wins over defaults.
+func (r *Root) InitializeVariables(vars []string) error {
+	for _, v := range vars {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("unexpected flag value for variable assignment: %s", v)
+		}
+		name, val := parts[0], parts[1]
+
+		if _, ok := r.Variables[name]; !ok {
+			return fmt.Errorf("variable %s has not been defined", name)
+		}
+		if r.Variables[name].IsComplex() {
+			return fmt.Errorf("setting variables of complex type via --var flag is not supported: %s", name)
+		}
+		if err := r.Variables[name].Set(val); err != nil {
+			return fmt.Errorf("failed to assign %s to %s: %s", val, name, err)
+		}
+	}
+	return nil
 }

--- a/ucm/config/root_test.go
+++ b/ucm/config/root_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/variable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -99,4 +100,77 @@ targets:
 
 	require.NoError(t, cfg.MergeTargetOverrides("prod"))
 	assert.Equal(t, "https://prod.example.com", cfg.Workspace.Host)
+}
+
+func TestMergeTargetOverrides_VariablesDefault(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+variables:
+  catalog_name:
+    description: UC catalog root
+    default: team_alpha
+targets:
+  prod:
+    variables:
+      catalog_name:
+        default: team_prod
+`))
+	require.NoError(t, diags.Error())
+
+	require.NoError(t, cfg.MergeTargetOverrides("prod"))
+	require.Contains(t, cfg.Variables, "catalog_name")
+	assert.Equal(t, "team_prod", cfg.Variables["catalog_name"].Default)
+}
+
+func TestInitializeVariables_AssignsValues(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+variables:
+  foo:
+    default: d
+  bar:
+    default: d2
+`))
+	require.NoError(t, diags.Error())
+
+	require.NoError(t, cfg.InitializeVariables([]string{"foo=123", "bar=456"}))
+	assert.Equal(t, "123", cfg.Variables["foo"].Value)
+	assert.Equal(t, "456", cfg.Variables["bar"].Value)
+}
+
+func TestInitializeVariables_EqualSignInValue(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: acme
+variables:
+  foo: {}
+`))
+	require.NoError(t, diags.Error())
+
+	require.NoError(t, cfg.InitializeVariables([]string{"foo=123=567"}))
+	assert.Equal(t, "123=567", cfg.Variables["foo"].Value)
+}
+
+func TestInitializeVariables_InvalidFormat(t *testing.T) {
+	cfg := &config.Root{Variables: map[string]*variable.Variable{"foo": {}}}
+	err := cfg.InitializeVariables([]string{"foo"})
+	assert.ErrorContains(t, err, "unexpected flag value")
+}
+
+func TestInitializeVariables_Undefined(t *testing.T) {
+	cfg := &config.Root{Variables: map[string]*variable.Variable{"foo": {}}}
+	err := cfg.InitializeVariables([]string{"bar=567"})
+	assert.ErrorContains(t, err, "variable bar has not been defined")
+}
+
+func TestInitializeVariables_ComplexRejected(t *testing.T) {
+	cfg := &config.Root{
+		Variables: map[string]*variable.Variable{
+			"foo": {Type: variable.VariableTypeComplex},
+		},
+	}
+	err := cfg.InitializeVariables([]string{"foo=bar"})
+	assert.ErrorContains(t, err, "setting variables of complex type via --var flag is not supported")
 }

--- a/ucm/config/target.go
+++ b/ucm/config/target.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/databricks/cli/ucm/config/variable"
+
 // Target defines overrides for a single deployment target (dev/staging/prod
 // or any user-chosen name). Merged into Root when SelectTarget runs.
 type Target struct {
@@ -10,4 +12,8 @@ type Target struct {
 	Workspace *Workspace `json:"workspace,omitempty"`
 	Account   *Account   `json:"account,omitempty"`
 	Resources *Resources `json:"resources,omitempty"`
+
+	// Variables per-target override. Values replace (not deep-merge) the
+	// matching root-level variable's default/lookup.
+	Variables map[string]*variable.TargetVariable `json:"variables,omitempty"`
 }

--- a/ucm/config/variable/lookup.go
+++ b/ucm/config/variable/lookup.go
@@ -1,0 +1,88 @@
+package variable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+)
+
+// Lookup resolves a known UC entity name into its ID at runtime. Only
+// UC-applicable lookups are supported in v1; additional kinds (storage
+// credentials, external locations, ...) will land as separate fields.
+type Lookup struct {
+	Metastore string `json:"metastore,omitempty"`
+}
+
+type resolver interface {
+	Resolve(ctx context.Context, w *databricks.WorkspaceClient) (string, error)
+	String() string
+}
+
+func (l *Lookup) constructResolver() (resolver, error) {
+	var resolvers []resolver
+
+	if l.Metastore != "" {
+		resolvers = append(resolvers, resolveMetastore{name: l.Metastore})
+	}
+
+	switch len(resolvers) {
+	case 0:
+		return nil, errors.New("no valid lookup fields provided")
+	case 1:
+		return resolvers[0], nil
+	default:
+		return nil, errors.New("exactly one lookup field must be provided")
+	}
+}
+
+// Resolve looks the entity up in the target workspace and returns its ID.
+func (l *Lookup) Resolve(ctx context.Context, w *databricks.WorkspaceClient) (string, error) {
+	r, err := l.constructResolver()
+	if err != nil {
+		return "", err
+	}
+	return r.Resolve(ctx, w)
+}
+
+// String returns a human-readable representation of the lookup.
+func (l *Lookup) String() string {
+	r, _ := l.constructResolver()
+	if r == nil {
+		return ""
+	}
+	return r.String()
+}
+
+type resolveMetastore struct {
+	name string
+}
+
+func (l resolveMetastore) Resolve(ctx context.Context, w *databricks.WorkspaceClient) (string, error) {
+	result, err := w.Metastores.ListAll(ctx, catalog.ListMetastoresRequest{})
+	if err != nil {
+		return "", err
+	}
+
+	var entities []catalog.MetastoreInfo
+	for _, entity := range result {
+		if entity.Name == l.name {
+			entities = append(entities, entity)
+		}
+	}
+
+	switch len(entities) {
+	case 0:
+		return "", fmt.Errorf("metastore named %q does not exist", l.name)
+	case 1:
+		return entities[0].MetastoreId, nil
+	default:
+		return "", fmt.Errorf("there are %d instances of metastores named %q", len(entities), l.name)
+	}
+}
+
+func (l resolveMetastore) String() string {
+	return "metastore: " + l.name
+}

--- a/ucm/config/variable/variable.go
+++ b/ucm/config/variable/variable.go
@@ -1,0 +1,98 @@
+// Package variable models ucm's top-level `variables:` block. Forked from
+// bundle/config/variable with the DAB-specific lookup kinds (clusters, SPNs,
+// jobs, ...) dropped — ucm only needs UC-applicable lookups and can add more
+// as needed.
+package variable
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// VariableValue holds any resolved variable value. Aliased to any because
+// complex variables can carry arbitrary shapes.
+type VariableValue = any
+
+type VariableType string
+
+const (
+	VariableTypeComplex VariableType = "complex"
+)
+
+// Values returns all valid VariableType values.
+func (VariableType) Values() []VariableType {
+	return []VariableType{
+		VariableTypeComplex,
+	}
+}
+
+// TargetVariable aliases Variable so the JSON schema for per-target overrides
+// can be adjusted separately — a target block may either provide a full
+// Variable definition or just a default value.
+type TargetVariable Variable
+
+// Variable is an input variable declared under `variables:` in ucm.yml.
+type Variable struct {
+	// Type of the variable. Currently only "complex" has semantic effect.
+	Type VariableType `json:"type,omitempty"`
+
+	// Default value that makes the variable optional.
+	Default VariableValue `json:"default,omitempty"`
+
+	// Description used for documentation / `ucm schema` output.
+	Description string `json:"description,omitempty"`
+
+	// Value holds the resolved value. Resolution priority (highest to lowest):
+	//
+	// 1. Command-line flag `--var="foo=bar"`
+	// 2. Environment variable `DATABRICKS_UCM_VAR_<NAME>`
+	// 3. Per-target default from `targets.<name>.variables.<name>.default`
+	// 4. Root default from `variables.<name>.default`
+	// 5. Lookup (resolved later by ResolveVariableReferencesInLookup)
+	// 6. Error — the variable is required but unset.
+	Value VariableValue `json:"value,omitempty" ucm:"readonly"`
+
+	// Lookup resolves a known UC entity name into its ID at runtime.
+	Lookup *Lookup `json:"lookup,omitempty"`
+}
+
+// HasDefault reports whether the variable declared a default value.
+func (v *Variable) HasDefault() bool {
+	return v.Default != nil
+}
+
+// HasValue reports whether the variable has already been resolved.
+func (v *Variable) HasValue() bool {
+	return v.Value != nil
+}
+
+// Set assigns val to the variable. Returns an error if a value is already
+// assigned or if val's shape is incompatible with the declared type.
+func (v *Variable) Set(val VariableValue) error {
+	if v.HasValue() {
+		return fmt.Errorf("variable has already been assigned value: %s", v.Value)
+	}
+
+	if v.IsComplexValued() && v.Type != VariableTypeComplex {
+		return fmt.Errorf("variable type is not complex: %s", v.Type)
+	}
+
+	v.Value = val
+	return nil
+}
+
+// IsComplexValued reports whether v.Value is a struct/array/slice/map.
+func (v *Variable) IsComplexValued() bool {
+	rv := reflect.ValueOf(v.Value)
+	switch rv.Kind() {
+	case reflect.Struct, reflect.Array, reflect.Slice, reflect.Map:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsComplex reports whether the declared type is "complex".
+func (v *Variable) IsComplex() bool {
+	return v.Type == VariableTypeComplex
+}

--- a/ucm/config/variable/variable_test.go
+++ b/ucm/config/variable/variable_test.go
@@ -1,0 +1,64 @@
+package variable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVariable_IsComplexValued(t *testing.T) {
+	tests := []struct {
+		name string
+		v    *Variable
+		want bool
+	}{
+		{
+			name: "map",
+			v:    &Variable{Value: map[string]any{"foo": "bar"}},
+			want: true,
+		},
+		{
+			name: "slice",
+			v:    &Variable{Value: []any{1, 2, 3}},
+			want: true,
+		},
+		{
+			name: "struct",
+			v:    &Variable{Value: struct{ Foo string }{Foo: "bar"}},
+			want: true,
+		},
+		{
+			name: "scalar",
+			v:    &Variable{Value: "foo"},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.v.IsComplexValued())
+		})
+	}
+}
+
+func TestVariable_SetAndHas(t *testing.T) {
+	v := &Variable{Default: "d"}
+	assert.True(t, v.HasDefault())
+	assert.False(t, v.HasValue())
+
+	require.NoError(t, v.Set("x"))
+	assert.True(t, v.HasValue())
+	assert.Equal(t, "x", v.Value)
+
+	err := v.Set("y")
+	assert.ErrorContains(t, err, "already been assigned")
+}
+
+func TestVariable_SetAllowsAnyIncomingShape(t *testing.T) {
+	// Matches bundle.variable parity: Set checks .Value, not val, so any
+	// shape is accepted on first assignment. Schema validation happens
+	// elsewhere.
+	v := &Variable{}
+	require.NoError(t, v.Set(map[string]any{"k": "v"}))
+	assert.True(t, v.IsComplexValued())
+}

--- a/ucm/phases/load.go
+++ b/ucm/phases/load.go
@@ -10,23 +10,37 @@ import (
 )
 
 // LoadDefaultTarget prepares a freshly-loaded Ucm for downstream phases when
-// the user did not pass --target.
+// the user did not pass --target. CLI --var values must be applied AFTER this
+// phase (via u.Config.InitializeVariables) and BEFORE Variables().
 func LoadDefaultTarget(ctx context.Context, u *ucm.Ucm) {
 	ucm.ApplySeqContext(ctx, u,
 		mutator.FlattenNestedResources(),
 		mutator.InheritCatalogTags(),
 		mutator.DefineDefaultTarget(),
 		mutator.SelectDefaultTarget(),
+		mutator.InitializeVariables(),
 	)
 }
 
 // LoadNamedTarget prepares a freshly-loaded Ucm when the user passed
-// --target <name>.
+// --target <name>. CLI --var values must be applied AFTER this phase
+// (via u.Config.InitializeVariables) and BEFORE Variables().
 func LoadNamedTarget(ctx context.Context, u *ucm.Ucm, name string) {
 	ucm.ApplySeqContext(ctx, u,
 		mutator.FlattenNestedResources(),
 		mutator.InheritCatalogTags(),
 		mutator.DefineDefaultTarget(),
 		mutator.SelectTarget(name),
+		mutator.InitializeVariables(),
+	)
+}
+
+// Variables resolves variable values and substitutes ${var.x} tokens across
+// the config tree. Must run after Load*Target and after the CLI has merged
+// any --var overrides, so it sees the final effective variable set.
+func Variables(ctx context.Context, u *ucm.Ucm) {
+	ucm.ApplySeqContext(ctx, u,
+		mutator.SetVariables(),
+		mutator.ResolveVariableReferences(),
 	)
 }


### PR DESCRIPTION
Closes #37
Parent: #36 (M2 umbrella)

## Summary

Full variable subsystem mirroring DAB's — fork-and-adapt, no `bundle/**` imports.

- `variables:` block on `config.Root` + per-target override.
- `--var key=value` flag (repeatable) as a PersistentFlag on the root `ucm` command (flows to every verb via `utils.ProcessUcm`).
- `${var.x}` / `${variables.x.value}` interpolation.
- Env override via `DATABRICKS_UCM_VAR_<NAME>` (ucm's prefix, parallel to DAB's `BUNDLE_VAR_`).

## DAB files forked 1:1

- `bundle/config/variable/variable.go` → `ucm/config/variable/variable.go`
- `bundle/config/mutator/initialize_variables.go` → `ucm/config/mutator/initialize_variables.go`
- `bundle/config/mutator/set_variables.go` → `ucm/config/mutator/set_variables.go`

## Adapted

- `variable/lookup.go` kept only `metastore` lookup. DAB's other lookups (cluster, ClusterPolicy, dashboard, InstancePool, job, …) don't apply to UC.
- Extended the existing `ResolveResourceReferences` mutator file with `ResolveVariableReferences` — a simpler round-loop than DAB's 3-variant split (DAB has artifact/build/source-linked-deployment complexity ucm doesn't).
- `phases.Variables()` helper; Load*Target only runs `InitializeVariables` so CLI `--var` can interpose before `SetVariables`.

## Punted (flagged)

- File-based variable overrides (`.databricks/bundle/<target>/variable-overrides.json`) — out of scope; follow-up if needed.
- Circular-reference check handled indirectly by `maxResolutionRounds=11` cap + warning (same mechanism DAB uses).
- `current_user` lookup — DAB populates it via a separate `PopulateCurrentUser` mutator, not via the `Lookup` mechanism. Follow-up.

## Test plan

- [x] `go build ./...`, `go vet`, `go test ./cmd/ucm/... ./ucm/...` — all green.
- [x] New tests for Variable/Initialize/SetVariables/ResolveVariableReferences covering default path, env path, `--var`, required-missing, complex env rejection, lookup deferred, chained refs, unknown-var, target-override.