### PR TITLE
feat(ucm): align terraform env setup with DAB

### DIFF
--- a/ucm/deploy/terraform/dir.go
+++ b/ucm/deploy/terraform/dir.go
@@ -16,13 +16,14 @@ import (
 // accidentally share state.
 const cacheDirName = ".databricks/ucm"
 
-// WorkingDir returns the absolute path of the terraform working directory
-// for the currently selected target: `<root>/.databricks/ucm/<target>/terraform`.
-// The directory is created on demand with 0o700 permissions.
+// localStateDir returns `<root>/.databricks/ucm/<target>/<sub>`, creating
+// the directory on demand with 0o700 permissions. Mirrors
+// bundle.Bundle.LocalStateDir.
 //
-// Errors if no target has been selected — the caller should have run
-// SelectTarget (or SelectDefaultTarget) before reaching here.
-func WorkingDir(u *ucm.Ucm) (string, error) {
+// Errors when u is nil, when no target has been selected, or when mkdir
+// fails. Callers are expected to have run SelectTarget (or
+// SelectDefaultTarget) before reaching here.
+func localStateDir(u *ucm.Ucm, sub string) (string, error) {
 	if u == nil {
 		return "", errors.New("ucm is nil")
 	}
@@ -30,9 +31,19 @@ func WorkingDir(u *ucm.Ucm) (string, error) {
 	if target == "" {
 		return "", errors.New("target not set; run SelectTarget before terraform operations")
 	}
-	dir := filepath.Join(u.RootPath, filepath.FromSlash(cacheDirName), target, "terraform")
+	dir := filepath.Join(u.RootPath, filepath.FromSlash(cacheDirName), target, sub)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", fmt.Errorf("create terraform working directory %s: %w", dir, err)
+		return "", fmt.Errorf("create %s: %w", dir, err)
 	}
 	return dir, nil
+}
+
+// WorkingDir returns the absolute path of the terraform working directory
+// for the currently selected target: `<root>/.databricks/ucm/<target>/terraform`.
+// The directory is created on demand with 0o700 permissions.
+//
+// Errors if no target has been selected — the caller should have run
+// SelectTarget (or SelectDefaultTarget) before reaching here.
+func WorkingDir(u *ucm.Ucm) (string, error) {
+	return localStateDir(u, "terraform")
 }

--- a/ucm/deploy/terraform/dir_test.go
+++ b/ucm/deploy/terraform/dir_test.go
@@ -1,0 +1,39 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalStateDirReturnsAbsolutePath(t *testing.T) {
+	root := t.TempDir()
+	u := &ucm.Ucm{RootPath: root}
+	u.Config.Ucm.Target = "dev"
+
+	dir, err := localStateDir(u, "tmp")
+	require.NoError(t, err)
+
+	want := filepath.Join(root, ".databricks", "ucm", "dev", "tmp")
+	assert.Equal(t, want, dir)
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestLocalStateDirErrorsWhenTargetUnset(t *testing.T) {
+	u := &ucm.Ucm{RootPath: t.TempDir()}
+	_, err := localStateDir(u, "tmp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target")
+}
+
+func TestLocalStateDirErrorsWhenUcmNil(t *testing.T) {
+	_, err := localStateDir(nil, "tmp")
+	require.Error(t, err)
+}

--- a/ucm/deploy/terraform/env.go
+++ b/ucm/deploy/terraform/env.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -156,6 +157,28 @@ func setProxyEnvVars(ctx context.Context, environ map[string]string) error {
 		}
 	}
 	return nil
+}
+
+// resolveDatabricksCliPath rewrites a relative DATABRICKS_CLI_PATH on
+// environ into its absolute form so the terraform subprocess — which
+// runs from .databricks/ucm/<target>/terraform — can still invoke the
+// parent CLI. Basename-only values are left as-is (the SDK will look
+// them up on $PATH). Values that are already absolute are left as-is.
+//
+// DAB carries the same bug in bundle/config/workspace.go's init() but
+// the fork rules forbid UCM PRs from editing bundle/**; until a
+// separate upstream fix lands, UCM absolute-izes locally.
+func resolveDatabricksCliPath(environ map[string]string) {
+	v, ok := environ["DATABRICKS_CLI_PATH"]
+	if !ok || v == "" {
+		return
+	}
+	if v == filepath.Base(v) {
+		return
+	}
+	if abs, err := filepath.Abs(v); err == nil {
+		environ["DATABRICKS_CLI_PATH"] = abs
+	}
 }
 
 // setTempDirEnvVars sets TMP/TEMP (Windows) or TMPDIR (Unix) on environ.

--- a/ucm/deploy/terraform/env.go
+++ b/ucm/deploy/terraform/env.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"runtime"
 
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
 )
 
 // getEnvVarWithMatchingVersion returns envVarName's value only when the
@@ -136,5 +138,32 @@ func inheritEnvVars(ctx context.Context, environ map[string]string) error {
 		environ["TF_CLI_CONFIG_FILE"] = configFile
 	}
 
+	return nil
+}
+
+// setTempDirEnvVars sets TMP/TEMP (Windows) or TMPDIR (Unix) on environ.
+// On Windows, if none of TMP/TEMP are set on the parent process, it
+// falls back to `<root>/.databricks/ucm/<target>/tmp` to avoid MAX_PATH
+// blow-ups for deeply nested state dirs. Mirrors
+// bundle/deploy/terraform/init.go's setTempDirEnvVars.
+func setTempDirEnvVars(ctx context.Context, environ map[string]string, u *ucm.Ucm) error {
+	switch runtime.GOOS {
+	case "windows":
+		if v, ok := env.Lookup(ctx, "TMP"); ok {
+			environ["TMP"] = v
+		} else if v, ok := env.Lookup(ctx, "TEMP"); ok {
+			environ["TEMP"] = v
+		} else {
+			tmpDir, err := localStateDir(u, "tmp")
+			if err != nil {
+				return err
+			}
+			environ["TMP"] = tmpDir
+		}
+	default:
+		if v, ok := env.Lookup(ctx, "TMPDIR"); ok {
+			environ["TMPDIR"] = v
+		}
+	}
 	return nil
 }

