### PR TITLE
Fix #85: ucm summary renders "(not deployed)" for undeployed resources

### DIFF
--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"strings"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
@@ -19,6 +18,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// notDeployedURL is the literal rendered when a URL-bearing resource has no
+// ID in the local tfstate. Matches the DAB wording at
+// bundle/render/render_text_output.go so users reading both tools' output
+// get a consistent signal.
+const notDeployedURL = "(not deployed)"
+
 func newSummaryCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "summary",
@@ -26,9 +31,11 @@ func newSummaryCommand() *cobra.Command {
 		Long: `Summarize the resources declared by this ucm deployment, grouped by kind,
 with workspace URLs when a Workspace.Host is configured.
 
-Mirrors ` + "`databricks bundle summary`" + `: reads the post-load, post-mutator
-config tree (not the tfstate), so the output reflects ucm.yml intent. Run
-` + "`ucm deploy`" + ` to realize those intents.
+Mirrors ` + "`databricks bundle summary`" + `: loads the per-target
+terraform.tfstate from the local cache to determine which resources have
+actually been deployed. URL lines show the workspace console link for
+resources present in state and ` + "`" + notDeployedURL + "`" + ` for resources declared in
+ucm.yml but not yet applied. Run ` + "`ucm deploy`" + ` to realize declared intents.
 
 Common invocations:
   databricks ucm summary                   # Text summary of the default target
@@ -39,7 +46,8 @@ Common invocations:
 	}
 
 	// forcePull is accepted for DAB parity but is a no-op today: summary reads
-	// the in-memory config, not cached remote state.
+	// the local tfstate, not the remote workspace. Wiring a real state pull
+	// belongs in a separate change.
 	var forcePull bool
 	var includeLocations bool
 	var showFullConfig bool
@@ -50,7 +58,7 @@ Common invocations:
 	_ = cmd.Flags().MarkHidden("show-full-config")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		u := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		u := utils.ProcessUcm(cmd, utils.ProcessOptions{InitIDs: true})
 		ctx := cmd.Context()
 		if u == nil || logdiag.HasError(ctx) {
 			return root.ErrAlreadyPrinted
@@ -107,9 +115,13 @@ type resourceRow struct {
 }
 
 // resourceGroup is a titled collection of resourceRows (e.g. "Catalogs").
+// HasURL distinguishes kinds that carry a workspace URL (so an empty URL
+// renders as "(not deployed)") from kinds that never do (Grants,
+// TagValidationRules) — those stay URL-less regardless of deploy state.
 type resourceGroup struct {
-	Title string
-	Rows  []resourceRow
+	Title  string
+	Rows   []resourceRow
+	HasURL bool
 }
 
 // renderSummaryText writes the bundle-summary-shaped text output: header
@@ -119,13 +131,19 @@ func renderSummaryText(out io.Writer, u *ucm.Ucm) {
 	renderSummaryHeader(out, u)
 
 	groups := collectResourceGroups(&u.Config)
+	cyan := color.New(color.FgCyan).SprintFunc()
 	for _, g := range groups {
 		fmt.Fprintf(out, "%s:\n", g.Title)
 		for _, r := range g.Rows {
 			fmt.Fprintf(out, "  %s:\n", r.Key)
 			fmt.Fprintf(out, "    Name: %s\n", r.Name)
-			if r.URL != "" {
-				fmt.Fprintf(out, "    URL:  %s\n", r.URL)
+			if !g.HasURL {
+				continue
+			}
+			if r.URL == "" {
+				fmt.Fprintf(out, "    URL:  %s\n", notDeployedURL)
+			} else {
+				fmt.Fprintf(out, "    URL:  %s\n", cyan(r.URL))
 			}
 		}
 	}
@@ -164,8 +182,11 @@ func renderSummaryHeader(out io.Writer, u *ucm.Ucm) {
 // collectResourceGroups gathers the declared resources into titled groups
 // sorted by title, each group's rows sorted by key. Groups with no entries
 // are omitted so the output only shows sections that exist.
+//
+// URL values are read from the config fields populated by
+// mutator.InitializeURLs — an empty URL means the resource is declared but
+// not yet deployed, and is rendered as "(not deployed)" by renderSummaryText.
 func collectResourceGroups(cfg *config.Root) []resourceGroup {
-	host := strings.TrimRight(cfg.Workspace.Host, "/")
 	var groups []resourceGroup
 
 	if len(cfg.Resources.Catalogs) > 0 {
@@ -174,24 +195,34 @@ func collectResourceGroups(cfg *config.Root) []resourceGroup {
 			rows = append(rows, resourceRow{
 				Key:  key,
 				Name: c.Name,
-				URL:  joinURL(host, "/explore/data/"+c.Name),
+				URL:  c.URL,
 			})
 		}
-		groups = append(groups, resourceGroup{Title: "Catalogs", Rows: rows})
+		groups = append(groups, resourceGroup{Title: "Catalogs", Rows: rows, HasURL: true})
 	}
 
 	if len(cfg.Resources.Schemas) > 0 {
 		rows := make([]resourceRow, 0, len(cfg.Resources.Schemas))
 		for key, s := range cfg.Resources.Schemas {
 			full := s.Name
-			var url string
 			if s.Catalog != "" {
 				full = s.Catalog + "." + s.Name
-				url = joinURL(host, "/explore/data/"+s.Catalog+"/"+s.Name)
 			}
-			rows = append(rows, resourceRow{Key: key, Name: full, URL: url})
+			rows = append(rows, resourceRow{Key: key, Name: full, URL: s.URL})
 		}
-		groups = append(groups, resourceGroup{Title: "Schemas", Rows: rows})
+		groups = append(groups, resourceGroup{Title: "Schemas", Rows: rows, HasURL: true})
+	}
+
+	if len(cfg.Resources.Volumes) > 0 {
+		rows := make([]resourceRow, 0, len(cfg.Resources.Volumes))
+		for key, v := range cfg.Resources.Volumes {
+			full := v.Name
+			if v.CatalogName != "" && v.SchemaName != "" {
+				full = v.CatalogName + "." + v.SchemaName + "." + v.Name
+			}
+			rows = append(rows, resourceRow{Key: key, Name: full, URL: v.URL})
+		}
+		groups = append(groups, resourceGroup{Title: "Volumes", Rows: rows, HasURL: true})
 	}
 
 	if len(cfg.Resources.StorageCredentials) > 0 {
@@ -200,10 +231,34 @@ func collectResourceGroups(cfg *config.Root) []resourceGroup {
 			rows = append(rows, resourceRow{
 				Key:  key,
 				Name: sc.Name,
-				URL:  joinURL(host, "/explore/storage-credentials/"+sc.Name),
+				URL:  sc.URL,
 			})
 		}
-		groups = append(groups, resourceGroup{Title: "Storage credentials", Rows: rows})
+		groups = append(groups, resourceGroup{Title: "Storage credentials", Rows: rows, HasURL: true})
+	}
+
+	if len(cfg.Resources.ExternalLocations) > 0 {
+		rows := make([]resourceRow, 0, len(cfg.Resources.ExternalLocations))
+		for key, el := range cfg.Resources.ExternalLocations {
+			rows = append(rows, resourceRow{
+				Key:  key,
+				Name: el.Name,
+				URL:  el.URL,
+			})
+		}
+		groups = append(groups, resourceGroup{Title: "External locations", Rows: rows, HasURL: true})
+	}
+
+	if len(cfg.Resources.Connections) > 0 {
+		rows := make([]resourceRow, 0, len(cfg.Resources.Connections))
+		for key, conn := range cfg.Resources.Connections {
+			rows = append(rows, resourceRow{
+				Key:  key,
+				Name: conn.Name,
+				URL:  conn.URL,
+			})
+		}
+		groups = append(groups, resourceGroup{Title: "Connections", Rows: rows, HasURL: true})
 	}
 
 	if len(cfg.Resources.Grants) > 0 {
@@ -229,13 +284,4 @@ func collectResourceGroups(cfg *config.Root) []resourceGroup {
 		slices.SortFunc(groups[i].Rows, func(a, b resourceRow) int { return cmp.Compare(a.Key, b.Key) })
 	}
 	return groups
-}
-
-// joinURL returns host+path, or "" when host is empty. Keeps the caller from
-// sprinkling if-host checks everywhere.
-func joinURL(host, path string) string {
-	if host == "" {
-		return ""
-	}
-	return host + path
 }

--- a/cmd/ucm/summary_test.go
+++ b/cmd/ucm/summary_test.go
@@ -15,6 +15,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// seedTfstate drops a fake terraform.tfstate at the path deploy.LocalTfStatePath
+// will resolve to for workDir + target. Keeps the summary tests self-contained
+// without plumbing test helpers into production code.
+func seedTfstate(t *testing.T, workDir, target, body string) {
+	t.Helper()
+	dir := filepath.Join(workDir, ".databricks", "ucm", target, "terraform")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "terraform.tfstate"), []byte(body), 0o600))
+}
+
 // writeUcmYml drops a ucm.yml file in a fresh temp dir and returns the dir so
 // the summary tests can drive runVerbInDir against an in-line fixture without
 // cloning the valid/ testdata tree.
@@ -56,18 +66,43 @@ workspace:
 	assert.NotContains(t, stdout, "Storage credentials:")
 }
 
-func TestCmd_Summary_ListsCatalogsAndSchemasWithURLs(t *testing.T) {
-	stdout, _, err := runVerb(t, validFixtureDir(t), "summary")
+func TestCmd_Summary_ListsCatalogsAndSchemasWhenDeployed(t *testing.T) {
+	work := cloneFixture(t, validFixtureDir(t))
+	seedTfstate(t, work, "default", `{
+  "version": 4,
+  "resources": [
+    {"type": "databricks_catalog", "name": "team_alpha", "mode": "managed", "instances": [{"attributes": {"id": "team_alpha"}}]},
+    {"type": "databricks_schema",  "name": "bronze",     "mode": "managed", "instances": [{"attributes": {"id": "team_alpha.bronze"}}]}
+  ]
+}`)
+
+	stdout, _, err := runVerbInDir(t, work, "summary")
 
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Catalogs:")
 	assert.Contains(t, stdout, "team_alpha:")
 	assert.Contains(t, stdout, "Name: team_alpha")
-	assert.Contains(t, stdout, "URL:  https://example.cloud.databricks.com/explore/data/team_alpha")
+	assert.Contains(t, stdout, "explore/data/team_alpha")
 	assert.Contains(t, stdout, "Schemas:")
 	assert.Contains(t, stdout, "bronze:")
 	assert.Contains(t, stdout, "Name: team_alpha.bronze")
-	assert.Contains(t, stdout, "URL:  https://example.cloud.databricks.com/explore/data/team_alpha/bronze")
+	assert.Contains(t, stdout, "explore/data/team_alpha/bronze")
+}
+
+// TestCmd_Summary_ListsCatalogsAndSchemasWhenNotDeployed is the DAB-parity
+// case that prompted this fix: no local tfstate exists, so every URL-bearing
+// resource must render "(not deployed)" instead of a URL that 404s.
+func TestCmd_Summary_ListsCatalogsAndSchemasWhenNotDeployed(t *testing.T) {
+	stdout, _, err := runVerb(t, validFixtureDir(t), "summary")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Catalogs:")
+	assert.Contains(t, stdout, "team_alpha:")
+	assert.Contains(t, stdout, "URL:  (not deployed)")
+	assert.Contains(t, stdout, "Schemas:")
+	assert.Contains(t, stdout, "bronze:")
+	// No workspace-console URL should appear anywhere in the output.
+	assert.NotContains(t, stdout, "explore/data/team_alpha")
 }
 
 func TestCmd_Summary_ListsGrantsWithoutURL(t *testing.T) {
@@ -81,7 +116,37 @@ func TestCmd_Summary_ListsGrantsWithoutURL(t *testing.T) {
 	assert.NotContains(t, stdout, "URL:  https://example.cloud.databricks.com/explore/grants")
 }
 
-func TestCmd_Summary_ListsStorageCredentials(t *testing.T) {
+func TestCmd_Summary_ListsStorageCredentialsWhenDeployed(t *testing.T) {
+	work := writeUcmYml(t, `ucm:
+  name: creds-only
+
+workspace:
+  host: https://workspace.cloud.databricks.com
+
+resources:
+  storage_credentials:
+    sales_cred:
+      name: sales_cred
+      aws_iam_role:
+        role_arn: arn:aws:iam::123:role/sales
+`)
+	seedTfstate(t, work, "default", `{
+  "version": 4,
+  "resources": [
+    {"type": "databricks_storage_credential", "name": "sales_cred", "mode": "managed", "instances": [{"attributes": {"id": "sales_cred"}}]}
+  ]
+}`)
+
+	stdout, _, err := runVerbInDir(t, work, "summary")
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Storage credentials:")
+	assert.Contains(t, stdout, "sales_cred:")
+	assert.Contains(t, stdout, "Name: sales_cred")
+	assert.Contains(t, stdout, "explore/storage-credentials/sales_cred")
+}
+
+func TestCmd_Summary_ListsStorageCredentialsWhenNotDeployed(t *testing.T) {
 	work := writeUcmYml(t, `ucm:
   name: creds-only
 
@@ -101,8 +166,8 @@ resources:
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Storage credentials:")
 	assert.Contains(t, stdout, "sales_cred:")
-	assert.Contains(t, stdout, "Name: sales_cred")
-	assert.Contains(t, stdout, "URL:  https://workspace.cloud.databricks.com/explore/storage-credentials/sales_cred")
+	assert.Contains(t, stdout, "URL:  (not deployed)")
+	assert.NotContains(t, stdout, "explore/storage-credentials/sales_cred")
 }
 
 // TestCmd_Summary_OutputJSONEmitsConfig exercises the JSON branch. Cobra's

