### PR TITLE
ucm: Rendering parity (sub-project B)

### DIFF
--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -1,20 +1,12 @@
 package ucm
 
 import (
-	"cmp"
-	"encoding/json"
-	"fmt"
-	"io"
-	"slices"
-
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
-	"github.com/databricks/cli/ucm/config"
-	"github.com/databricks/cli/ucm/config/mutator"
-	"github.com/fatih/color"
+	"github.com/databricks/cli/ucm/render"
 	"github.com/spf13/cobra"
 )
 
@@ -49,15 +41,18 @@ Common invocations:
 	// belongs in a separate change.
 	var forcePull bool
 	var includeLocations bool
-	var showFullConfig bool
+	var shouldShowFullConfig bool
 	cmd.Flags().BoolVar(&forcePull, "force-pull", false, "Skip local cache and load the state from the remote workspace (no-op today)")
 	cmd.Flags().BoolVar(&includeLocations, "include-locations", false, "Include location information in the output")
 	_ = cmd.Flags().MarkHidden("include-locations")
-	cmd.Flags().BoolVar(&showFullConfig, "show-full-config", false, "Load and output the full ucm config")
+	cmd.Flags().BoolVar(&shouldShowFullConfig, "show-full-config", false, "Load and output the full ucm config")
 	_ = cmd.Flags().MarkHidden("show-full-config")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{InitIDs: true})
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
+			InitIDs:          true,
+			IncludeLocations: includeLocations,
+		})
 		ctx := cmd.Context()
 		if err != nil {
 			return err
@@ -66,214 +61,24 @@ Common invocations:
 			return root.ErrAlreadyPrinted
 		}
 
-		if includeLocations {
-			ucm.ApplyContext(ctx, u, mutator.PopulateLocations())
-			if logdiag.HasError(ctx) {
-				return root.ErrAlreadyPrinted
-			}
+		// --show-full-config short-circuits the grouped text renderer and
+		// always emits the resolved config tree as JSON, regardless of -o.
+		if shouldShowFullConfig {
+			return renderJsonOutput(cmd, u)
 		}
 
-		out := cmd.OutOrStdout()
-		if showFullConfig {
-			buf, err := json.MarshalIndent(u.Config, "", "  ")
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(out, string(buf))
-			return nil
-		}
-		switch root.OutputType(cmd) {
-		case flags.OutputJSON:
-			buf, err := json.MarshalIndent(u.Config, "", "  ")
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(out, string(buf))
-			return nil
-		default:
-			renderSummaryText(out, u)
-			return nil
-		}
+		return showSummary(cmd, u)
 	}
 
 	return cmd
 }
 