--- a/ucm/deploy/terraform/env.go
+++ b/ucm/deploy/terraform/env.go
@@ -1,0 +1,46 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/log"
+)
+
+// getEnvVarWithMatchingVersion returns envVarName's value only when the
+// path it points to exists and, if versionVarName is set, its value
+// matches currentVersion. Mirrors bundle/deploy/terraform/init.go. The
+// VSCode extension sets DATABRICKS_TF_CLI_CONFIG_FILE + the corresponding
+// DATABRICKS_TF_PROVIDER_VERSION so that a cached provider mirror is only
+// honoured when it was built against the provider version we actually
+// use; using a mismatched mirror would make terraform init fail.
+func getEnvVarWithMatchingVersion(ctx context.Context, envVarName, versionVarName, currentVersion string) (string, error) {
+	envValue := env.Get(ctx, envVarName)
+	versionValue := env.Get(ctx, versionVarName)
+
+	if envValue == "" {
+		log.Debugf(ctx, "%s is not defined", envVarName)
+		return "", nil
+	}
+
+	if _, err := os.Stat(envValue); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			log.Debugf(ctx, "%s at %s does not exist", envVarName, envValue)
+			return "", nil
+		}
+		return "", err
+	}
+
+	if versionValue == "" {
+		return envValue, nil
+	}
+
+	if versionValue != currentVersion {
+		log.Debugf(ctx, "%s as %s does not match the current version %s, ignoring %s", versionVarName, versionValue, currentVersion, envVarName)
+		return "", nil
+	}
+	return envValue, nil
+}

--- a/ucm/deploy/terraform/env.go
+++ b/ucm/deploy/terraform/env.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/log"
@@ -138,6 +139,22 @@ func inheritEnvVars(ctx context.Context, environ map[string]string) error {
 		environ["TF_CLI_CONFIG_FILE"] = configFile
 	}
 
+	return nil
+}
+
+// setProxyEnvVars inherits HTTP_PROXY, HTTPS_PROXY, NO_PROXY from the
+// parent process onto environ. The case of these vars is notoriously
+// inconsistent on Unix tools; we read both upper and lower case forms
+// and emit only the upper-case form to terraform. Mirrors
+// bundle/deploy/terraform/init.go's setProxyEnvVars.
+func setProxyEnvVars(ctx context.Context, environ map[string]string) error {
+	for _, v := range []string{"http_proxy", "https_proxy", "no_proxy"} {
+		for _, key := range []string{strings.ToUpper(v), strings.ToLower(v)} {
+			if val, ok := env.Lookup(ctx, key); ok {
+				environ[strings.ToUpper(v)] = val
+			}
+		}
+	}
 	return nil
 }
 

--- a/ucm/deploy/terraform/env.go
+++ b/ucm/deploy/terraform/env.go
@@ -44,3 +44,97 @@ func getEnvVarWithMatchingVersion(ctx context.Context, envVarName, versionVarNam
 	}
 	return envValue, nil
 }
+
+// envCopy enumerates environment variables that are passed through to the
+// terraform subprocess verbatim. Mirrors bundle/deploy/terraform/init.go.
+var envCopy = []string{
+	// $HOME — terraform and the databricks provider read ~/.databrickscfg,
+	// ~/.databricks/token-cache, etc. from HOME.
+	"HOME",
+
+	// $USERPROFILE — Windows equivalent of HOME; used by Azure CLI to
+	// locate stored credentials and metadata.
+	"USERPROFILE",
+
+	// $PATH — so the databricks provider can invoke auxiliary tools
+	// (`az`, `gcloud`) that live on PATH.
+	"PATH",
+
+	// $AZURE_CONFIG_DIR — set by Azure DevOps' AzureCLI@2 task so
+	// downstream az invocations share the same config dir.
+	"AZURE_CONFIG_DIR",
+
+	// $TF_CLI_CONFIG_FILE — override terraform provider source in
+	// development. See
+	// https://developer.hashicorp.com/terraform/cli/config/config-file
+	"TF_CLI_CONFIG_FILE",
+
+	// $USE_SDK_V2_RESOURCES / $USE_SDK_V2_DATA_SOURCES — escape hatch for
+	// the databricks provider's plugin-framework ↔ SDKv2 migration.
+	// See https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/troubleshooting#plugin-framework-migration-problems
+	"USE_SDK_V2_RESOURCES",
+	"USE_SDK_V2_DATA_SOURCES",
+}
+
+// azureDevOpsSystemVars enumerates Azure DevOps SYSTEM_* variables the
+// databricks SDK reads during OIDC authentication on Azure DevOps
+// pipelines. Passed through so terraform-spawned SDK calls can use the
+// same OIDC token exchange the parent CLI would.
+var azureDevOpsSystemVars = []string{
+	"SYSTEM_ACCESSTOKEN",
+	"SYSTEM_COLLECTIONID",
+	"SYSTEM_COLLECTIONURI",
+	"SYSTEM_DEFINITIONID",
+	"SYSTEM_HOSTTYPE",
+	"SYSTEM_JOBID",
+	"SYSTEM_OIDCREQUESTURI",
+	"SYSTEM_PLANID",
+	"SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
+	"SYSTEM_TEAMPROJECT",
+	"SYSTEM_TEAMPROJECTID",
+}
+
+// inheritEnvVars populates environ with env vars that should cross into
+// the terraform subprocess: the envCopy allow-list, OIDC token (direct or
+// indirect via DATABRICKS_OIDC_TOKEN_ENV), Azure DevOps SYSTEM_* vars,
+// and a version-gated DATABRICKS_TF_CLI_CONFIG_FILE → TF_CLI_CONFIG_FILE
+// mapping. Mirrors bundle/deploy/terraform/init.go's inheritEnvVars.
+func inheritEnvVars(ctx context.Context, environ map[string]string) error {
+	for _, key := range envCopy {
+		if v, ok := env.Lookup(ctx, key); ok {
+			environ[key] = v
+		}
+	}
+
+	// DATABRICKS_OIDC_TOKEN_ENV points at another env var that holds the
+	// actual token. When unset we fall back to DATABRICKS_OIDC_TOKEN.
+	oidcTokenEnv, ok := env.Lookup(ctx, "DATABRICKS_OIDC_TOKEN_ENV")
+	if ok {
+		environ["DATABRICKS_OIDC_TOKEN_ENV"] = oidcTokenEnv
+	} else {
+		oidcTokenEnv = "DATABRICKS_OIDC_TOKEN"
+	}
+	if token, ok := env.Lookup(ctx, oidcTokenEnv); ok {
+		environ[oidcTokenEnv] = token
+	}
+
+	for _, k := range azureDevOpsSystemVars {
+		if v, ok := env.Lookup(ctx, k); ok {
+			environ[k] = v
+		}
+	}
+
+	// Map DATABRICKS_TF_CLI_CONFIG_FILE → TF_CLI_CONFIG_FILE only when the
+	// mirror matches the provider version we actually use; otherwise
+	// terraform init would fail to download the right version.
+	configFile, err := getEnvVarWithMatchingVersion(ctx, CliConfigPathEnv, ProviderVersionEnv, ProviderVersion)
+	if err != nil {
+		return err
+	}
+	if configFile != "" {
+		log.Debugf(ctx, "Using Terraform CLI config from %s at %s", CliConfigPathEnv, configFile)
+		environ["TF_CLI_CONFIG_FILE"] = configFile
+	}
+
+	return nil
+}