--- a/cmd/ucm/utils/utils.go
+++ b/cmd/ucm/utils/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/databricks/cli/ucm/config/engine"
 	"github.com/databricks/cli/ucm/config/mutator"
 	"github.com/databricks/cli/ucm/phases"
+	"github.com/databricks/cli/ucm/statemgmt"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +40,12 @@ type ProcessOptions struct {
 	// Validate runs phases.Validate after loading the target. Set this when
 	// implementing the `validate` or `policy-check` verbs.
 	Validate bool
+
+	// InitIDs hydrates resource.ID from the local terraform.tfstate and runs
+	// the InitializeURLs mutator. Set this for read-only consumers (e.g.
+	// `ucm summary`) that need URLs to reflect deployed-vs-not-deployed
+	// state. Mirrors cmd/bundle/utils.ProcessOptions.InitIDs.
+	InitIDs bool
 }
 
 // ProcessUcm loads the ucm.yml rooted at the working directory (or
@@ -97,6 +104,25 @@ func ProcessUcm(cmd *cobra.Command, opts ProcessOptions) *ucm.Ucm {
 	)
 	if logdiag.HasError(ctx) {
 		return u
+	}
+
+	// Hydrate resource.ID from the local tfstate and populate URL fields.
+	// Missing tfstate is treated as "first run" and leaves IDs unset, so
+	// InitializeURLs will leave URL empty and summary can render
+	// "(not deployed)". Mirrors cmd/bundle/utils.ProcessBundle's InitIDs path.
+	if opts.InitIDs {
+		ucm.ApplyFuncContext(ctx, u, func(ctx context.Context, u *ucm.Ucm) {
+			for _, d := range statemgmt.Load(ctx, u) {
+				logdiag.LogDiag(ctx, d)
+			}
+		})
+		if logdiag.HasError(ctx) {
+			return u
+		}
+		ucm.ApplyContext(ctx, u, mutator.InitializeURLs())
+		if logdiag.HasError(ctx) {
+			return u
+		}
 	}
 
 	if opts.Validate {

--- a/ucm/config/mutator/initialize_urls_test.go
+++ b/ucm/config/mutator/initialize_urls_test.go
@@ -19,22 +19,22 @@ func TestInitializeURLs(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Catalogs: map[string]*resources.Catalog{
-					"cat1": {Name: "cat1"},
+					"cat1": {Name: "cat1", ID: "cat1"},
 				},
 				Schemas: map[string]*resources.Schema{
-					"sch1": {Name: "sch1", Catalog: "cat1"},
+					"sch1": {Name: "sch1", Catalog: "cat1", ID: "cat1.sch1"},
 				},
 				Volumes: map[string]*resources.Volume{
-					"vol1": {Name: "vol1", CatalogName: "cat1", SchemaName: "sch1"},
+					"vol1": {Name: "vol1", CatalogName: "cat1", SchemaName: "sch1", ID: "cat1.sch1.vol1"},
 				},
 				StorageCredentials: map[string]*resources.StorageCredential{
-					"sc1": {Name: "sc1"},
+					"sc1": {Name: "sc1", ID: "sc1"},
 				},
 				ExternalLocations: map[string]*resources.ExternalLocation{
-					"el1": {Name: "el1", Url: "s3://bucket/path"},
+					"el1": {Name: "el1", Url: "s3://bucket/path", ID: "el1"},
 				},
 				Connections: map[string]*resources.Connection{
-					"conn1": {Name: "conn1", ConnectionType: "POSTGRESQL"},
+					"conn1": {Name: "conn1", ConnectionType: "POSTGRESQL", ID: "conn1"},
 				},
 			},
 		},