-// resourceRow is one line in a summary group.
-type resourceRow struct {
-	Key  string
-	Name string
-	URL  string
-}
-
-// resourceGroup is a titled collection of resourceRows (e.g. "Catalogs").
-// HasURL distinguishes kinds that carry a workspace URL (so an empty URL
-// renders as "(not deployed)") from kinds that never do (Grants,
-// TagValidationRules) — those stay URL-less regardless of deploy state.
-type resourceGroup struct {
-	Title  string
-	Rows   []resourceRow
-	HasURL bool
-}
-
-// renderSummaryText writes the bundle-summary-shaped text output: header
-// (Name / Target / Workspace) followed by one section per non-empty resource
-// group. Empty groups are suppressed.
-func renderSummaryText(out io.Writer, u *ucm.Ucm) {
-	renderSummaryHeader(out, u)
-
-	groups := collectResourceGroups(&u.Config)
-	cyan := color.New(color.FgCyan).SprintFunc()
-	for _, g := range groups {
-		fmt.Fprintf(out, "%s:\n", g.Title)
-		for _, r := range g.Rows {
-			fmt.Fprintf(out, "  %s:\n", r.Key)
-			fmt.Fprintf(out, "    Name: %s\n", r.Name)
-			if !g.HasURL {
-				continue
-			}
-			if r.URL == "" {
-				fmt.Fprintf(out, "    URL:  %s\n", cyan(notDeployedURL))
-			} else {
-				fmt.Fprintf(out, "    URL:  %s\n", cyan(r.URL))
-			}
-		}
+func showSummary(cmd *cobra.Command, u *ucm.Ucm) error {
+	if root.OutputType(cmd) == flags.OutputText {
+		return render.RenderSummary(cmd.Context(), cmd.OutOrStdout(), u)
 	}
-}
-
-func renderSummaryHeader(out io.Writer, u *ucm.Ucm) {
-	bold := color.New(color.Bold).SprintFunc()
-	cfg := &u.Config
-	if cfg.Ucm.Name != "" {
-		fmt.Fprintf(out, "Name: %s\n", bold(cfg.Ucm.Name))
+	if root.OutputType(cmd) == flags.OutputJSON {
+		return renderJsonOutput(cmd, u)
 	}
-	if cfg.Ucm.Target != "" {
-		fmt.Fprintf(out, "Target: %s\n", bold(cfg.Ucm.Target))
-	}
-
-	var userName string
-	if u.CurrentUser != nil && u.CurrentUser.User != nil {
-		userName = u.CurrentUser.UserName
-	}
-	hasWorkspace := cfg.Workspace.Host != "" || userName != "" || cfg.Workspace.RootPath != ""
-	if hasWorkspace {
-		fmt.Fprintln(out, "Workspace:")
-		if cfg.Workspace.Host != "" {
-			fmt.Fprintf(out, "  Host: %s\n", bold(cfg.Workspace.Host))
-		}
-		if userName != "" {
-			fmt.Fprintf(out, "  User: %s\n", bold(userName))
-		}
-		if cfg.Workspace.RootPath != "" {
-			fmt.Fprintf(out, "  Path: %s\n", bold(cfg.Workspace.RootPath))
-		}
-	}
-	fmt.Fprintln(out)
-}
-
-// collectResourceGroups gathers the declared resources into titled groups
-// sorted by title, each group's rows sorted by key. Groups with no entries
-// are omitted so the output only shows sections that exist.
-//
-// URL values are read from the config fields populated by
-// mutator.InitializeURLs — an empty URL means the resource is declared but
-// not yet deployed, and is rendered as "(not deployed)" by renderSummaryText.
-func collectResourceGroups(cfg *config.Root) []resourceGroup {
-	var groups []resourceGroup
-
-	if len(cfg.Resources.Catalogs) > 0 {
-		rows := make([]resourceRow, 0, len(cfg.Resources.Catalogs))
-		for key, c := range cfg.Resources.Catalogs {
-			rows = append(rows, resourceRow{
-				Key:  key,
-				Name: c.Name,
-				URL:  c.URL,
-			})
-		}
-		groups = append(groups, resourceGroup{Title: "Catalogs", Rows: rows, HasURL: true})
-	}
-
-	if len(cfg.Resources.Schemas) > 0 {
-		rows := make([]resourceRow, 0, len(cfg.Resources.Schemas))
-		for key, s := range cfg.Resources.Schemas {
-			full := s.Name
-			if s.CatalogName != "" {
-				full = s.CatalogName + "." + s.Name
-			}
-			rows = append(rows, resourceRow{Key: key, Name: full, URL: s.URL})
-		}
-		groups = append(groups, resourceGroup{Title: "Schemas", Rows: rows, HasURL: true})
-	}
-
-	if len(cfg.Resources.Volumes) > 0 {
-		rows := make([]resourceRow, 0, len(cfg.Resources.Volumes))
-		for key, v := range cfg.Resources.Volumes {
-			full := v.Name
-			if v.CatalogName != "" && v.SchemaName != "" {
-				full = v.CatalogName + "." + v.SchemaName + "." + v.Name
-			}
-			rows = append(rows, resourceRow{Key: key, Name: full, URL: v.URL})
-		}
-		groups = append(groups, resourceGroup{Title: "Volumes", Rows: rows, HasURL: true})
-	}
-
-	if len(cfg.Resources.StorageCredentials) > 0 {
-		rows := make([]resourceRow, 0, len(cfg.Resources.StorageCredentials))
-		for key, sc := range cfg.Resources.StorageCredentials {
-			rows = append(rows, resourceRow{
-				Key:  key,
-				Name: sc.Name,
-				URL:  sc.URL,
-			})
-		}
-		groups = append(groups, resourceGroup{Title: "Storage credentials", Rows: rows, HasURL: true})
-	}
-
-	if len(cfg.Resources.ExternalLocations) > 0 {
-		rows := make([]resourceRow, 0, len(cfg.Resources.ExternalLocations))
-		for key, el := range cfg.Resources.ExternalLocations {
-			rows = append(rows, resourceRow{
-				Key:  key,
-				Name: el.Name,
-				URL:  el.URL,
-			})
-		}
-		groups = append(groups, resourceGroup{Title: "External locations", Rows: rows, HasURL: true})
-	}
-
-	if len(cfg.Resources.Connections) > 0 {
-		rows := make([]resourceRow, 0, len(cfg.Resources.Connections))
-		for key, conn := range cfg.Resources.Connections {
-			rows = append(rows, resourceRow{
-				Key:  key,
-				Name: conn.Name,
-				URL:  conn.URL,
-			})
-		}
-		groups = append(groups, resourceGroup{Title: "Connections", Rows: rows, HasURL: true})
-	}
-
-	if len(cfg.Resources.Grants) > 0 {
-		rows := make([]resourceRow, 0, len(cfg.Resources.Grants))
-		for key, g := range cfg.Resources.Grants {
-			// Grants have no workspace URL; summarise securable + principal.
-			name := fmt.Sprintf("%s %s -> %s", g.Securable.Type, g.Securable.Name, g.Principal)
-			rows = append(rows, resourceRow{Key: key, Name: name})
-		}
-		groups = append(groups, resourceGroup{Title: "Grants", Rows: rows})
-	}
-
-	if len(cfg.Resources.TagValidationRules) > 0 {
-		rows := make([]resourceRow, 0, len(cfg.Resources.TagValidationRules))
-		for key := range cfg.Resources.TagValidationRules {
-			rows = append(rows, resourceRow{Key: key, Name: key})
-		}
-		groups = append(groups, resourceGroup{Title: "Tag validation rules", Rows: rows})
-	}
-
-	slices.SortFunc(groups, func(a, b resourceGroup) int { return cmp.Compare(a.Title, b.Title) })
-	for i := range groups {
-		slices.SortFunc(groups[i].Rows, func(a, b resourceRow) int { return cmp.Compare(a.Key, b.Key) })
-	}
-	return groups
+	return nil
 }

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -1,6 +1,8 @@
 package ucm
 
 import (
+	"errors"
+
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/diag"
@@ -48,8 +50,11 @@ Common invocations:
 		// project has errors. Mirrors cmd/bundle/summary.go::showFullConfig
 		// shape: prime the logdiag context, downgrade severity so noisy
 		// recommendations don't crowd the JSON output, then render whatever
-		// ProcessUcm could resolve. Skipping the HasError gate is deliberate
-		// — users debugging a broken ucm.yml need the JSON to inspect.
+		// ProcessUcm could resolve. The render is unconditional so users
+		// debugging a broken ucm.yml can still inspect the JSON, but the
+		// outer HasError gate (mirroring cmd/bundle/summary.go:61) ensures
+		// the process still exits non-zero — important for `ucm summary
+		// --show-full-config | jq ...` in CI scripts.
 		if shouldShowFullConfig {
 			ctx := logdiag.InitContext(cmd.Context())
 			cmd.SetContext(ctx)
@@ -59,13 +64,19 @@ Common invocations:
 				SkipInitContext:  true,
 				IncludeLocations: includeLocations,
 			})
-			if err != nil && err != root.ErrAlreadyPrinted {
+			if err != nil && !errors.Is(err, root.ErrAlreadyPrinted) {
 				return err
 			}
 			if u == nil {
 				return root.ErrAlreadyPrinted
 			}
-			return renderJsonOutput(cmd, u)
+			if err := renderJsonOutput(cmd, u); err != nil {
+				return err
+			}
+			if logdiag.HasError(cmd.Context()) {
+				return root.ErrAlreadyPrinted
+			}
+			return nil
 		}
 
 		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{

--- a/cmd/ucm/summary.go
+++ b/cmd/ucm/summary.go
@@ -3,18 +3,13 @@ package ucm
 import (
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/render"
 	"github.com/spf13/cobra"
 )
-
-// notDeployedURL is the literal rendered when a URL-bearing resource has no
-// ID in the local tfstate. Matches the DAB wording at
-// bundle/render/render_text_output.go so users reading both tools' output
-// get a consistent signal.
-const notDeployedURL = "(not deployed)"
 
 func newSummaryCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -26,7 +21,7 @@ with workspace URLs when a Workspace.Host is configured.
 Mirrors ` + "`databricks bundle summary`" + `: loads the per-target
 terraform.tfstate from the local cache to determine which resources have
 actually been deployed. URL lines show the workspace console link for
-resources present in state and ` + "`" + notDeployedURL + "`" + ` for resources declared in
+resources present in state and ` + "`(not deployed)`" + ` for resources declared in
 ucm.yml but not yet applied. Run ` + "`ucm deploy`" + ` to realize declared intents.
 
 Common invocations:
@@ -49,6 +44,30 @@ Common invocations:
 	_ = cmd.Flags().MarkHidden("show-full-config")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// --show-full-config dumps the resolved config tree even when the
+		// project has errors. Mirrors cmd/bundle/summary.go::showFullConfig
+		// shape: prime the logdiag context, downgrade severity so noisy
+		// recommendations don't crowd the JSON output, then render whatever
+		// ProcessUcm could resolve. Skipping the HasError gate is deliberate
+		// — users debugging a broken ucm.yml need the JSON to inspect.
+		if shouldShowFullConfig {
+			ctx := logdiag.InitContext(cmd.Context())
+			cmd.SetContext(ctx)
+			logdiag.SetSeverity(ctx, diag.Warning)
+
+			u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
+				SkipInitContext:  true,
+				IncludeLocations: includeLocations,
+			})
+			if err != nil && err != root.ErrAlreadyPrinted {
+				return err
+			}
+			if u == nil {
+				return root.ErrAlreadyPrinted
+			}
+			return renderJsonOutput(cmd, u)
+		}
+
 		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
 			InitIDs:          true,
 			IncludeLocations: includeLocations,
@@ -59,12 +78,6 @@ Common invocations:
 		}
 		if u == nil || logdiag.HasError(ctx) {
 			return root.ErrAlreadyPrinted
-		}
-
-		// --show-full-config short-circuits the grouped text renderer and
-		// always emits the resolved config tree as JSON, regardless of -o.
-		if shouldShowFullConfig {
-			return renderJsonOutput(cmd, u)
 		}
 
 		return showSummary(cmd, u)

--- a/cmd/ucm/summary_test.go
+++ b/cmd/ucm/summary_test.go
@@ -1,7 +1,6 @@
 package ucm
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -272,33 +271,3 @@ func TestCmd_Summary_ShowFullConfigBypassesGroupedText(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stdout), &tree))
 }
 