--- a/ucm/deploy/terraform/env_test.go
+++ b/ucm/deploy/terraform/env_test.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/databricks/cli/libs/env"
@@ -156,4 +157,61 @@ func TestInheritEnvVarsSkipsCliConfigFileOnVersionMismatch(t *testing.T) {
 
 	_, ok := out["TF_CLI_CONFIG_FILE"]
 	assert.False(t, ok, "mismatched version must not emit TF_CLI_CONFIG_FILE")
+}
+
+func TestSetTempDirEnvVarsUnixInheritsTMPDIR(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only branch")
+	}
+	u, _ := newRenderUcm(t)
+	ctx := env.Set(t.Context(), "TMPDIR", "/custom/tmp")
+
+	out := map[string]string{}
+	require.NoError(t, setTempDirEnvVars(ctx, out, u))
+
+	assert.Equal(t, "/custom/tmp", out["TMPDIR"])
+}
+
+func TestSetTempDirEnvVarsUnixOmitsWhenUnset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only branch")
+	}
+	u, _ := newRenderUcm(t)
+	// Ensure TMPDIR is truly absent from both the context and the process env.
+	t.Setenv("TMPDIR", "")
+	require.NoError(t, os.Unsetenv("TMPDIR"))
+	ctx := t.Context()
+
+	out := map[string]string{}
+	require.NoError(t, setTempDirEnvVars(ctx, out, u))
+
+	_, ok := out["TMPDIR"]
+	assert.False(t, ok)
+}
+
+func TestSetTempDirEnvVarsWindowsInheritsTMP(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only branch")
+	}
+	u, _ := newRenderUcm(t)
+	ctx := env.Set(t.Context(), "TMP", `C:\custom\tmp`)
+
+	out := map[string]string{}
+	require.NoError(t, setTempDirEnvVars(ctx, out, u))
+
+	assert.Equal(t, `C:\custom\tmp`, out["TMP"])
+}
+
+func TestSetTempDirEnvVarsWindowsFallsBackToLocalStateDir(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only branch")
+	}
+	u, root := newRenderUcm(t)
+	ctx := t.Context()
+
+	out := map[string]string{}
+	require.NoError(t, setTempDirEnvVars(ctx, out, u))
+
+	want := filepath.Join(root, ".databricks", "ucm", "dev", "tmp")
+	assert.Equal(t, want, out["TMP"])
 }

--- a/ucm/deploy/terraform/env_test.go
+++ b/ucm/deploy/terraform/env_test.go
@@ -251,3 +251,38 @@ func TestSetProxyEnvVarsOmitsUnset(t *testing.T) {
 		assert.False(t, ok, "%s should not be set when neither case is on env", k)
 	}
 }
+
+func TestResolveDatabricksCliPathLeavesAbsoluteUnchanged(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), "cli")
+	environ := map[string]string{"DATABRICKS_CLI_PATH": abs}
+
+	resolveDatabricksCliPath(environ)
+
+	assert.Equal(t, abs, environ["DATABRICKS_CLI_PATH"])
+}
+
+func TestResolveDatabricksCliPathLeavesBasenameUnchanged(t *testing.T) {
+	environ := map[string]string{"DATABRICKS_CLI_PATH": "databricks"}
+
+	resolveDatabricksCliPath(environ)
+
+	// Basename-only means "use PATH resolution in the child"; we don't
+	// want to rewrite it to an absolute cwd-relative path.
+	assert.Equal(t, "databricks", environ["DATABRICKS_CLI_PATH"])
+}
+
+func TestResolveDatabricksCliPathResolvesRelative(t *testing.T) {
+	environ := map[string]string{"DATABRICKS_CLI_PATH": "../cli/cli"}
+
+	resolveDatabricksCliPath(environ)
+
+	assert.True(t, filepath.IsAbs(environ["DATABRICKS_CLI_PATH"]),
+		"expected absolute path, got %q", environ["DATABRICKS_CLI_PATH"])
+}
+
+func TestResolveDatabricksCliPathNoop(t *testing.T) {
+	environ := map[string]string{}
+	resolveDatabricksCliPath(environ)
+	_, ok := environ["DATABRICKS_CLI_PATH"]
+	assert.False(t, ok)
+}