@@ -76,7 +76,7 @@ func TestInitializeURLsStripsTrailingSlash(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Catalogs: map[string]*resources.Catalog{
-					"cat1": {Name: "cat1"},
+					"cat1": {Name: "cat1", ID: "cat1"},
 				},
 			},
 		},
@@ -88,4 +88,32 @@ func TestInitializeURLsStripsTrailingSlash(t *testing.T) {
 	// Exactly one slash between host and path — no double slash regardless of
 	// whether Workspace.Host had a trailing slash.
 	assert.Equal(t, "https://mycompany.databricks.com/explore/data/cat1", u.Config.Resources.Catalogs["cat1"].URL)
+}
+
+// TestInitializeURLsSkipsNonDeployedResources verifies the DAB-parity gate:
+// resources without a tfstate ID are declared-but-not-yet-deployed and must
+// leave URL empty so `ucm summary` renders "(not deployed)" instead of a URL
+// that 404s.
+func TestInitializeURLsSkipsNonDeployedResources(t *testing.T) {
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				Host: "https://mycompany.databricks.com",
+			},
+			Resources: config.Resources{
+				Catalogs: map[string]*resources.Catalog{
+					"cat1": {Name: "cat1"}, // no ID
+				},
+				Schemas: map[string]*resources.Schema{
+					"sch1": {Name: "sch1", Catalog: "cat1"}, // no ID
+				},
+			},
+		},
+	}
+
+	diags := ucm.Apply(t.Context(), u, mutator.InitializeURLs())
+	require.Empty(t, diags)
+
+	assert.Empty(t, u.Config.Resources.Catalogs["cat1"].URL)
+	assert.Empty(t, u.Config.Resources.Schemas["sch1"].URL)
 }