-// TestRenderSummaryText_EmitsOnlyNonEmptyGroups covers the shape contract:
-// groups with no entries do not emit a header.
-func TestRenderSummaryText_EmitsOnlyNonEmptyGroups(t *testing.T) {
-	work := writeUcmYml(t, `ucm:
-  name: demo
-
-workspace:
-  host: https://workspace.cloud.databricks.com
-
-resources:
-  catalogs:
-    sales:
-      name: sales_prod
-`)
-
-	ctx := logdiag.InitContext(context.Background())
-	u, err := ucmpkg.Load(ctx, work)
-	require.NoError(t, err)
-	phases.LoadDefaultTarget(ctx, u)
-	require.False(t, logdiag.HasError(ctx))
-
-	var buf bytes.Buffer
-	renderSummaryText(&buf, u)
-
-	out := buf.String()
-	assert.Contains(t, out, "Catalogs:")
-	assert.NotContains(t, out, "Schemas:")
-	assert.NotContains(t, out, "Grants:")
-	assert.NotContains(t, out, "Storage credentials:")
-}

--- a/cmd/ucm/summary_test.go
+++ b/cmd/ucm/summary_test.go
@@ -104,15 +104,20 @@ func TestCmd_Summary_ListsCatalogsAndSchemasWhenNotDeployed(t *testing.T) {
 	assert.NotContains(t, stdout, "explore/data/team_alpha")
 }
 
-func TestCmd_Summary_ListsGrantsWithoutURL(t *testing.T) {
+// TestCmd_Summary_ListsGrantsWithNotDeployedURL covers the rendered shape for
+// resources that intentionally have no workspace URL (grants, tag-validation
+// rules): the URL line is still emitted, but with the "(not deployed)" literal
+// from the shared resources template.
+func TestCmd_Summary_ListsGrantsWithNotDeployedURL(t *testing.T) {
 	stdout, _, err := runVerb(t, validFixtureDir(t), "summary")
 
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Grants:")
 	assert.Contains(t, stdout, "alpha_read:")
 	assert.Contains(t, stdout, "Name: catalog team_alpha -> alpha-readers")
-	// Grants deliberately do not carry a workspace URL.
-	assert.NotContains(t, stdout, "URL:  https://example.cloud.databricks.com/explore/grants")
+	// Grants don't carry a workspace URL, so the URL line falls back to the
+	// shared "(not deployed)" literal rather than a real https:// link.
+	assert.Contains(t, stdout, "URL:  (not deployed)")
 }
 
 func TestCmd_Summary_ListsStorageCredentialsWhenDeployed(t *testing.T) {

--- a/cmd/ucm/validate.go
+++ b/cmd/ucm/validate.go
@@ -1,21 +1,31 @@
 package ucm
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"strings"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
-	"github.com/databricks/cli/ucm/config/mutator"
-	"github.com/fatih/color"
+	"github.com/databricks/cli/ucm/render"
 	"github.com/spf13/cobra"
 )
+
+func renderJsonOutput(cmd *cobra.Command, u *ucm.Ucm) error {
+	if u == nil {
+		return nil
+	}
+	buf, err := json.MarshalIndent(u.Config.Value().AsAny(), "", "  ")
+	if err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	_, _ = out.Write(buf)
+	_, _ = out.Write([]byte{'\n'})
+	return nil
+}
 
 func newValidateCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -43,98 +53,47 @@ Common invocations:
 	_ = cmd.Flags().MarkHidden("include-locations")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{Validate: true})
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
+			Validate:         true,
+			IncludeLocations: includeLocations,
+		})
 		ctx := cmd.Context()