--- a/ucm/deploy/terraform/env_test.go
+++ b/ucm/deploy/terraform/env_test.go
@@ -1,0 +1,53 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEnvVarWithMatchingVersionUnsetReturnsEmpty(t *testing.T) {
+	got, err := getEnvVarWithMatchingVersion(t.Context(), "UCM_TEST_ENV", "UCM_TEST_VER", "1.0")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestGetEnvVarWithMatchingVersionPathMissingReturnsEmpty(t *testing.T) {
+	ctx := env.Set(t.Context(), "UCM_TEST_ENV", "/definitely/not/a/real/path/xyzzy")
+	got, err := getEnvVarWithMatchingVersion(ctx, "UCM_TEST_ENV", "UCM_TEST_VER", "1.0")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestGetEnvVarWithMatchingVersionNoVersionReturnsValue(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+	ctx := env.Set(t.Context(), "UCM_TEST_ENV", f)
+	got, err := getEnvVarWithMatchingVersion(ctx, "UCM_TEST_ENV", "UCM_TEST_VER", "1.0")
+	require.NoError(t, err)
+	assert.Equal(t, f, got)
+}
+
+func TestGetEnvVarWithMatchingVersionMatchingVersionReturnsValue(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+	ctx := env.Set(t.Context(), "UCM_TEST_ENV", f)
+	ctx = env.Set(ctx, "UCM_TEST_VER", "1.0")
+	got, err := getEnvVarWithMatchingVersion(ctx, "UCM_TEST_ENV", "UCM_TEST_VER", "1.0")
+	require.NoError(t, err)
+	assert.Equal(t, f, got)
+}
+
+func TestGetEnvVarWithMatchingVersionMismatchReturnsEmpty(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+	ctx := env.Set(t.Context(), "UCM_TEST_ENV", f)
+	ctx = env.Set(ctx, "UCM_TEST_VER", "0.9")
+	got, err := getEnvVarWithMatchingVersion(ctx, "UCM_TEST_ENV", "UCM_TEST_VER", "1.0")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/ucm/deploy/terraform/env_test.go
+++ b/ucm/deploy/terraform/env_test.go
@@ -51,3 +51,109 @@ func TestGetEnvVarWithMatchingVersionMismatchReturnsEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
+
+func TestInheritEnvVarsPassesThroughEnvCopy(t *testing.T) {
+	ctx := t.Context()
+	for _, k := range []string{
+		"HOME",
+		"USERPROFILE",
+		"PATH",
+		"AZURE_CONFIG_DIR",
+		"TF_CLI_CONFIG_FILE",
+		"USE_SDK_V2_RESOURCES",
+		"USE_SDK_V2_DATA_SOURCES",
+	} {
+		ctx = env.Set(ctx, k, "val-"+k)
+	}
+
+	out := map[string]string{}
+	require.NoError(t, inheritEnvVars(ctx, out))
+
+	for _, k := range []string{
+		"HOME",
+		"USERPROFILE",
+		"PATH",
+		"AZURE_CONFIG_DIR",
+		"TF_CLI_CONFIG_FILE",
+		"USE_SDK_V2_RESOURCES",
+		"USE_SDK_V2_DATA_SOURCES",
+	} {
+		assert.Equal(t, "val-"+k, out[k], "expected %s pass-through", k)
+	}
+}
+
+func TestInheritEnvVarsDirectOidcToken(t *testing.T) {
+	ctx := env.Set(t.Context(), "DATABRICKS_OIDC_TOKEN", "direct-token")
+
+	out := map[string]string{}
+	require.NoError(t, inheritEnvVars(ctx, out))
+
+	assert.Equal(t, "direct-token", out["DATABRICKS_OIDC_TOKEN"])
+	_, hasIndirect := out["DATABRICKS_OIDC_TOKEN_ENV"]
+	assert.False(t, hasIndirect)
+}
+
+func TestInheritEnvVarsIndirectOidcToken(t *testing.T) {
+	ctx := env.Set(t.Context(), "DATABRICKS_OIDC_TOKEN_ENV", "CUSTOM_OIDC_VAR")
+	ctx = env.Set(ctx, "CUSTOM_OIDC_VAR", "custom-token")
+
+	out := map[string]string{}
+	require.NoError(t, inheritEnvVars(ctx, out))
+
+	assert.Equal(t, "CUSTOM_OIDC_VAR", out["DATABRICKS_OIDC_TOKEN_ENV"])
+	assert.Equal(t, "custom-token", out["CUSTOM_OIDC_VAR"])
+}
+
+func TestInheritEnvVarsAzureDevOpsSystemVars(t *testing.T) {
+	ctx := t.Context()
+	vars := []string{
+		"SYSTEM_ACCESSTOKEN",
+		"SYSTEM_COLLECTIONID",
+		"SYSTEM_COLLECTIONURI",
+		"SYSTEM_DEFINITIONID",
+		"SYSTEM_HOSTTYPE",
+		"SYSTEM_JOBID",
+		"SYSTEM_OIDCREQUESTURI",
+		"SYSTEM_PLANID",
+		"SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
+		"SYSTEM_TEAMPROJECT",
+		"SYSTEM_TEAMPROJECTID",
+	}
+	for _, k := range vars {
+		ctx = env.Set(ctx, k, "val-"+k)
+	}
+
+	out := map[string]string{}
+	require.NoError(t, inheritEnvVars(ctx, out))
+
+	for _, k := range vars {
+		assert.Equal(t, "val-"+k, out[k], "expected %s forward", k)
+	}
+}
+
+func TestInheritEnvVarsMapsCliConfigFileWhenVersionMatches(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "cliconfig")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+
+	ctx := env.Set(t.Context(), CliConfigPathEnv, f)
+	ctx = env.Set(ctx, ProviderVersionEnv, ProviderVersion)
+
+	out := map[string]string{}
+	require.NoError(t, inheritEnvVars(ctx, out))
+
+	assert.Equal(t, f, out["TF_CLI_CONFIG_FILE"])
+}
+
+func TestInheritEnvVarsSkipsCliConfigFileOnVersionMismatch(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "cliconfig")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+
+	ctx := env.Set(t.Context(), CliConfigPathEnv, f)
+	ctx = env.Set(ctx, ProviderVersionEnv, "0.0.0-mismatch")
+
+	out := map[string]string{}
+	require.NoError(t, inheritEnvVars(ctx, out))
+
+	_, ok := out["TF_CLI_CONFIG_FILE"]
+	assert.False(t, ok, "mismatched version must not emit TF_CLI_CONFIG_FILE")
+}

--- a/ucm/deploy/terraform/env_test.go
+++ b/ucm/deploy/terraform/env_test.go
@@ -215,3 +215,39 @@ func TestSetTempDirEnvVarsWindowsFallsBackToLocalStateDir(t *testing.T) {
 	want := filepath.Join(root, ".databricks", "ucm", "dev", "tmp")
 	assert.Equal(t, want, out["TMP"])
 }
+
+func TestSetProxyEnvVarsUpperCase(t *testing.T) {
+	ctx := env.Set(t.Context(), "HTTP_PROXY", "http://up:3128")
+	ctx = env.Set(ctx, "HTTPS_PROXY", "http://up:3129")
+	ctx = env.Set(ctx, "NO_PROXY", "localhost")
+
+	out := map[string]string{}
+	require.NoError(t, setProxyEnvVars(ctx, out))
+
+	assert.Equal(t, "http://up:3128", out["HTTP_PROXY"])
+	assert.Equal(t, "http://up:3129", out["HTTPS_PROXY"])
+	assert.Equal(t, "localhost", out["NO_PROXY"])
+}
+
+func TestSetProxyEnvVarsLowerCaseNormalizedToUpper(t *testing.T) {
+	ctx := env.Set(t.Context(), "http_proxy", "http://low:3128")
+	ctx = env.Set(ctx, "https_proxy", "http://low:3129")
+	ctx = env.Set(ctx, "no_proxy", "127.0.0.1")
+
+	out := map[string]string{}
+	require.NoError(t, setProxyEnvVars(ctx, out))
+
+	assert.Equal(t, "http://low:3128", out["HTTP_PROXY"])
+	assert.Equal(t, "http://low:3129", out["HTTPS_PROXY"])
+	assert.Equal(t, "127.0.0.1", out["NO_PROXY"])
+}
+
+func TestSetProxyEnvVarsOmitsUnset(t *testing.T) {
+	out := map[string]string{}
+	require.NoError(t, setProxyEnvVars(t.Context(), out))
+
+	for _, k := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+		_, ok := out[k]
+		assert.False(t, ok, "%s should not be set when neither case is on env", k)
+	}
+}

