### PR TITLE
Fix #85 follow-up: Color "(not deployed)" cyan in ucm summary

### DIFF
--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -141,7 +141,7 @@ func renderSummaryText(out io.Writer, u *ucm.Ucm) {
 				continue
 			}
 			if r.URL == "" {
-				fmt.Fprintf(out, "    URL:  %s\n", notDeployedURL)
+				fmt.Fprintf(out, "    URL:  %s\n", cyan(notDeployedURL))
 			} else {
 				fmt.Fprintf(out, "    URL:  %s\n", cyan(r.URL))
 			}


### PR DESCRIPTION
Follow-up to #86 (which closed #85). The merged PR rendered the real URL in cyan but left the `(not deployed)` placeholder uncolored; `databricks bundle summary` colors both via `bundle/render/render_text_output.go:58`. This one-line change brings UCM to literal DAB parity.

## Summary
- Wrap the `(not deployed)` literal in the same `color.FgCyan` SprintFunc already used for live URLs in `cmd/ucm/summary.go:renderSummaryText`.

## Why
DAB parity missed in PR #86. No new tests needed — `fatih/color` no-ops when writing to a non-TTY `bytes.Buffer`, so existing `"URL:  (not deployed)"` substring assertions continue to pass.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/ucm/... ./ucm/...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] Manual: verified the change only affects colored output