-		// Surface non-ErrAlreadyPrinted errors as a diagnostic so the trailer
-		// still prints; the deferred return below preserves the failure exit.
+
 		if err != nil && err != root.ErrAlreadyPrinted {
 			logdiag.LogError(ctx, err)
 			err = root.ErrAlreadyPrinted
 		}
 
-		if includeLocations && u != nil && !logdiag.HasError(ctx) {
-			ucm.ApplyContext(ctx, u, mutator.PopulateLocations())
-		}
+		// output before checking the error on purpose
 
-		out := cmd.OutOrStdout()
-		output := root.OutputType(cmd)
-
-		// Emit output before returning on error so users see the summary or
-		// the (partial) config tree regardless.
-		if output == flags.OutputJSON {
-			if err := renderValidateJSON(out, u); err != nil {
-				return err
+		if root.OutputType(cmd) == flags.OutputText {
+			err1 := render.RenderDiagnosticsSummary(ctx, cmd.OutOrStdout(), u)
+			if err1 != nil {
+				return err1
 			}
-		} else {
-			if u != nil {
-				renderSummaryHeader(out, u)
+		}
+
+		if root.OutputType(cmd) == flags.OutputJSON {
+			err1 := renderJsonOutput(cmd, u)
+			if err1 != nil {
+				return err1
 			}
-			writeValidateTrailer(ctx, out)
 		}
 
-		if err != nil {
-			return err
-		}
-
+		// In strict mode, treat warnings as errors.
 		numWarnings := logdiag.NumWarnings(ctx)
-		if strict && numWarnings > 0 {
-			noun := "warning"
-			if numWarnings != 1 {
-				noun = "warnings"
+		if err == nil && strict && numWarnings > 0 {
+			prefix := ""
+			if numWarnings == 1 {
+				prefix = "1 warning was found"
+			} else {
+				prefix = fmt.Sprintf("%d warnings were found", numWarnings)
 			}
-			return fmt.Errorf("%d %s found. Warnings are not allowed in strict mode", numWarnings, noun)
+			return fmt.Errorf("%s. Warnings are not allowed in strict mode", prefix)
 		}
 
-		return nil
+		return err
 	}
 
 	return cmd
-}
-
-// renderValidateJSON emits the loaded ucm config tree as indented JSON.
-func renderValidateJSON(out io.Writer, u *ucm.Ucm) error {
-	if u == nil {
-		return nil
-	}
-	buf, err := json.MarshalIndent(u.Config.Value().AsAny(), "", "  ")
-	if err != nil {
-		return err
-	}
-	_, _ = out.Write(buf)
-	_, _ = out.Write([]byte{'\n'})
-	return nil
-}
-
-// writeValidateTrailer prints the DAB-style "Found X errors / Y warnings"
-// summary, or "Validation OK!" when no diagnostics were recorded.
-func writeValidateTrailer(ctx context.Context, out io.Writer) {
-	info := logdiag.Copy(ctx)
-	var parts []string
-	if info.Errors > 0 {
-		parts = append(parts, color.RedString(pluralize(info.Errors, "error", "errors")))
-	}
-	if info.Warnings > 0 {
-		parts = append(parts, color.YellowString(pluralize(info.Warnings, "warning", "warnings")))
-	}
-	if info.Recommendations > 0 {
-		parts = append(parts, color.BlueString(pluralize(info.Recommendations, "recommendation", "recommendations")))
-	}
-	switch len(parts) {
-	case 0:
-		fmt.Fprint(out, color.GreenString("Validation OK!\n"))
-	case 1:
-		fmt.Fprintf(out, "Found %s\n", parts[0])
-	case 2:
-		fmt.Fprintf(out, "Found %s and %s\n", parts[0], parts[1])
-	default:
-		first := strings.Join(parts[:len(parts)-1], ", ")
-		fmt.Fprintf(out, "Found %s, and %s\n", first, parts[len(parts)-1])
-	}
-}
-
-func pluralize(n int, singular, plural string) string {
-	if n == 1 {
-		return fmt.Sprintf("%d %s", n, singular)
-	}
-	return fmt.Sprintf("%d %s", n, plural)
 }

--- a/ucm/render/groups.go
+++ b/ucm/render/groups.go
@@ -1,0 +1,145 @@
+package render
+
+import (
+	"fmt"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+)
+
+// resourceGroupsForUcm enumerates UC resource kinds for RenderSummary.
+// Skips empty groups so a project with no schemas doesn't print "Schemas:"
+// with nothing under it. Mirrors the inline resource-list assembly in
+// bundle/render/render_text_output.go::RenderSummary, adapted to ucm's
+// resource shapes (no uniform ResourceDescription accessor today).
+func resourceGroupsForUcm(u *ucm.Ucm) []ResourceGroup {
+	if u == nil {
+		return nil
+	}
+	cfg := &u.Config
+	var groups []ResourceGroup
+
+	if g, ok := catalogGroup(cfg); ok {
+		groups = append(groups, g)
+	}
+	if g, ok := schemaGroup(cfg); ok {
+		groups = append(groups, g)
+	}
+	if g, ok := volumeGroup(cfg); ok {
+		groups = append(groups, g)
+	}
+	if g, ok := storageCredentialGroup(cfg); ok {
+		groups = append(groups, g)
+	}
+	if g, ok := externalLocationGroup(cfg); ok {
+		groups = append(groups, g)
+	}
+	if g, ok := connectionGroup(cfg); ok {
+		groups = append(groups, g)
+	}
+	if g, ok := grantGroup(cfg); ok {
+		groups = append(groups, g)
+	}
+	if g, ok := tagValidationRuleGroup(cfg); ok {
+		groups = append(groups, g)
+	}
+	return groups
+}
+
+func catalogGroup(cfg *config.Root) (ResourceGroup, bool) {
+	if len(cfg.Resources.Catalogs) == 0 {
+		return ResourceGroup{}, false
+	}
+	rows := make([]ResourceInfo, 0, len(cfg.Resources.Catalogs))
+	for key, c := range cfg.Resources.Catalogs {
+		rows = append(rows, ResourceInfo{Key: key, Name: c.Name, URL: c.URL})
+	}
+	return ResourceGroup{GroupName: "Catalogs", Resources: rows}, true
+}
+
+func schemaGroup(cfg *config.Root) (ResourceGroup, bool) {
+	if len(cfg.Resources.Schemas) == 0 {
+		return ResourceGroup{}, false
+	}
+	rows := make([]ResourceInfo, 0, len(cfg.Resources.Schemas))
+	for key, s := range cfg.Resources.Schemas {
+		full := s.Name
+		if s.CatalogName != "" {
+			full = s.CatalogName + "." + s.Name
+		}
+		rows = append(rows, ResourceInfo{Key: key, Name: full, URL: s.URL})
+	}
+	return ResourceGroup{GroupName: "Schemas", Resources: rows}, true
+}
+
+func volumeGroup(cfg *config.Root) (ResourceGroup, bool) {
+	if len(cfg.Resources.Volumes) == 0 {
+		return ResourceGroup{}, false
+	}
+	rows := make([]ResourceInfo, 0, len(cfg.Resources.Volumes))
+	for key, v := range cfg.Resources.Volumes {
+		full := v.Name
+		if v.CatalogName != "" && v.SchemaName != "" {
+			full = v.CatalogName + "." + v.SchemaName + "." + v.Name
+		}
+		rows = append(rows, ResourceInfo{Key: key, Name: full, URL: v.URL})
+	}
+	return ResourceGroup{GroupName: "Volumes", Resources: rows}, true
+}
+
+func storageCredentialGroup(cfg *config.Root) (ResourceGroup, bool) {
+	if len(cfg.Resources.StorageCredentials) == 0 {
+		return ResourceGroup{}, false
+	}
+	rows := make([]ResourceInfo, 0, len(cfg.Resources.StorageCredentials))
+	for key, sc := range cfg.Resources.StorageCredentials {
+		rows = append(rows, ResourceInfo{Key: key, Name: sc.Name, URL: sc.URL})
+	}
+	return ResourceGroup{GroupName: "Storage credentials", Resources: rows}, true
+}
+
+func externalLocationGroup(cfg *config.Root) (ResourceGroup, bool) {
+	if len(cfg.Resources.ExternalLocations) == 0 {
+		return ResourceGroup{}, false
+	}
+	rows := make([]ResourceInfo, 0, len(cfg.Resources.ExternalLocations))
+	for key, el := range cfg.Resources.ExternalLocations {
+		rows = append(rows, ResourceInfo{Key: key, Name: el.Name, URL: el.URL})
+	}
+	return ResourceGroup{GroupName: "External locations", Resources: rows}, true
+}
+
+func connectionGroup(cfg *config.Root) (ResourceGroup, bool) {
+	if len(cfg.Resources.Connections) == 0 {
+		return ResourceGroup{}, false
+	}
+	rows := make([]ResourceInfo, 0, len(cfg.Resources.Connections))
+	for key, conn := range cfg.Resources.Connections {
+		rows = append(rows, ResourceInfo{Key: key, Name: conn.Name, URL: conn.URL})
+	}
+	return ResourceGroup{GroupName: "Connections", Resources: rows}, true
+}
+
+func grantGroup(cfg *config.Root) (ResourceGroup, bool) {
+	if len(cfg.Resources.Grants) == 0 {
+		return ResourceGroup{}, false
+	}
+	rows := make([]ResourceInfo, 0, len(cfg.Resources.Grants))
+	for key, g := range cfg.Resources.Grants {
+		// Grants have no workspace URL; summarise securable + principal.
+		name := fmt.Sprintf("%s %s -> %s", g.Securable.Type, g.Securable.Name, g.Principal)
+		rows = append(rows, ResourceInfo{Key: key, Name: name})
+	}
+	return ResourceGroup{GroupName: "Grants", Resources: rows}, true
+}
+
+func tagValidationRuleGroup(cfg *config.Root) (ResourceGroup, bool) {
+	if len(cfg.Resources.TagValidationRules) == 0 {
+		return ResourceGroup{}, false
+	}
+	rows := make([]ResourceInfo, 0, len(cfg.Resources.TagValidationRules))
+	for key := range cfg.Resources.TagValidationRules {
+		rows = append(rows, ResourceInfo{Key: key, Name: key})
+	}
+	return ResourceGroup{GroupName: "Tag validation rules", Resources: rows}, true
+}

--- a/ucm/render/groups.go
+++ b/ucm/render/groups.go
@@ -9,9 +9,8 @@ import (
 
 // resourceGroupsForUcm enumerates UC resource kinds for RenderSummary.
 // Skips empty groups so a project with no schemas doesn't print "Schemas:"
-// with nothing under it. Mirrors the inline resource-list assembly in
-// bundle/render/render_text_output.go::RenderSummary, adapted to ucm's
-// resource shapes (no uniform ResourceDescription accessor today).
+// with nothing under it. The enumeration order here is irrelevant — the
+// downstream template alphabetizes both groups and rows for stable output.
 func resourceGroupsForUcm(u *ucm.Ucm) []ResourceGroup {
 	if u == nil {
 		return nil

--- a/ucm/render/render_text_output.go
+++ b/ucm/render/render_text_output.go
@@ -1,0 +1,186 @@
+package render
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"text/template"
+
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/fatih/color"
+)
+
+var renderFuncMap = template.FuncMap{
+	"red":     color.RedString,
+	"green":   color.GreenString,
+	"blue":    color.BlueString,
+	"yellow":  color.YellowString,
+	"magenta": color.MagentaString,
+	"cyan":    color.CyanString,
+	"bold": func(format string, a ...any) string {
+		return color.New(color.Bold).Sprintf(format, a...)
+	},
+	"italic": func(format string, a ...any) string {
+		return color.New(color.Italic).Sprintf(format, a...)
+	},
+}
+
+const summaryHeaderTemplate = `{{- if .Name -}}
+Name: {{ .Name | bold }}
+{{- if .Target }}
+Target: {{ .Target | bold }}
+{{- end }}
+{{- if or .User .Host .Path }}
+Workspace:
+{{- if .Host }}
+  Host: {{ .Host | bold }}
+{{- end }}
+{{- if .User }}
+  User: {{ .User | bold }}
+{{- end }}
+{{- if .Path }}
+  Path: {{ .Path | bold }}
+{{- end }}
+{{- end }}
+{{ end -}}`
+
+const resourcesTemplate = `Resources:
+{{- range . }}
+  {{ .GroupName }}:
+  {{- range .Resources }}
+    {{ .Key | bold }}:
+      Name: {{ .Name }}
+      URL:  {{ if .URL }}{{ .URL | cyan }}{{ else }}{{ "(not deployed)" | cyan }}{{ end }}
+  {{- end }}
+{{- end }}
+`
+
+type ResourceGroup struct {
+	GroupName string
+	Resources []ResourceInfo
+}
+
+type ResourceInfo struct {
+	Key  string
+	Name string
+	URL  string
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
+}
+
+func buildTrailer(ctx context.Context) string {
+	info := logdiag.Copy(ctx)
+	var parts []string
+	if info.Errors > 0 {
+		parts = append(parts, color.RedString(pluralize(info.Errors, "error", "errors")))
+	}
+	if info.Warnings > 0 {
+		parts = append(parts, color.YellowString(pluralize(info.Warnings, "warning", "warnings")))
+	}
+	if info.Recommendations > 0 {
+		parts = append(parts, color.BlueString(pluralize(info.Recommendations, "recommendation", "recommendations")))
+	}
+	switch {
+	case len(parts) >= 3:
+		first := strings.Join(parts[:len(parts)-1], ", ")
+		last := parts[len(parts)-1]
+		return fmt.Sprintf("Found %s, and %s\n", first, last)
+	case len(parts) == 2:
+		return fmt.Sprintf("Found %s and %s\n", parts[0], parts[1])
+	case len(parts) == 1:
+		return fmt.Sprintf("Found %s\n", parts[0])
+	default:
+		// No diagnostics to print.
+		return color.GreenString("Validation OK!\n")
+	}
+}
+
+func renderSummaryHeaderTemplate(ctx context.Context, out io.Writer, u *ucm.Ucm) error {
+	if u == nil {
+		return nil
+	}
+
+	currentUser := &iam.User{}
+
+	if u.CurrentUser != nil {
+		if u.CurrentUser.User != nil {
+			currentUser = u.CurrentUser.User
+		}
+	}
+
+	t := template.Must(template.New("summary").Funcs(renderFuncMap).Parse(summaryHeaderTemplate))
+	err := t.Execute(out, map[string]any{
+		"Name":   u.Config.Ucm.Name,
+		"Target": u.Config.Ucm.Target,
+		"User":   currentUser.UserName,
+		"Path":   u.Config.Workspace.RootPath,
+		"Host":   u.Config.Workspace.Host,
+	})
+
+	return err
+}
+
+// RenderDiagnostics renders the diagnostics in a human-readable format.
+func RenderDiagnosticsSummary(ctx context.Context, out io.Writer, u *ucm.Ucm) error {
+	if u != nil {
+		err := renderSummaryHeaderTemplate(ctx, out, u)
+		if err != nil {
+			return fmt.Errorf("failed to render summary: %w", err)
+		}
+		_, err = io.WriteString(out, "\n")
+		if err != nil {
+			return err
+		}
+	}
+	trailer := buildTrailer(ctx)
+	_, err := io.WriteString(out, trailer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RenderSummary(ctx context.Context, out io.Writer, u *ucm.Ucm) error {
+	if u == nil {
+		return nil
+	}
+	if err := renderSummaryHeaderTemplate(ctx, out, u); err != nil {
+		return err
+	}
+
+	resourceGroups := resourceGroupsForUcm(u)
+
+	if err := renderResourcesTemplate(out, resourceGroups); err != nil {
+		return fmt.Errorf("failed to render resources template: %w", err)
+	}
+
+	return nil
+}
+
+// Helper function to sort and render resource groups using the template
+func renderResourcesTemplate(out io.Writer, resourceGroups []ResourceGroup) error {
+	// Sort everything to ensure consistent output
+	slices.SortFunc(resourceGroups, func(a, b ResourceGroup) int {
+		return cmp.Compare(a.GroupName, b.GroupName)
+	})
+	for _, group := range resourceGroups {
+		slices.SortFunc(group.Resources, func(a, b ResourceInfo) int {
+			return cmp.Compare(a.Key, b.Key)
+		})
+	}
+
+	t := template.Must(template.New("resources").Funcs(renderFuncMap).Parse(resourcesTemplate))
+
+	return t.Execute(out, resourceGroups)
+}

--- a/ucm/render/render_text_output_test.go
+++ b/ucm/render/render_text_output_test.go
@@ -1,0 +1,375 @@
+package render
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderSummaryHeaderTemplate_nilUcm(t *testing.T) {
+	writer := &bytes.Buffer{}
+
+	err := renderSummaryHeaderTemplate(t.Context(), writer, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", writer.String())
+}
+
+func TestRenderDiagnosticsSummary(t *testing.T) {
+	// Disable colors for consistent test output
+	oldNoColor := color.NoColor
+	color.NoColor = true
+	defer func() {
+		color.NoColor = oldNoColor
+	}()
+
+	testCases := []struct {
+		name            string
+		ucm             *ucm.Ucm
+		errors          int
+		warnings        int
+		recommendations int
+		expectedSummary string
+	}{
+		{
+			name:            "no diagnostics",
+			ucm:             nil,
+			errors:          0,
+			warnings:        0,
+			recommendations: 0,
+			expectedSummary: "Validation OK!\n",
+		},
+		{
+			name:            "1 error",
+			ucm:             nil,
+			errors:          1,
+			warnings:        0,
+			recommendations: 0,
+			expectedSummary: "Found 1 error\n",
+		},
+		{
+			name:            "1 warning",
+			ucm:             nil,
+			errors:          0,
+			warnings:        1,
+			recommendations: 0,
+			expectedSummary: "Found 1 warning\n",
+		},
+		{
+			name:            "1 recommendation",
+			ucm:             nil,
+			errors:          0,
+			warnings:        0,
+			recommendations: 1,
+			expectedSummary: "Found 1 recommendation\n",
+		},
+		{
+			name:            "multiple diagnostics",
+			ucm:             nil,
+			errors:          2,
+			warnings:        1,
+			recommendations: 1,
+			expectedSummary: "Found 2 errors, 1 warning, and 1 recommendation\n",
+		},
+		{
+			name: "with ucm info",
+			ucm: &ucm.Ucm{
+				Config: config.Root{
+					Ucm: config.Ucm{
+						Name:   "test-ucm",
+						Target: "test-target",
+					},
+					Workspace: config.Workspace{
+						Host:     "https://test.databricks.com",
+						RootPath: "/Users/test@test.com/.ucm/test-ucm/test-target",
+					},
+				},
+				CurrentUser: &config.User{
+					User: &iam.User{UserName: "test@test.com"},
+				},
+			},
+			errors:          1,
+			warnings:        0,
+			recommendations: 0,
+			expectedSummary: "Name: test-ucm\nTarget: test-target\nWorkspace:\n  Host: https://test.databricks.com\n  User: test@test.com\n  Path: /Users/test@test.com/.ucm/test-ucm/test-target\n\nFound 1 error\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := logdiag.InitContext(t.Context())
+			logdiag.SetCollect(ctx, true) // Collect diagnostics instead of outputting to stderr
+
+			// Simulate diagnostic counts by logging fake diagnostics
+			for range tc.errors {
+				logdiag.LogError(ctx, errors.New("test error"))
+			}
+			for range tc.warnings {
+				logdiag.LogDiag(ctx, diag.Diagnostic{Severity: diag.Warning, Summary: "test warning"})
+			}
+			for range tc.recommendations {
+				logdiag.LogDiag(ctx, diag.Diagnostic{Severity: diag.Recommendation, Summary: "test recommendation"})
+			}
+
+			writer := &bytes.Buffer{}
+			err := RenderDiagnosticsSummary(ctx, writer, tc.ucm)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedSummary, writer.String())
+		})
+	}
+}
+
+type renderDiagnosticsTestCase struct {
+	name     string
+	diags    diag.Diagnostics
+	expected string
+}
+
+func TestRenderDiagnostics(t *testing.T) {
+	// Disable colors for consistent test output
+	oldNoColor := color.NoColor
+	color.NoColor = true
+	defer func() {
+		color.NoColor = oldNoColor
+	}()
+
+	testCases := []renderDiagnosticsTestCase{
+		{
+			name:     "empty diagnostics",
+			diags:    diag.Diagnostics{},
+			expected: "",
+		},
+		{
+			name: "error with short summary",
+			diags: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "failed to load xxx",
+				},
+			},
+			expected: "Error: failed to load xxx\n\n",
+		},
+		{
+			name: "error with source location",
+			diags: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "failed to load xxx",
+					Detail:   "'name' is required",
+					Locations: []dyn.Location{{
+						File:   "foo.yaml",
+						Line:   1,
+						Column: 2,
+					}},
+				},
+			},
+			expected: "Error: failed to load xxx\n" +
+				"  in foo.yaml:1:2\n\n" +
+				"'name' is required\n\n",
+		},
+		{
+			name: "error with multiple source locations",
+			diags: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "failed to load xxx",
+					Detail:   "'name' is required",
+					Locations: []dyn.Location{
+						{
+							File:   "foo.yaml",
+							Line:   1,
+							Column: 2,
+						},
+						{
+							File:   "bar.yaml",
+							Line:   3,
+							Column: 4,
+						},
+					},
+				},
+			},
+			expected: "Error: failed to load xxx\n" +
+				"  in foo.yaml:1:2\n" +
+				"     bar.yaml:3:4\n\n" +
+				"'name' is required\n\n",
+		},
+		{
+			name: "error with path",
+			diags: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Detail:   "'name' is required",
+					Summary:  "failed to load xxx",
+					Paths:    []dyn.Path{dyn.MustPathFromString("resources.catalogs.xxx")},
+				},
+			},
+			expected: "Error: failed to load xxx\n" +
+				"  at resources.catalogs.xxx\n" +
+				"\n" +
+				"'name' is required\n\n",
+		},
+		{
+			name: "error with multiple paths",
+			diags: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Detail:   "'name' is required",
+					Summary:  "failed to load xxx",
+					Paths: []dyn.Path{
+						dyn.MustPathFromString("resources.catalogs.xxx"),
+						dyn.MustPathFromString("resources.catalogs.yyy"),
+						dyn.MustPathFromString("resources.catalogs.zzz"),
+					},
+				},
+			},
+			expected: "Error: failed to load xxx\n" +
+				"  at resources.catalogs.xxx\n" +
+				"     resources.catalogs.yyy\n" +
+				"     resources.catalogs.zzz\n" +
+				"\n" +
+				"'name' is required\n\n",
+		},
+		{
+			name: "recommendation with multiple paths and locations",
+			diags: diag.Diagnostics{
+				{
+					Severity: diag.Recommendation,
+					Summary:  "summary",
+					Detail:   "detail",
+					Paths: []dyn.Path{
+						dyn.MustPathFromString("resources.catalogs.xxx"),
+						dyn.MustPathFromString("resources.catalogs.yyy"),
+					},
+					Locations: []dyn.Location{
+						{File: "foo.yaml", Line: 1, Column: 2},
+						{File: "bar.yaml", Line: 3, Column: 4},
+					},
+				},
+			},
+			expected: "Recommendation: summary\n" +
+				"  at resources.catalogs.xxx\n" +
+				"     resources.catalogs.yyy\n" +
+				"  in foo.yaml:1:2\n" +
+				"     bar.yaml:3:4\n\n" +
+				"detail\n\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, stderr := cmdio.NewTestContextWithStderr(t.Context())
+
+			err := cmdio.RenderDiagnostics(ctx, tc.diags)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, stderr.String())
+		})
+	}
+}
+
+func TestRenderSummaryTemplate_nilUcm(t *testing.T) {
+	// Disable colors for consistent test output
+	oldNoColor := color.NoColor
+	color.NoColor = true
+	defer func() {
+		color.NoColor = oldNoColor
+	}()
+
+	ctx := logdiag.InitContext(t.Context())
+	writer := &bytes.Buffer{}
+
+	err := renderSummaryHeaderTemplate(ctx, writer, nil)
+	require.NoError(t, err)
+
+	_, err = io.WriteString(writer, buildTrailer(ctx))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Validation OK!\n", writer.String())
+}
+
+func TestRenderSummary(t *testing.T) {
+	ctx := t.Context()
+
+	// Disable colors for consistent test output
+	oldNoColor := color.NoColor
+	color.NoColor = true
+	defer func() {
+		color.NoColor = oldNoColor
+	}()
+
+	// Create a mock ucm with various resources
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Ucm: config.Ucm{
+				Name:   "test-ucm",
+				Target: "test-target",
+			},
+			Workspace: config.Workspace{
+				Host: "https://mycompany.databricks.com/",
+			},
+			Resources: config.Resources{
+				Catalogs: map[string]*resources.Catalog{
+					"catalog1": {
+						CreateCatalog: catalog.CreateCatalog{Name: "catalog1-name"},
+						URL:           "https://url1",
+					},
+					"catalog2": {
+						CreateCatalog: catalog.CreateCatalog{Name: "catalog2-name"},
+						URL:           "https://url2",
+					},
+				},
+				Schemas: map[string]*resources.Schema{
+					"schema2": {
+						CreateSchema: catalog.CreateSchema{Name: "schema", CatalogName: "catalog1-name"},
+						// no URL
+					},
+					"schema1": {
+						CreateSchema: catalog.CreateSchema{Name: "schema", CatalogName: "catalog2-name"},
+						URL:          "https://url3",
+					},
+				},
+			},
+		},
+	}
+
+	writer := &bytes.Buffer{}
+	err := RenderSummary(ctx, writer, u)
+	require.NoError(t, err)
+
+	expectedSummary := `Name: test-ucm
+Target: test-target
+Workspace:
+  Host: https://mycompany.databricks.com/
+Resources:
+  Catalogs:
+    catalog1:
+      Name: catalog1-name
+      URL:  https://url1
+    catalog2:
+      Name: catalog2-name
+      URL:  https://url2
+  Schemas:
+    schema1:
+      Name: catalog2-name.schema
+      URL:  https://url3
+    schema2:
+      Name: catalog1-name.schema
+      URL:  (not deployed)
+`
+	assert.Equal(t, expectedSummary, writer.String())
+}