--- a/ucm/config/resources/catalog.go
+++ b/ucm/config/resources/catalog.go
@@ -24,12 +24,19 @@ type Catalog struct {
 	Schemas map[string]*Schema `json:"schemas,omitempty"`
 	Grants  map[string]*Grant  `json:"grants,omitempty"`
 
+	// ID is the deployed resource's terraform-state ID. Populated by
+	// statemgmt.Load from the local tfstate; never written from ucm.yml.
+	ID string `json:"id,omitempty" ucm:"readonly"`
+
 	// URL is populated by the initialize_urls mutator.
 	URL string `json:"url,omitempty" ucm:"readonly"`
 }
 
+// InitializeURL sets c.URL iff the catalog has been deployed (ID is non-empty).
+// Mirrors bundle/config/resources.Job.InitializeURL's ID-gated pattern so
+// `ucm summary` only prints URLs that actually resolve.
 func (c *Catalog) InitializeURL(baseURL url.URL) {
-	if c.Name == "" {
+	if c.ID == "" {
 		return
 	}
 	baseURL.Path = "explore/data/" + c.Name

--- a/ucm/config/resources/catalog_test.go
+++ b/ucm/config/resources/catalog_test.go
@@ -12,17 +12,18 @@ func TestCatalogInitializeURL(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	c := &Catalog{Name: "my_catalog"}
+	c := &Catalog{Name: "my_catalog", ID: "my_catalog"}
 	c.InitializeURL(*base)
 
 	assert.Equal(t, "https://mycompany.databricks.com/explore/data/my_catalog", c.URL)
 }
 
-func TestCatalogInitializeURLSkipsWhenNameEmpty(t *testing.T) {
+func TestCatalogInitializeURLSkipsWhenIDEmpty(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	c := &Catalog{}
+	// Name is set but ID is not — a declared-but-not-deployed catalog.
+	c := &Catalog{Name: "my_catalog"}
 	c.InitializeURL(*base)
 
 	assert.Empty(t, c.URL)

--- a/ucm/config/resources/connection.go
+++ b/ucm/config/resources/connection.go
@@ -18,12 +18,18 @@ type Connection struct {
 	Properties     map[string]string `json:"properties,omitempty"`
 	ReadOnly       bool              `json:"read_only,omitempty"`
 
+	// ID is the deployed resource's terraform-state ID. Populated by
+	// statemgmt.Load from the local tfstate; never written from ucm.yml.
+	ID string `json:"id,omitempty" ucm:"readonly"`
+
 	// URL is populated by the initialize_urls mutator.
 	URL string `json:"url,omitempty" ucm:"readonly"`
 }
 
+// InitializeURL sets c.URL iff the connection has been deployed
+// (ID is non-empty).
 func (c *Connection) InitializeURL(baseURL url.URL) {
-	if c.Name == "" {
+	if c.ID == "" {
 		return
 	}
 	baseURL.Path = "explore/connections/" + c.Name

--- a/ucm/config/resources/connection_test.go
+++ b/ucm/config/resources/connection_test.go
@@ -12,17 +12,17 @@ func TestConnectionInitializeURL(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	c := &Connection{Name: "my_conn", ConnectionType: "POSTGRESQL"}
+	c := &Connection{Name: "my_conn", ConnectionType: "POSTGRESQL", ID: "my_conn"}
 	c.InitializeURL(*base)
 
 	assert.Equal(t, "https://mycompany.databricks.com/explore/connections/my_conn", c.URL)
 }
 
-func TestConnectionInitializeURLSkipsWhenNameEmpty(t *testing.T) {
+func TestConnectionInitializeURLSkipsWhenIDEmpty(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	c := &Connection{}
+	c := &Connection{Name: "my_conn", ConnectionType: "POSTGRESQL"}
 	c.InitializeURL(*base)
 
 	assert.Empty(t, c.URL)

--- a/ucm/config/resources/external_location.go
+++ b/ucm/config/resources/external_location.go
@@ -23,12 +23,18 @@ type ExternalLocation struct {
 	SkipValidation bool   `json:"skip_validation,omitempty"`
 	Fallback       bool   `json:"fallback,omitempty"`
 
+	// ID is the deployed resource's terraform-state ID. Populated by
+	// statemgmt.Load from the local tfstate; never written from ucm.yml.
+	ID string `json:"id,omitempty" ucm:"readonly"`
+
 	// URL is populated by the initialize_urls mutator.
 	URL string `json:"workspace_url,omitempty" ucm:"readonly"`
 }
 
+// InitializeURL sets e.URL iff the external location has been deployed
+// (ID is non-empty).
 func (e *ExternalLocation) InitializeURL(baseURL url.URL) {
-	if e.Name == "" {
+	if e.ID == "" {
 		return
 	}
 	baseURL.Path = "explore/external-locations/" + e.Name

--- a/ucm/config/resources/external_location_test.go
+++ b/ucm/config/resources/external_location_test.go
@@ -12,7 +12,7 @@ func TestExternalLocationInitializeURL(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	e := &ExternalLocation{Name: "my_loc", Url: "s3://bucket/path"}
+	e := &ExternalLocation{Name: "my_loc", Url: "s3://bucket/path", ID: "my_loc"}
 	e.InitializeURL(*base)
 
 	assert.Equal(t, "https://mycompany.databricks.com/explore/external-locations/my_loc", e.URL)
@@ -20,11 +20,11 @@ func TestExternalLocationInitializeURL(t *testing.T) {
 	assert.Equal(t, "s3://bucket/path", e.Url)
 }
 
-func TestExternalLocationInitializeURLSkipsWhenNameEmpty(t *testing.T) {
+func TestExternalLocationInitializeURLSkipsWhenIDEmpty(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	e := &ExternalLocation{}
+	e := &ExternalLocation{Name: "my_loc", Url: "s3://bucket/path"}
 	e.InitializeURL(*base)
 
 	assert.Empty(t, e.URL)

--- a/ucm/config/resources/schema.go
+++ b/ucm/config/resources/schema.go
@@ -28,12 +28,17 @@ type Schema struct {
 	// Always nil after load.
 	Grants map[string]*Grant `json:"grants,omitempty"`
 
+	// ID is the deployed resource's terraform-state ID. Populated by
+	// statemgmt.Load from the local tfstate; never written from ucm.yml.
+	ID string `json:"id,omitempty" ucm:"readonly"`
+
 	// URL is populated by the initialize_urls mutator.
 	URL string `json:"url,omitempty" ucm:"readonly"`
 }
 
+// InitializeURL sets s.URL iff the schema has been deployed (ID is non-empty).
 func (s *Schema) InitializeURL(baseURL url.URL) {
-	if s.Catalog == "" || s.Name == "" {
+	if s.ID == "" {
 		return
 	}
 	baseURL.Path = "explore/data/" + s.Catalog + "/" + s.Name

--- a/ucm/config/resources/schema_test.go
+++ b/ucm/config/resources/schema_test.go
@@ -12,17 +12,18 @@ func TestSchemaInitializeURL(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	s := &Schema{Name: "my_schema", Catalog: "my_catalog"}
+	s := &Schema{Name: "my_schema", Catalog: "my_catalog", ID: "my_catalog.my_schema"}
 	s.InitializeURL(*base)
 
 	assert.Equal(t, "https://mycompany.databricks.com/explore/data/my_catalog/my_schema", s.URL)
 }
 
-func TestSchemaInitializeURLSkipsWhenCatalogEmpty(t *testing.T) {
+func TestSchemaInitializeURLSkipsWhenIDEmpty(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	s := &Schema{Name: "my_schema"}
+	// Declared but not deployed: URL must not be set.
+	s := &Schema{Name: "my_schema", Catalog: "my_catalog"}
 	s.InitializeURL(*base)
 
 	assert.Empty(t, s.URL)

--- a/ucm/config/resources/storage_credential.go
+++ b/ucm/config/resources/storage_credential.go
@@ -19,12 +19,18 @@ type StorageCredential struct {
 	ReadOnly       bool `json:"read_only,omitempty"`
 	SkipValidation bool `json:"skip_validation,omitempty"`
 
+	// ID is the deployed resource's terraform-state ID. Populated by
+	// statemgmt.Load from the local tfstate; never written from ucm.yml.
+	ID string `json:"id,omitempty" ucm:"readonly"`
+
 	// URL is populated by the initialize_urls mutator.
 	URL string `json:"url,omitempty" ucm:"readonly"`
 }
 
+// InitializeURL sets s.URL iff the storage credential has been deployed
+// (ID is non-empty).
 func (s *StorageCredential) InitializeURL(baseURL url.URL) {
-	if s.Name == "" {
+	if s.ID == "" {
 		return
 	}
 	baseURL.Path = "explore/storage-credentials/" + s.Name

--- a/ucm/config/resources/storage_credential_test.go
+++ b/ucm/config/resources/storage_credential_test.go
@@ -12,17 +12,17 @@ func TestStorageCredentialInitializeURL(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	s := &StorageCredential{Name: "my_cred"}
+	s := &StorageCredential{Name: "my_cred", ID: "my_cred"}
 	s.InitializeURL(*base)
 
 	assert.Equal(t, "https://mycompany.databricks.com/explore/storage-credentials/my_cred", s.URL)
 }
 
-func TestStorageCredentialInitializeURLSkipsWhenNameEmpty(t *testing.T) {
+func TestStorageCredentialInitializeURLSkipsWhenIDEmpty(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	s := &StorageCredential{}
+	s := &StorageCredential{Name: "my_cred"}
 	s.InitializeURL(*base)
 
 	assert.Empty(t, s.URL)

--- a/ucm/config/resources/volume.go
+++ b/ucm/config/resources/volume.go
@@ -17,12 +17,17 @@ type Volume struct {
 	StorageLocation string `json:"storage_location,omitempty"`
 	Comment         string `json:"comment,omitempty"`
 
+	// ID is the deployed resource's terraform-state ID. Populated by
+	// statemgmt.Load from the local tfstate; never written from ucm.yml.
+	ID string `json:"id,omitempty" ucm:"readonly"`
+
 	// URL is populated by the initialize_urls mutator.
 	URL string `json:"url,omitempty" ucm:"readonly"`
 }
 
+// InitializeURL sets v.URL iff the volume has been deployed (ID is non-empty).
 func (v *Volume) InitializeURL(baseURL url.URL) {
-	if v.CatalogName == "" || v.SchemaName == "" || v.Name == "" {
+	if v.ID == "" {
 		return
 	}
 	baseURL.Path = "explore/data/" + v.CatalogName + "/" + v.SchemaName + "/" + v.Name

--- a/ucm/config/resources/volume_test.go
+++ b/ucm/config/resources/volume_test.go
@@ -12,17 +12,18 @@ func TestVolumeInitializeURL(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	v := &Volume{Name: "my_volume", CatalogName: "my_catalog", SchemaName: "my_schema"}
+	v := &Volume{Name: "my_volume", CatalogName: "my_catalog", SchemaName: "my_schema", ID: "my_catalog.my_schema.my_volume"}
 	v.InitializeURL(*base)
 
 	assert.Equal(t, "https://mycompany.databricks.com/explore/data/my_catalog/my_schema/my_volume", v.URL)
 }
 
-func TestVolumeInitializeURLSkipsWhenParentMissing(t *testing.T) {
+func TestVolumeInitializeURLSkipsWhenIDEmpty(t *testing.T) {
 	base, err := url.Parse("https://mycompany.databricks.com")
 	require.NoError(t, err)
 
-	v := &Volume{Name: "my_volume"}
+	// Declared but not deployed: URL must not be set.
+	v := &Volume{Name: "my_volume", CatalogName: "my_catalog", SchemaName: "my_schema"}
 	v.InitializeURL(*base)
 
 	assert.Empty(t, v.URL)

--- a/ucm/phases/initialize_test.go
+++ b/ucm/phases/initialize_test.go
@@ -100,13 +100,15 @@ func TestInitializeDefinesWorkspacePaths(t *testing.T) {
 }
 
 // TestInitializePopulatesResourceURLs asserts InitializeURLs ran inside
-// Initialize: each declared resource gets a console URL derived from the
-// configured Workspace.Host.
+// Initialize: a resource with an ID (i.e. one already present in state) gets
+// a console URL derived from the configured Workspace.Host. Resources without
+// an ID are declared-but-not-deployed and deliberately keep URL == "" so
+// `ucm summary` can render "(not deployed)".
 func TestInitializePopulatesResourceURLs(t *testing.T) {
 	f := newFixture(t)
 	f.u.Config.Workspace.Host = "https://mycompany.databricks.com"
 	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
-		"cat1": {Name: "cat1"},
+		"cat1": {Name: "cat1", ID: "cat1"},
 	}
 
 	ctx := logdiag.InitContext(t.Context())

--- a/ucm/statemgmt/state_load.go
+++ b/ucm/statemgmt/state_load.go
@@ -1,0 +1,152 @@
+// Package statemgmt wires the local terraform.tfstate into the ucm config tree
+// for summary-time rendering. Parallels bundle/statemgmt without importing
+// from it so the fork boundary stays clean.
+package statemgmt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/deploy"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// SupportedStateVersion pins the tfstate schema we understand. Matches the
+// version terraform itself emits today (also matches bundle/deploy/terraform's
+// SupportedStateVersion for ease of cross-check).
+const SupportedStateVersion = 4
+
+// resourcesState is the partial shape of terraform.tfstate we care about.
+// Matches bundle/deploy/terraform/util.go's decoder so any divergence in the
+// future is immediately visible.
+type resourcesState struct {
+	Version   int             `json:"version"`
+	Resources []stateResource `json:"resources"`
+}
+
+type stateResource struct {
+	Type      string                  `json:"type"`
+	Name      string                  `json:"name"`
+	Mode      tfjson.ResourceMode     `json:"mode"`
+	Instances []stateResourceInstance `json:"instances"`
+}
+
+type stateResourceInstance struct {
+	Attributes stateInstanceAttributes `json:"attributes"`
+}
+
+type stateInstanceAttributes struct {
+	ID string `json:"id"`
+}
+
+// terraformToGroup maps databricks_* terraform resource types onto the
+// corresponding key in Config.Resources. Grants and anything not URL-bearing
+// are deliberately absent — those groups don't carry an ID on their struct.
+var terraformToGroup = map[string]string{
+	"databricks_catalog":            "catalogs",
+	"databricks_schema":             "schemas",
+	"databricks_volume":             "volumes",
+	"databricks_storage_credential": "storage_credentials",
+	"databricks_external_location":  "external_locations",
+	"databricks_connection":         "connections",
+}
+
+// Load reads the local terraform.tfstate at deploy.LocalTfStatePath(u) and
+// copies attributes.id onto u.Config.Resources.<kind>[key].ID for each
+// managed instance whose type is mapped in terraformToGroup.
+//
+// Behaviours:
+//   - Missing tfstate file → no-op (first-run case before any deploy).
+//   - Unreadable / malformed file → diag warning; config left untouched.
+//   - Unknown terraform resource type → logged at debug, skipped.
+//   - Config key absent (resource was removed from ucm.yml after deploy) →
+//     logged at debug, skipped. Stale state is not a summary-time error.
+func Load(ctx context.Context, u *ucm.Ucm) diag.Diagnostics {
+	if u == nil {
+		return nil
+	}
+
+	path := deploy.LocalTfStatePath(u)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Debugf(ctx, "statemgmt: no local tfstate at %s; skipping ID hydration", path)
+			return nil
+		}
+		return diag.Warningf("statemgmt: read %s: %v", path, err)
+	}
+
+	var state resourcesState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return diag.Warningf("statemgmt: parse %s: %v", path, err)
+	}
+
+	if state.Version != SupportedStateVersion {
+		return diag.Warningf("statemgmt: unsupported tfstate version %d in %s (want %d)", state.Version, path, SupportedStateVersion)
+	}
+
+	applyState(ctx, u, &state)
+	return nil
+}
+
+// applyState walks the parsed tfstate and hydrates the .ID field on every
+// managed instance whose (type, name) address matches a still-declared
+// resource in u.Config.
+func applyState(ctx context.Context, u *ucm.Ucm, state *resourcesState) {
+	for _, r := range state.Resources {
+		if r.Mode != tfjson.ManagedResourceMode {
+			continue
+		}
+		group, ok := terraformToGroup[r.Type]
+		if !ok {
+			log.Debugf(ctx, "statemgmt: skip state address %s.%s (type not URL-bearing)", r.Type, r.Name)
+			continue
+		}
+		for _, inst := range r.Instances {
+			setResourceID(ctx, u, group, r.Name, inst.Attributes.ID)
+		}
+	}
+}
+
+// setResourceID writes id onto u.Config.Resources.<group>[key] when the key
+// still exists; logs and skips otherwise so stale state doesn't fail summary.
+func setResourceID(ctx context.Context, u *ucm.Ucm, group, key, id string) {
+	switch group {
+	case "catalogs":
+		if r, ok := u.Config.Resources.Catalogs[key]; ok {
+			r.ID = id
+			return
+		}
+	case "schemas":
+		if r, ok := u.Config.Resources.Schemas[key]; ok {
+			r.ID = id
+			return
+		}
+	case "volumes":
+		if r, ok := u.Config.Resources.Volumes[key]; ok {
+			r.ID = id
+			return
+		}
+	case "storage_credentials":
+		if r, ok := u.Config.Resources.StorageCredentials[key]; ok {
+			r.ID = id
+			return
+		}
+	case "external_locations":
+		if r, ok := u.Config.Resources.ExternalLocations[key]; ok {
+			r.ID = id
+			return
+		}
+	case "connections":
+		if r, ok := u.Config.Resources.Connections[key]; ok {
+			r.ID = id
+			return
+		}
+	}
+	log.Debugf(ctx, "statemgmt: state address %s.%s has no matching declared resource; skipping", group, key)
+}

--- a/ucm/statemgmt/state_load_test.go
+++ b/ucm/statemgmt/state_load_test.go
@@ -1,0 +1,179 @@
+package statemgmt_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/statemgmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUcm returns a Ucm rooted at a fresh temp dir with the target seeded so
+// deploy.LocalTfStatePath resolves to <tmp>/.databricks/ucm/<target>/terraform/terraform.tfstate.
+func newUcm(t *testing.T, target string, cfg config.Resources) *ucm.Ucm {
+	t.Helper()
+	root := t.TempDir()
+	u := &ucm.Ucm{
+		RootPath: root,
+		Config: config.Root{
+			Ucm:       config.Ucm{Target: target},
+			Resources: cfg,
+		},
+	}
+	return u
+}
+
+// writeTfstate drops a tfstate file at deploy.LocalTfStatePath(u).
+func writeTfstate(t *testing.T, u *ucm.Ucm, body string) {
+	t.Helper()
+	p := deploy.LocalTfStatePath(u)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+}
+
+func TestLoad_NilUcmIsNoOp(t *testing.T) {
+	diags := statemgmt.Load(t.Context(), nil)
+	assert.Empty(t, diags)
+}
+
+func TestLoad_MissingFileIsNoOp(t *testing.T) {
+	u := newUcm(t, "dev", config.Resources{
+		Catalogs: map[string]*resources.Catalog{"c1": {Name: "c1"}},
+	})
+
+	diags := statemgmt.Load(t.Context(), u)
+
+	assert.Empty(t, diags)
+	assert.Empty(t, u.Config.Resources.Catalogs["c1"].ID)
+}
+
+func TestLoad_MalformedJSONWarns(t *testing.T) {
+	u := newUcm(t, "dev", config.Resources{
+		Catalogs: map[string]*resources.Catalog{"c1": {Name: "c1"}},
+	})
+	writeTfstate(t, u, `{not valid json`)
+
+	diags := statemgmt.Load(t.Context(), u)
+
+	require.NotEmpty(t, diags)
+	assert.False(t, diags.HasError(), "malformed tfstate is a warning, not an error")
+	assert.Empty(t, u.Config.Resources.Catalogs["c1"].ID)
+}
+
+func TestLoad_WrongVersionWarns(t *testing.T) {
+	u := newUcm(t, "dev", config.Resources{
+		Catalogs: map[string]*resources.Catalog{"c1": {Name: "c1"}},
+	})
+	writeTfstate(t, u, `{"version": 3, "resources": []}`)
+
+	diags := statemgmt.Load(t.Context(), u)
+
+	require.NotEmpty(t, diags)
+	assert.False(t, diags.HasError())
+}
+
+func TestLoad_PopulatesIDsForMappedKinds(t *testing.T) {
+	u := newUcm(t, "dev", config.Resources{
+		Catalogs: map[string]*resources.Catalog{
+			"team_alpha": {Name: "team_alpha"},
+		},
+		Schemas: map[string]*resources.Schema{
+			"bronze": {Name: "bronze", Catalog: "team_alpha"},
+		},
+		Volumes: map[string]*resources.Volume{
+			"raw": {Name: "raw", CatalogName: "team_alpha", SchemaName: "bronze"},
+		},
+		StorageCredentials: map[string]*resources.StorageCredential{
+			"creds": {Name: "creds"},
+		},
+		ExternalLocations: map[string]*resources.ExternalLocation{
+			"loc": {Name: "loc"},
+		},
+		Connections: map[string]*resources.Connection{
+			"conn": {Name: "conn", ConnectionType: "POSTGRESQL"},
+		},
+	})
+
+	writeTfstate(t, u, `{
+  "version": 4,
+  "resources": [
+    {"type": "databricks_catalog",            "name": "team_alpha", "mode": "managed", "instances": [{"attributes": {"id": "team_alpha"}}]},
+    {"type": "databricks_schema",             "name": "bronze",     "mode": "managed", "instances": [{"attributes": {"id": "team_alpha.bronze"}}]},
+    {"type": "databricks_volume",             "name": "raw",        "mode": "managed", "instances": [{"attributes": {"id": "team_alpha.bronze.raw"}}]},
+    {"type": "databricks_storage_credential", "name": "creds",      "mode": "managed", "instances": [{"attributes": {"id": "creds"}}]},
+    {"type": "databricks_external_location",  "name": "loc",        "mode": "managed", "instances": [{"attributes": {"id": "loc"}}]},
+    {"type": "databricks_connection",         "name": "conn",       "mode": "managed", "instances": [{"attributes": {"id": "conn"}}]}
+  ]
+}`)
+
+	diags := statemgmt.Load(t.Context(), u)
+	require.Empty(t, diags)
+
+	assert.Equal(t, "team_alpha", u.Config.Resources.Catalogs["team_alpha"].ID)
+	assert.Equal(t, "team_alpha.bronze", u.Config.Resources.Schemas["bronze"].ID)
+	assert.Equal(t, "team_alpha.bronze.raw", u.Config.Resources.Volumes["raw"].ID)
+	assert.Equal(t, "creds", u.Config.Resources.StorageCredentials["creds"].ID)
+	assert.Equal(t, "loc", u.Config.Resources.ExternalLocations["loc"].ID)
+	assert.Equal(t, "conn", u.Config.Resources.Connections["conn"].ID)
+}
+
+func TestLoad_UnknownTypeIsSkipped(t *testing.T) {
+	u := newUcm(t, "dev", config.Resources{
+		Catalogs: map[string]*resources.Catalog{"c1": {Name: "c1"}},
+	})
+	writeTfstate(t, u, `{
+  "version": 4,
+  "resources": [
+    {"type": "databricks_grant",   "name": "anything", "mode": "managed", "instances": [{"attributes": {"id": "ignored"}}]},
+    {"type": "databricks_unknown", "name": "x",        "mode": "managed", "instances": [{"attributes": {"id": "ignored"}}]}
+  ]
+}`)
+
+	diags := statemgmt.Load(t.Context(), u)
+
+	assert.Empty(t, diags)
+	assert.Empty(t, u.Config.Resources.Catalogs["c1"].ID)
+}
+
+func TestLoad_MissingConfigKeyIsSkipped(t *testing.T) {
+	u := newUcm(t, "dev", config.Resources{
+		Catalogs: map[string]*resources.Catalog{
+			"c1": {Name: "c1"},
+		},
+	})
+	// state references c2, which has been removed from ucm.yml.
+	writeTfstate(t, u, `{
+  "version": 4,
+  "resources": [
+    {"type": "databricks_catalog", "name": "c2", "mode": "managed", "instances": [{"attributes": {"id": "c2"}}]}
+  ]
+}`)
+
+	diags := statemgmt.Load(t.Context(), u)
+
+	assert.Empty(t, diags)
+	assert.Empty(t, u.Config.Resources.Catalogs["c1"].ID)
+}
+
+func TestLoad_SkipsNonManagedMode(t *testing.T) {
+	u := newUcm(t, "dev", config.Resources{
+		Catalogs: map[string]*resources.Catalog{"c1": {Name: "c1"}},
+	})
+	writeTfstate(t, u, `{
+  "version": 4,
+  "resources": [
+    {"type": "databricks_catalog", "name": "c1", "mode": "data", "instances": [{"attributes": {"id": "c1"}}]}
+  ]
+}`)
+
+	diags := statemgmt.Load(t.Context(), u)
+
+	assert.Empty(t, diags)
+	assert.Empty(t, u.Config.Resources.Catalogs["c1"].ID)
+}


### PR DESCRIPTION
Closes #85

## Summary
- Gate each URL-bearing UC resource's `InitializeURL` on a new `ID` field so resources without a tfstate ID keep `URL == ""`. Mirrors the DAB pattern in `bundle/config/resources/job.go:65`.
- Add `ucm/statemgmt.Load(ctx, u)` that reads the local `terraform.tfstate` at `deploy.LocalTfStatePath(u)` and copies `attributes.id` onto `Config.Resources.<kind>[key].ID` for the six mapped terraform types. Parallels `bundle/statemgmt/state_load.go` without importing from bundle.
- Thread an `InitIDs` flag through `cmd/ucm/utils.ProcessOptions`; `ucm summary` sets it so state is hydrated before URLs populate.
- Rewrite `renderSummaryText` to emit `URL:  (not deployed)` for URL-bearing groups whose resource has no state ID, matching `bundle/render/render_text_output.go:58`. Grants and tag validation rules still render URL-less.

## Why
`databricks ucm summary` printed a workspace URL for every declared UC resource as soon as `workspace.host` was set. For resources that hadn't been deployed yet, those URLs looked legitimate but 404'd when clicked. DAB's `bundle summary` handles this correctly by loading the local tfstate, populating `URL` only when an ID is present, and showing `(not deployed)` otherwise. This change gets UCM to the same behaviour.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...`
- [x] New `ucm/statemgmt/state_load_test.go` covers missing file no-op, malformed JSON, unsupported version, mapped-type hydration, unknown type skip, missing config key skip, and non-managed mode skip.
- [x] `cmd/ucm/summary_test.go` split into `_WhenDeployed` (seeds a fake tfstate) and `_WhenNotDeployed` (no tfstate → asserts `URL:  (not deployed)`) variants for catalogs/schemas and storage credentials.
- [x] `TestCmd_Summary_ListsGrantsWithoutURL` still passes — `HasURL=false` keeps grants URL-less.

## Fork-divergence notes
- Edits to upstream files: **none**.
- All changes live inside `cmd/ucm/**` and `ucm/**` (new package `ucm/statemgmt/`, plus edits to `cmd/ucm/summary.go`, `cmd/ucm/summary_test.go`, `cmd/ucm/utils/utils.go`, the six `ucm/config/resources/*` files and their tests, `ucm/config/mutator/initialize_urls_test.go`, and `ucm/phases/initialize_test.go`).

## Base branch
`main`.