### PR TITLE
Fix: Repair post-merge conflict fallout across ucm verb + M2 batch

### DIFF
--- a/cmd/ucm/deployment/helpers_test.go
+++ b/cmd/ucm/deployment/helpers_test.go
@@ -155,6 +155,25 @@ func (f *fakeDirectClient) UpdatePermissions(context.Context, catalog.UpdatePerm
 	panic("bind/unbind should not call UpdatePermissions")
 }
 
+func (*fakeDirectClient) ListCatalogs(context.Context) ([]catalog.CatalogInfo, error) {
+	return nil, nil
+}
+func (*fakeDirectClient) ListSchemas(context.Context, string) ([]catalog.SchemaInfo, error) {
+	return nil, nil
+}
+func (*fakeDirectClient) ListStorageCredentials(context.Context) ([]catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+func (*fakeDirectClient) ListExternalLocations(context.Context) ([]catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+func (*fakeDirectClient) ListVolumes(context.Context, string, string) ([]catalog.VolumeInfo, error) {
+	return nil, nil
+}
+func (*fakeDirectClient) ListConnections(context.Context) ([]catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+
 var _ direct.Client = (*fakeDirectClient)(nil)
 
 // setupUcmFixture writes a ucm.yml with every supported resource kind into a

--- a/cmd/ucm/drift_test.go
+++ b/cmd/ucm/drift_test.go
@@ -110,6 +110,25 @@ func (*driftFakeClient) UpdatePermissions(context.Context, catalog.UpdatePermiss
 	panic("unexpected write")
 }
 
+func (*driftFakeClient) ListCatalogs(context.Context) ([]catalog.CatalogInfo, error) {
+	return nil, nil
+}
+func (*driftFakeClient) ListSchemas(context.Context, string) ([]catalog.SchemaInfo, error) {
+	return nil, nil
+}
+func (*driftFakeClient) ListStorageCredentials(context.Context) ([]catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+func (*driftFakeClient) ListExternalLocations(context.Context) ([]catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+func (*driftFakeClient) ListVolumes(context.Context, string, string) ([]catalog.VolumeInfo, error) {
+	return nil, nil
+}
+func (*driftFakeClient) ListConnections(context.Context) ([]catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+
 // seedDirectState writes a direct.State file under workDir/.databricks/ucm/<target>/
 // so the drift command's direct.LoadState picks it up. The valid fixture
 // selects the default target; tests that need a non-default target should

--- a/cmd/ucm/stubs.go
+++ b/cmd/ucm/stubs.go
@@ -1,45 +1,12 @@
 package ucm
 
 import (
-	"fmt"
-
-	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/debug"
 	"github.com/spf13/cobra"
 )
 
-// stub returns a cobra command that prints a not-yet-implemented message.
-// Each verb gets its own dedicated file once real behavior lands.
-func stub(use, short string) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   use,
-		Short: short,
-		Args:  root.NoArgs,
-	}
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return fmt.Errorf("ucm %s is not yet implemented", use)
-	}
-	return cmd
-}
-
-func newInitCommand() *cobra.Command {
-	return stub("init [template]", "Scaffold a new ucm.yml project from a starter template.")
-func newGenerateCommand() *cobra.Command {
-	return stub("generate", "Scan an existing account+metastore+workspace and emit ucm.yml + seed state.")
-}
-
-func newBindCommand() *cobra.Command {
-	return stub("bind", "Attach an existing Databricks resource to a ucm.yml node without recreating it.")
-}
-
 // newDebugCommand returns the `ucm debug` group. Delegates to the
-// cmd/ucm/debug subpackage so the stub file keeps its "bare wiring" role.
+// cmd/ucm/debug subpackage so each debug subcommand lives in its own file.
 func newDebugCommand() *cobra.Command {
 	return debug.New()
-}
-
-func newImportCommand() *cobra.Command {
-	return stub("import <type> <name>", "Import a single existing UC or cloud resource into ucm state.")
-func newDriftCommand() *cobra.Command {
-	return stub("drift", "Compare live UC state to persisted terraform state; alert on out-of-band changes.")
 }

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -51,12 +51,6 @@ Common invocations:
 			return root.ErrAlreadyPrinted
 		}
 
-		statePath := deploy.LocalTfStatePath(u)
-		counts, err := readTfstateCounts(statePath)
-		if err != nil {
-			return fmt.Errorf("read local state %s: %w", filepath.ToSlash(statePath), err)
-		}
-
 		out := cmd.OutOrStdout()
 		switch summaryOutputType(cmd) {
 		case flags.OutputJSON:

--- a/cmd/ucm/summary_test.go
+++ b/cmd/ucm/summary_test.go
@@ -15,20 +15,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// writeTfstateForTarget seeds .databricks/ucm/<target>/terraform/terraform.tfstate
-// under fixtureDir — the nested path where terraform natively writes and where
-// ucm's state mirroring + summary agree to look.
-func writeTfstateForTarget(t *testing.T, fixtureDir, target string, resources []map[string]any) {
+// writeUcmYml drops a ucm.yml file in a fresh temp dir and returns the dir so
+// the summary tests can drive runVerbInDir against an in-line fixture without
+// cloning the valid/ testdata tree.
+func writeUcmYml(t *testing.T, body string) string {
 	t.Helper()
-	dir := filepath.Join(fixtureDir, filepath.FromSlash(deploy.LocalCacheDir), target, "terraform")
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	blob := map[string]any{
-		"version":   4,
-		"resources": resources,
-	}
-	data, err := json.Marshal(blob)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, deploy.TfStateFileName), data, 0o600))
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ucm.yml"), []byte(body), 0o600))
+	return dir
 }
 
 func TestCmd_Summary_HeaderRendersNameAndWorkspace(t *testing.T) {

--- a/ucm/deploy/direct/drift_test.go
+++ b/ucm/deploy/direct/drift_test.go
@@ -138,6 +138,25 @@ func (*fakeReadClient) UpdatePermissions(context.Context, catalog.UpdatePermissi
 	panic("unexpected write")
 }
 
+func (*fakeReadClient) ListCatalogs(context.Context) ([]catalog.CatalogInfo, error) {
+	return nil, nil
+}
+func (*fakeReadClient) ListSchemas(context.Context, string) ([]catalog.SchemaInfo, error) {
+	return nil, nil
+}
+func (*fakeReadClient) ListStorageCredentials(context.Context) ([]catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+func (*fakeReadClient) ListExternalLocations(context.Context) ([]catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+func (*fakeReadClient) ListVolumes(context.Context, string, string) ([]catalog.VolumeInfo, error) {
+	return nil, nil
+}
+func (*fakeReadClient) ListConnections(context.Context) ([]catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+
 func TestComputeDrift_NoDrift(t *testing.T) {
 	state := direct.NewState()
 	state.Catalogs["sales"] = &direct.CatalogState{

--- a/ucm/deploy/direct/import_test.go
+++ b/ucm/deploy/direct/import_test.go
@@ -105,6 +105,25 @@ func (*importFakeClient) UpdatePermissions(_ context.Context, _ catalog.UpdatePe
 	return nil
 }
 
+func (*importFakeClient) ListCatalogs(context.Context) ([]catalog.CatalogInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) ListSchemas(context.Context, string) ([]catalog.SchemaInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) ListStorageCredentials(context.Context) ([]catalog.StorageCredentialInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) ListExternalLocations(context.Context) ([]catalog.ExternalLocationInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) ListVolumes(context.Context, string, string) ([]catalog.VolumeInfo, error) {
+	return nil, nil
+}
+func (*importFakeClient) ListConnections(context.Context) ([]catalog.ConnectionInfo, error) {
+	return nil, nil
+}
+
 func TestImportResource_CatalogSeedsStateFromSDK(t *testing.T) {
 	u := &ucm.Ucm{Config: config.Root{}}
 	u.Config.Resources.Catalogs = map[string]*resources.Catalog{

--- a/ucm/phases/options.go
+++ b/ucm/phases/options.go
@@ -17,8 +17,8 @@ type TerraformWrapper interface {
 	Render(ctx context.Context, u *ucm.Ucm) error
 	Init(ctx context.Context, u *ucm.Ucm) error
 	Plan(ctx context.Context, u *ucm.Ucm) (*terraform.PlanResult, error)
-	Apply(ctx context.Context, u *ucm.Ucm) error
-	Destroy(ctx context.Context, u *ucm.Ucm) error
+	Apply(ctx context.Context, u *ucm.Ucm, forceLock bool) error
+	Destroy(ctx context.Context, u *ucm.Ucm, forceLock bool) error
 	Import(ctx context.Context, u *ucm.Ucm, address, id string) error
 }
 


### PR DESCRIPTION
## Summary

The 13 back-to-back feature PRs (#65, #67–#81) overlapped on `stubs.go`, `phases/options.go`, `summary.go`, and the `direct.Client` test fakes. GitHub's auto-rebase dropped pieces and left main with broken build + vet + tests. This PR restores each one.

## Fallout repaired

1. **TerraformWrapper.Apply/Destroy** lost the `forceLock bool` parameter in `phases/options.go` (from #65). The production `*terraform.Terraform` kept it, callers pass it — only the interface was stale. Restored.

2. **`cmd/ucm/stubs.go`** accumulated duplicate re-stubbed verbs (init, generate, bind, import, drift) with missing closing braces — each of the seven verb-implementation PRs removed its own stub but the rebase stacked the deletions wrong. Rewrote the file to only keep `newDebugCommand()` (delegates to `cmd/ucm/debug` subpackage).

3. **`cmd/ucm/summary.go`** retained dead tfstate-reading code (`deploy` / `filepath` imports + `readTfstateCounts`) that the DAB-style reshape in #65 replaced with the config-driven renderer. Removed.

4. **`cmd/ucm/summary_test.go`** lost `writeUcmYml` (helper the DAB-style tests rely on) and carried a dead `writeTfstateForTarget` referencing the removed path. Replaced with the actual helper.

5. **`direct.Client`** gained six `List*` methods in #80 (generate) but four test fakes (`driftFakeClient`, `fakeReadClient`, `fakeDirectClient` in `cmd/ucm/deployment/`, `importFakeClient`) weren't taught them and failed interface satisfaction. Added no-op `List*` methods.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./cmd/ucm/... ./ucm/...` clean
- [x] `go test ./cmd/ucm/... ./ucm/...` all green across 15 packages