### PR DESCRIPTION
Closes #106

## Summary

Sub-project B of the UCM ↔ Bundle alignment effort. Ports `RenderDiagnosticsSummary`, `RenderSummary`, `ResourceGroup`, `ResourceInfo` from `bundle/render/` into `ucm/render/`, then strips the inlined renderers from `cmd/ucm/{validate,summary}.go` so those verb files mirror their bundle peers' shape.

**Changes:**
- Fork `bundle/render/render_text_output.go` → `ucm/render/render_text_output.go` (1:1 mechanical Bundle→Ucm rename).
- Add `ucm/render/groups.go` with `resourceGroupsForUcm(u *ucm.Ucm) []ResourceGroup` enumerating UC resources (catalogs, schemas, volumes, external_locations, storage_credentials, connections, grants, tag_validation_rules) and skipping empty groups. Per-kind helpers because UCM resources don't share a uniform accessor (Schemas/Volumes need fully-qualified names; Grants synthesize from Securable+Principal; TagValidationRules use map-key).
- Fork `bundle/render/render_text_output_test.go` → `ucm/render/render_text_output_test.go` with UC resource fixtures.
- Strip `writeValidateTrailer`/`pluralize`/`renderSummaryHeader`/`renderValidateJSON` from `cmd/ucm/validate.go`. Replace with `render.RenderDiagnosticsSummary`. **LOC: 140 → 99.**
- Strip the inline tree-rendering bulk from `cmd/ucm/summary.go`. Replace with `render.RenderSummary`. **LOC: 279 → 84.**
- `--show-full-config` now matches bundle's exit-code contract: render JSON regardless of errors, then return `ErrAlreadyPrinted` if errors present (so scripted callers exit non-zero on broken configs).