--- a/ucm/deploy/terraform/terraform.go
+++ b/ucm/deploy/terraform/terraform.go
@@ -204,10 +204,11 @@ func buildEnv(ctx context.Context, u *ucm.Ucm, authCfg *config.Config) (map[stri
 		return nil, err
 	}
 
-	// Pick up DATABRICKS_CLI_PATH from the parent env/context so
-	// resolveDatabricksCliPath can absolute-ize it. It is not in
-	// envCopy because it is UCM-only and must be processed rather than
-	// forwarded verbatim.
+	// Pre-seed DATABRICKS_CLI_PATH from the parent env so
+	// resolveDatabricksCliPath has something to absolute-ize when
+	// authCfg is nil. inheritEnvVars's envCopy allow-list
+	// intentionally omits this key — it needs to be processed (made
+	// absolute), not forwarded verbatim.
 	if v, ok := env.Lookup(ctx, "DATABRICKS_CLI_PATH"); ok && v != "" {
 		out["DATABRICKS_CLI_PATH"] = v
 	}

--- a/ucm/deploy/terraform/terraform.go
+++ b/ucm/deploy/terraform/terraform.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strings"
 
 	"github.com/databricks/cli/libs/auth"
 	"github.com/databricks/cli/libs/env"
@@ -60,8 +58,9 @@ type Terraform struct {
 	// WorkingDir is where main.tf.json, the plan artefact, and the state
 	// backend config live.
 	WorkingDir string
-	// Env is the environment map passed to terraform-exec. Populated by New;
-	// includes DATABRICKS_HOST/CLIENT_ID/CLIENT_SECRET + cloud-cred passthrough.
+	// Env is the environment map passed to terraform-exec. Populated by New
+	// from buildEnv — auth.Env(authCfg) + inheritEnvVars + temp/proxy
+	// passthrough + DATABRICKS_CLI_PATH absolute-ization.
 	Env map[string]string
 
 	runner         tfRunner
@@ -77,8 +76,8 @@ type Terraform struct {
 
 // New wires up a Terraform for the given ucm. It resolves (and if necessary
 // downloads via hc-install) the terraform binary, computes the working
-// directory, and assembles the env-var map used for auth and cloud-cred
-// passthrough. The caller is expected to have run SelectTarget first.
+// directory, and assembles the env-var map used for auth and process
+// plumbing. The caller is expected to have run SelectTarget first.
 func New(ctx context.Context, u *ucm.Ucm) (*Terraform, error) {
 	workingDir, err := WorkingDir(u)
 	if err != nil {
@@ -94,7 +93,10 @@ func New(ctx context.Context, u *ucm.Ucm) (*Terraform, error) {
 	if err != nil {
 		return nil, err
 	}
-	envMap := buildEnv(ctx, authCfg)
+	envMap, err := buildEnv(ctx, u, authCfg)
+	if err != nil {
+		return nil, err
+	}
 
 	user, lockDir := lockIdentity(ctx, u)
 
@@ -167,113 +169,51 @@ func resolveAuthConfig(u *ucm.Ucm) (*config.Config, error) {
 	return w.Config, nil
 }
 
-// buildEnv assembles the env map passed to terraform-exec.
+// buildEnv assembles the env map passed to terraform-exec. Mirrors the
+// order DAB's bundle/deploy/terraform/init.go uses:
 //
-// It starts with the resolved SDK auth config (so `--profile` selections and
-// OAuth-cache resolutions are visible to the subprocess), then falls back to
-// passthrough of auth env vars set on the parent process. Cloud credentials
-// (AWS, Azure, GCP) flow through unchanged — the underlay resources will
-// need them once they land. PATH/HOME/TMPDIR/proxy are inherited so the
-// subprocess runs in a sane environment.
+//  1. auth.Env(authCfg) seeds DATABRICKS_* from the resolved SDK config
+//     so --profile and OAuth-cache selections win over parent-env state.
+//  2. inheritEnvVars copies envCopy, OIDC tokens, Azure DevOps SYSTEM_*,
+//     and DATABRICKS_TF_CLI_CONFIG_FILE (version-gated → TF_CLI_CONFIG_FILE).
+//  3. setTempDirEnvVars sets TMP/TEMP/TMPDIR, falling back to
+//     localStateDir("tmp") on Windows to dodge MAX_PATH.
+//  4. setProxyEnvVars forwards HTTP_PROXY / HTTPS_PROXY / NO_PROXY.
+//  5. resolveDatabricksCliPath absolute-izes DATABRICKS_CLI_PATH so the
+//     terraform subprocess can find the parent CLI from .databricks/ucm/...
 //
-// Ordering matters: auth.Env wins over the passthrough fallback so a
-// --profile override materialised through the SDK cannot be clobbered by a
-// stale DATABRICKS_CONFIG_PROFILE lingering in the parent env.
-func buildEnv(ctx context.Context, authCfg *config.Config) map[string]string {
+// Cloud-cred env vars (AWS/Azure/GCP) are intentionally NOT forwarded
+// — UCM strictly mirrors DAB here. Revisit when UCM gains resources
+// that need them.
+func buildEnv(ctx context.Context, u *ucm.Ucm, authCfg *config.Config) (map[string]string, error) {
 	out := map[string]string{}
 
-	passthroughKeys := []string{
-		// Databricks auth — consumed by the terraform-provider-databricks.
-		// See https://registry.terraform.io/providers/databricks/databricks/latest/docs
-		"DATABRICKS_HOST",
-		"DATABRICKS_CLIENT_ID",
-		"DATABRICKS_CLIENT_SECRET",
-		"DATABRICKS_TOKEN",
-		"DATABRICKS_CONFIG_PROFILE",
-		"DATABRICKS_CONFIG_FILE",
-		"DATABRICKS_ACCOUNT_ID",
-		"DATABRICKS_AUTH_TYPE",
-		"DATABRICKS_METADATA_SERVICE_URL",
-
-		// AWS cloud-underlay credentials. Out-of-scope for M1, but passing
-		// them through now keeps the wrapper from re-shaping once AWS
-		// resources land.
-		"AWS_ACCESS_KEY_ID",
-		"AWS_SECRET_ACCESS_KEY",
-		"AWS_SESSION_TOKEN",
-		"AWS_REGION",
-		"AWS_DEFAULT_REGION",
-		"AWS_PROFILE",
-		"AWS_WEB_IDENTITY_TOKEN_FILE",
-		"AWS_ROLE_ARN",
-		"AWS_ROLE_SESSION_NAME",
-
-		// Azure cloud-underlay credentials.
-		"AZURE_TENANT_ID",
-		"AZURE_CLIENT_ID",
-		"AZURE_CLIENT_SECRET",
-		"AZURE_SUBSCRIPTION_ID",
-		"AZURE_FEDERATED_TOKEN_FILE",
-
-		// GCP cloud-underlay credentials.
-		"GOOGLE_CREDENTIALS",
-		"GOOGLE_APPLICATION_CREDENTIALS",
-		"GOOGLE_PROJECT",
-		"GOOGLE_REGION",
-
-		// Process plumbing.
-		"HOME",
-		"USERPROFILE",
-		"PATH",
-		"TF_CLI_CONFIG_FILE",
-	}
-	for _, k := range passthroughKeys {
-		if v, ok := env.Lookup(ctx, k); ok {
-			out[k] = v
-		}
-	}
-
-	// $DATABRICKS_TF_CLI_CONFIG_FILE maps to $TF_CLI_CONFIG_FILE so the
-	// VSCode extension's filesystem-mirror config is picked up when it lines
-	// up with the provider version we actually use.
-	if v, ok := env.Lookup(ctx, CliConfigPathEnv); ok && v != "" {
-		if _, err := os.Stat(v); err == nil {
-			out["TF_CLI_CONFIG_FILE"] = v
-		}
-	}
-
-	// Proxy variables — both upper and lower case; terraform-exec is fine
-	// with either, but downstream tools on macOS/Linux commonly read the
-	// uppercase form.
-	for _, v := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
-		for _, key := range []string{v, strings.ToLower(v)} {
-			if val, ok := env.Lookup(ctx, key); ok {
-				out[strings.ToUpper(v)] = val
-			}
-		}
-	}
-
-	// TMPDIR / TMP — let terraform create temp files in a place it can write.
-	if runtime.GOOS == "windows" {
-		for _, k := range []string{"TMP", "TEMP"} {
-			if v, ok := env.Lookup(ctx, k); ok {
-				out[k] = v
-			}
-		}
-	} else if v, ok := env.Lookup(ctx, "TMPDIR"); ok {
-		out["TMPDIR"] = v
-	}
-
-	// Overlay the resolved SDK auth on top so `--profile` or OAuth-cache
-	// selections survive into the subprocess even when the parent env has
-	// no DATABRICKS_* set.
 	if authCfg != nil {
 		for k, v := range auth.Env(authCfg) {
 			out[k] = v
 		}
 	}
 
-	return out
+	if err := inheritEnvVars(ctx, out); err != nil {
+		return nil, err
+	}
+	if err := setTempDirEnvVars(ctx, out, u); err != nil {
+		return nil, err
+	}
+	if err := setProxyEnvVars(ctx, out); err != nil {
+		return nil, err
+	}
+
+	// Pick up DATABRICKS_CLI_PATH from the parent env/context so
+	// resolveDatabricksCliPath can absolute-ize it. It is not in
+	// envCopy because it is UCM-only and must be processed rather than
+	// forwarded verbatim.
+	if v, ok := env.Lookup(ctx, "DATABRICKS_CLI_PATH"); ok && v != "" {
+		out["DATABRICKS_CLI_PATH"] = v
+	}
+	resolveDatabricksCliPath(out)
+
+	return out, nil
 }
 
 // lockIdentity returns the (user, lockTargetDir) pair used to construct a

--- a/ucm/deploy/terraform/terraform_test.go
+++ b/ucm/deploy/terraform/terraform_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/libs/env"
@@ -9,79 +10,102 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBuildEnvPassesAuthAndCloudVars pins the wire-level auth and cloud-cred
-// env variables we expect to forward to the terraform subprocess. The test
-// uses libs/env's context-backed environment so it doesn't pollute the
-// process-wide os.Environ.
-func TestBuildEnvPassesAuthAndCloudVars(t *testing.T) {
-	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://example.cloud.databricks.com")
-	ctx = env.Set(ctx, "DATABRICKS_CLIENT_ID", "sp-client-id")
-	ctx = env.Set(ctx, "DATABRICKS_CLIENT_SECRET", "sp-client-secret")
-	ctx = env.Set(ctx, "AWS_ACCESS_KEY_ID", "AKIA...")
-	ctx = env.Set(ctx, "AWS_SECRET_ACCESS_KEY", "secret")
+// TestBuildEnvForwardsAuthFromAuthConfig pins the wire-level DATABRICKS_*
+// env vars we expect to forward to terraform — they reach the subprocess
+// via the resolved SDK auth config (auth.Env), NOT via parent-env
+// passthrough. Mirrors DAB ordering.
+func TestBuildEnvForwardsAuthFromAuthConfig(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	authCfg := &config.Config{
+		Host:  "https://example.cloud.databricks.com",
+		Token: "resolved-token",
+	}
+
+	got, err := buildEnv(t.Context(), u, authCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://example.cloud.databricks.com", got["DATABRICKS_HOST"])
+	assert.Equal(t, "resolved-token", got["DATABRICKS_TOKEN"])
+}
+
+// TestBuildEnvDropsCloudCreds pins the strict-DAB-alignment decision:
+// AWS/Azure/GCP cloud-underlay credentials are NOT forwarded to terraform.
+// Revisit when UCM gains resources that actually need them (tracked
+// issue).
+func TestBuildEnvDropsCloudCreds(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	ctx := env.Set(t.Context(), "AWS_ACCESS_KEY_ID", "AKIA...")
 	ctx = env.Set(ctx, "AZURE_TENANT_ID", "azure-tenant")
 	ctx = env.Set(ctx, "GOOGLE_CREDENTIALS", `{"type":"service_account"}`)
 
-	got := buildEnv(ctx, nil)
+	got, err := buildEnv(ctx, u, nil)
+	require.NoError(t, err)
 
-	for _, key := range []string{
-		"DATABRICKS_HOST",
-		"DATABRICKS_CLIENT_ID",
-		"DATABRICKS_CLIENT_SECRET",
+	for _, k := range []string{
 		"AWS_ACCESS_KEY_ID",
-		"AWS_SECRET_ACCESS_KEY",
 		"AZURE_TENANT_ID",
 		"GOOGLE_CREDENTIALS",
 	} {
-		_, ok := got[key]
-		assert.Truef(t, ok, "expected %s to be passed through", key)
+		_, ok := got[k]
+		assert.Falsef(t, ok, "%s must not be forwarded (strict DAB alignment)", k)
 	}
-
-	assert.Equal(t, "https://example.cloud.databricks.com", got["DATABRICKS_HOST"])
-	assert.Equal(t, "sp-client-id", got["DATABRICKS_CLIENT_ID"])
 }
 
-func TestBuildEnvOmitsUnsetVars(t *testing.T) {
-	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://example.cloud.databricks.com")
-	got := buildEnv(ctx, nil)
+// TestBuildEnvWithoutAuthConfigDropsDatabricksHost pins that parent-env
+// DATABRICKS_HOST reaches terraform only via SDK config → auth.Env. UCM
+// no longer passes DATABRICKS_HOST through from the parent env directly;
+// the SDK's config resolution does that on our behalf.
+func TestBuildEnvWithoutAuthConfigDropsDatabricksHost(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://parent.cloud.databricks.com")
 
-	_, ok := got["DATABRICKS_CLIENT_ID"]
-	assert.False(t, ok, "unset var should not leak into env map")
-	_, ok = got["AWS_ACCESS_KEY_ID"]
-	assert.False(t, ok)
+	got, err := buildEnv(ctx, u, nil)
+	require.NoError(t, err)
+
+	_, ok := got["DATABRICKS_HOST"]
+	assert.False(t, ok,
+		"DATABRICKS_HOST reaches terraform only via auth.Env; parent-env passthrough was dropped for DAB alignment")
 }
 
+// TestBuildEnvMapsProxyVarsUppercase verifies setProxyEnvVars is wired
+// into buildEnv.
 func TestBuildEnvMapsProxyVarsUppercase(t *testing.T) {
+	u, _ := newRenderUcm(t)
 	ctx := env.Set(t.Context(), "http_proxy", "http://proxy.example:3128")
 	ctx = env.Set(ctx, "HTTPS_PROXY", "http://proxy.example:3129")
 
-	got := buildEnv(ctx, nil)
+	got, err := buildEnv(ctx, u, nil)
+	require.NoError(t, err)
+
 	assert.Equal(t, "http://proxy.example:3128", got["HTTP_PROXY"])
 	assert.Equal(t, "http://proxy.example:3129", got["HTTPS_PROXY"])
 }
 
-// TestBuildEnvMaterializesResolvedAuth pins the behaviour that makes
-// `ucm plan`/`ucm deploy` work when auth comes from ~/.databrickscfg
-// instead of DATABRICKS_* env vars. The resolved SDK config must be
-// serialised into DATABRICKS_* so the terraform subprocess can auth.
-func TestBuildEnvMaterializesResolvedAuth(t *testing.T) {
-	authCfg := &config.Config{
-		Host:  "https://profile.cloud.databricks.com",
-		Token: "resolved-token",
-	}
-	got := buildEnv(t.Context(), authCfg)
-	assert.Equal(t, "https://profile.cloud.databricks.com", got["DATABRICKS_HOST"])
-	assert.Equal(t, "resolved-token", got["DATABRICKS_TOKEN"])
-}
-
-// TestBuildEnvResolvedAuthOverridesPassthrough pins the overlay ordering:
-// a resolved --profile host must win over a stale DATABRICKS_HOST that
-// happens to be set on the parent env.
+// TestBuildEnvResolvedAuthOverridesPassthrough pins the DAB ordering:
+// auth.Env seeds the map first; inheritEnvVars / other passthrough
+// cannot override DATABRICKS_* already set by auth resolution.
 func TestBuildEnvResolvedAuthOverridesPassthrough(t *testing.T) {
+	u, _ := newRenderUcm(t)
 	ctx := env.Set(t.Context(), "DATABRICKS_HOST", "https://stale.cloud.databricks.com")
 	authCfg := &config.Config{Host: "https://profile.cloud.databricks.com"}
-	got := buildEnv(ctx, authCfg)
+	got, err := buildEnv(ctx, u, authCfg)
+	require.NoError(t, err)
+
 	assert.Equal(t, "https://profile.cloud.databricks.com", got["DATABRICKS_HOST"])
+}
+
+// TestBuildEnvAbsolutizesRelativeDatabricksCliPath pins the UCM-local
+// fix for the shared DAB bug where DATABRICKS_CLI_PATH can be a
+// relative path that fails to resolve from terraform's working dir.
+func TestBuildEnvAbsolutizesRelativeDatabricksCliPath(t *testing.T) {
+	u, _ := newRenderUcm(t)
+	ctx := env.Set(t.Context(), "DATABRICKS_CLI_PATH", "../cli/cli")
+
+	got, err := buildEnv(ctx, u, nil)
+	require.NoError(t, err)
+
+	assert.True(t, filepath.IsAbs(got["DATABRICKS_CLI_PATH"]),
+		"expected absolute path, got %q", got["DATABRICKS_CLI_PATH"])
 }
 
 func TestLockIdentityDerivesPathFromTarget(t *testing.T) {


### PR DESCRIPTION
Closes #88

## Summary

- Port DAB's terraform env pipeline 1:1 into `ucm/deploy/terraform/env.go`: `auth.Env` -> `inheritEnvVars` -> `setTempDirEnvVars` -> `setProxyEnvVars` -> `resolveDatabricksCliPath` (UCM-local).
- Absolute-ize `DATABRICKS_CLI_PATH` inside `buildEnv` so relative invocations (e.g. `../cli/cli ucm deploy`) no longer fail with "databricks CLI not found" from the terraform-exec subprocess.
- Forward the env vars DAB propagates that UCM was silently dropping: `AZURE_CONFIG_DIR`, `USE_SDK_V2_RESOURCES`, `USE_SDK_V2_DATA_SOURCES`, `DATABRICKS_OIDC_TOKEN[_ENV]`, 11 Azure DevOps `SYSTEM_*` vars, and the version-gated `DATABRICKS_TF_CLI_CONFIG_FILE` -> `TF_CLI_CONFIG_FILE` rename.
- Extract a `localStateDir` helper in `dir.go` so `buildEnv` reads the target dir from a single source.

## Why

`ucm deploy` had drifted from DAB's terraform env setup in two user-visible ways:

1. **Relative-path CLI bug.** `DATABRICKS_CLI_PATH` was seeded as the relative `os.Args[0]` at CLI init. When terraform-exec runs its subprocess with cwd set to `.databricks/ucm/<target>/terraform/`, a relative path can't resolve back to the CLI binary — so any `../cli/cli ucm deploy` invocation failed terraform init with `databricks CLI not found`. Fixed UCM-locally (fork rules forbid editing `bundle/**` from a UCM-labeled PR); the matching upstream fix for DAB is tracked separately (see follow-ups).
2. **Dropped env vars.** UCM's prior `buildEnv` didn't forward several vars DAB has long propagated to the terraform subprocess. This broke Azure auth in workspaces using `AZURE_CONFIG_DIR`, broke SDK-v2 opt-in flags, broke OIDC token flows, broke Azure DevOps pipeline attribution, and broke terraform CLI config overrides via the renamed env var.

The fix is strict 1:1 alignment with DAB's pipeline — same function names, same ordering — so that future divergence is obvious in review and a later shared-library extraction (see #92) is a mechanical lift.

## Intentional divergence from prior UCM behavior

The previous UCM `buildEnv` forwarded AWS/Azure/GCP cloud-credential env vars. This PR drops them for DAB alignment — DAB doesn't forward them because the databricks provider handles workspace auth itself. UCM will need these back when underlay resources land (AWS first per the M-sequence). Tracked as follow-up #90.

## Test plan

- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...` — clean
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...` — clean
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./cmd/ucm/... ./ucm/...` — all packages pass
- [x] `gofmt`, `make lint` clean on `ucm/**` paths
- [x] Smoke: `../cli/cli ucm plan` from ucm_test fixture produces a valid plan (previously failed with "databricks CLI not found")

## Fork-divergence notes

- Edits to upstream files: **none**. All changes confined to `ucm/deploy/terraform/**`.
- New touchpoints outside `cmd/ucm/**`, `ucm/**`, `.claude/**`, `.github/workflows/upstream-sync.yml`: **none**.
- `cmd/cmd.go` (the single allowed upstream touchpoint) is untouched.
- The `DATABRICKS_CLI_PATH` relative-path bug is fixed UCM-locally here; the root fix in `bundle/config/workspace.go` must land via a separate non-UCM-labeled PR (see #91).

## Base branch

`main` — not stacked on any other open PR.

## Follow-ups filed

- #89 `ucm: set DATABRICKS_USER_AGENT_EXTRA like DAB (telemetry attribution)`
- #90 `ucm: re-add AWS/Azure/GCP cloud-cred passthrough when underlay resources land`
- #91 `bundle: absolute-ize DATABRICKS_CLI_PATH in workspace.go init (shared bug with UCM)` — non-UCM PR required
- #92 `ucm: extract shared tfenv helpers into libs/ for DAB+UCM reuse`

## Design docs

- Spec: `docs/superpowers/specs/2026-04-24-ucm-terraform-env-align-dab-design.md`
- Plan: `docs/superpowers/plans/2026-04-24-ucm-terraform-env-align-dab.md`

(Not committed — directory is gitignored.)