### PR TITLE
ucm: Add TryLoad and phases.Load helpers

### DIFF
--- a/ucm/phases/load.go
+++ b/ucm/phases/load.go
@@ -5,10 +5,19 @@ package phases
 import (
 	"context"
 
+	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config/mutator"
 )
+
+// Load reads ucm.yml from disk into u.Config and runs the default mutator
+// chain. Used by targetCompletion to enumerate target names without
+// selecting one. Mirrors bundle/phases/load.go::Load.
+func Load(ctx context.Context, u *ucm.Ucm) {
+	log.Info(ctx, "Phase: load")
+	mutator.DefaultMutators(ctx, u)
+}
 
 // LoadDefaultTarget prepares a freshly-loaded Ucm for downstream phases when
 // the user did not pass --target. CLI --var values must be applied AFTER this

--- a/ucm/ucm.go
+++ b/ucm/ucm.go
@@ -88,6 +88,26 @@ func MustLoad(ctx context.Context) *Ucm {
 	return u
 }
 
+// TryLoad returns a Ucm if a ucm.yml is reachable from the working
+// directory (or DATABRICKS_UCM_ROOT). Returns nil with no diagnostic
+// when no config is found — mirrors bundle.TryLoad.
+func TryLoad(ctx context.Context) *Ucm {
+	root, err := tryGetRoot(ctx)
+	if err != nil {
+		logdiag.LogError(ctx, err)
+		return nil
+	}
+	if root == "" {
+		return nil
+	}
+	u, err := Load(ctx, root)
+	if err != nil {
+		logdiag.LogError(ctx, err)
+		return nil
+	}
+	return u
+}
+
 func getRootEnv(ctx context.Context) (string, error) {
 	path, ok := env.Lookup(ctx, RootEnv)
 	if !ok {
@@ -122,4 +142,18 @@ func mustGetRoot(ctx context.Context) (string, error) {
 		return path, err
 	}
 	return getRootWithTraversal()
+}
+
+// tryGetRoot is the non-fatal sibling of mustGetRoot. Returns "" with no
+// diagnostic when no ucm.yml is reachable from the working directory and
+// DATABRICKS_UCM_ROOT is unset.
+func tryGetRoot(ctx context.Context) (string, error) {
+	// Note: an invalid value in the environment variable is still an error.
+	path, err := getRootEnv(ctx)
+	if path != "" || err != nil {
+		return path, err
+	}
+	// Note: traversal failing means the ucm root cannot be found.
+	path, _ = getRootWithTraversal()
+	return path, nil
 }

--- a/ucm/ucm_test.go
+++ b/ucm/ucm_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,4 +29,30 @@ func TestLoad_MissingUcmYml(t *testing.T) {
 	dir := t.TempDir()
 	_, err := ucm.Load(t.Context(), dir)
 	require.Error(t, err)
+}
+
+func TestTryLoadFromValidUcmRoot(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ucm.yml"), []byte("ucm:\n  name: test\n"), 0o644))
+	t.Setenv(ucm.RootEnv, dir)
+	ctx = logdiag.InitContext(ctx)
+
+	u := ucm.TryLoad(ctx)
+	require.NotNil(t, u)
+	assert.Equal(t, "test", u.Config.Ucm.Name)
+	assert.False(t, logdiag.HasError(ctx))
+}
+
+func TestTryLoadReturnsNilWhenNoUcmYml(t *testing.T) {
+	ctx := t.Context()
+	// Defensively unset the env in case the host has it set.
+	t.Setenv(ucm.RootEnv, "")
+	require.NoError(t, os.Unsetenv(ucm.RootEnv))
+	t.Chdir(t.TempDir())
+	ctx = logdiag.InitContext(ctx)
+
+	u := ucm.TryLoad(ctx)
+	assert.Nil(t, u)
+	assert.False(t, logdiag.HasError(ctx))
 }


### PR DESCRIPTION
Closes #96

## Summary
- Add `ucm.TryLoad(ctx) *Ucm` mirroring `bundle.TryLoad`
- Add `ucm.tryGetRoot` (non-fatal sibling of `mustGetRoot`)
- Add `ucm.phases.Load` mirroring `bundle/phases.Load`

## Why
Precursor for sub-project A foundation switchover (see spec
`docs/superpowers/specs/2026-04-28-ucm-bundle-alignment-foundation-design.md`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/ucm/... ./ucm/...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] Manual: `./databricks ucm validate` in a non-ucm dir produces no panic

This pull request and its description were written by Isaac.