## Notable behavior change to flag for reviewers

Pre-PR UCM's `summary.go` had a `HasURL: false` flag that suppressed the `URL:` line entirely for Grants and TagValidationRules. Bundle's `resourcesTemplate` is monomorphic — it always emits `URL:` (rendering `(not deployed)` when empty). Post-PR, those kinds render `URL:  (not deployed)` instead of being URL-less. This is consistent with bundle's tree grammar per the spec's behavior contract.

## Why

Spec at `docs/superpowers/specs/2026-04-28-ucm-bundle-alignment-rendering-design.md`. Sub-project A (PR #105) aligned the foundation; this PR (sub-project B) ports the canonical render helpers so per-verb files mirror bundle's shape. Sub-project C (per-verb cleanup for the remaining UCM verbs) builds on this.

## Hard constraints honored

- No edits to `cmd/cmd.go`, `cmd/root/**`, `bundle/**`, `libs/**`. `git diff --name-only origin/main..HEAD | grep -E '^(bundle/|cmd/root/|cmd/cmd\.go|libs/)'` → empty.
- Faithful copy/fork — adaptations called out at the call site, not just in commit bodies.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./cmd/ucm/... ./ucm/...` — clean
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...` — all packages pass uncached (~80s total). New `ucm/render` package now in the test summary.
- [x] No edits to `bundle/**`, `cmd/root/**`, `cmd/cmd.go`, `libs/**` (verified)
- [ ] Behavior-preservation diff (manual smoke against a real `ucm.yml` fixture): `./databricks ucm validate` and `summary` produce identical output to a pre-PR build, modulo the documented Grants/TagValidationRules URL line change.

This pull request and its description were written by Isaac.