### PR TITLE
ucm: Small verbs scaffolding pass (sub-project C.1)

### DIFF
--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/spf13/cobra"
 )
@@ -28,11 +29,28 @@ Common invocations:
 
 	var autoApprove bool
 	var forceLock bool
+	var verbose bool
+	var readPlanPath string
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip interactive approvals for destructive actions.")
 	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose output.")
+	// Verbose flag is parity with bundle; UCM has no file sync today so the
+	// flag is currently a no-op. Hidden until file sync lands.
+	_ = cmd.Flags().MarkHidden("verbose")
+	cmd.Flags().StringVar(&readPlanPath, "plan", "", "Path to a JSON plan file to apply instead of planning (direct engine only).")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
+			InitFunc: func(u *ucm.Ucm) {
+				u.ForceLock = forceLock
+				u.AutoApprove = autoApprove
+			},
+			Verbose:      verbose,
+			AlwaysPull:   true,
+			FastValidate: true,
+			Build:        true,
+			ReadPlanPath: readPlanPath,
+		})
 		ctx := cmd.Context()
 		if err != nil {
 			return err
@@ -41,12 +59,15 @@ Common invocations:
 			return root.ErrAlreadyPrinted
 		}
 
+		// UCM's phases.Deploy needs a Backend + TerraformFactory that ProcessUcm
+		// does not yet plumb (tracked in #103). Until then the verb assembles
+		// phases.Options here and runs Deploy directly.
 		opts, err := buildPhaseOptions(ctx, u)
 		if err != nil {
 			return fmt.Errorf("resolve deploy options: %w", err)
 		}
-		opts.ForceLock = forceLock
-		opts.AutoApprove = autoApprove
+		opts.ForceLock = u.ForceLock
+		opts.AutoApprove = u.AutoApprove
 
 		phases.Deploy(ctx, u, opts)
 		if logdiag.HasError(ctx) {

--- a/cmd/ucm/deploy.go
+++ b/cmd/ucm/deploy.go
@@ -34,10 +34,10 @@ Common invocations:
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip interactive approvals for destructive actions.")
 	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose output.")
+	cmd.Flags().StringVar(&readPlanPath, "plan", "", "Path to a JSON plan file to apply instead of planning (direct engine only).")
 	// Verbose flag is parity with bundle; UCM has no file sync today so the
 	// flag is currently a no-op. Hidden until file sync lands.
-	_ = cmd.Flags().MarkHidden("verbose")
-	cmd.Flags().StringVar(&readPlanPath, "plan", "", "Path to a JSON plan file to apply instead of planning (direct engine only).")
+	cmd.Flags().MarkHidden("verbose")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
@@ -62,6 +62,10 @@ Common invocations:
 		// UCM's phases.Deploy needs a Backend + TerraformFactory that ProcessUcm
 		// does not yet plumb (tracked in #103). Until then the verb assembles
 		// phases.Options here and runs Deploy directly.
+		// (Build: true above is safe — phases.BuildArtifacts is a no-op stub
+		// today per #101. Deploy: true would trigger phases.Deploy with
+		// zero-value Options that lacks Backend; we run Deploy ourselves below
+		// until #103 plumbs Backend through ProcessOptions.)
 		opts, err := buildPhaseOptions(ctx, u)
 		if err != nil {
 			return fmt.Errorf("resolve deploy options: %w", err)

--- a/cmd/ucm/deploy_test.go
+++ b/cmd/ucm/deploy_test.go
@@ -33,7 +33,7 @@ func TestCmd_Deploy_PropagatesApplyError(t *testing.T) {
 
 func TestCmd_Deploy_DeclaresAutoApproveAndForceLockFlags(t *testing.T) {
 	cmd := newDeployCommand()
-	for _, name := range []string{"auto-approve", "force-lock"} {
+	for _, name := range []string{"auto-approve", "force-lock", "verbose", "plan"} {
 		flag := cmd.Flags().Lookup(name)
 		assert.NotNil(t, flag, "deploy missing --%s flag", name)
 	}

--- a/cmd/ucm/deployment/bind.go
+++ b/cmd/ucm/deployment/bind.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/spf13/cobra"
 )
@@ -61,10 +62,14 @@ made outside ucm may be overwritten on the next deploy.`,
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		key, ucName := args[0], args[1]
-		ctx := cmd.Context()
 
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{})
-		ctx = cmd.Context()
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
+			InitFunc: func(u *ucm.Ucm) {
+				u.ForceLock = forceLock
+			},
+			InitIDs: true,
+		})
+		ctx := cmd.Context()
 		if err != nil {
 			return err
 		}
@@ -94,11 +99,13 @@ made outside ucm may be overwritten on the next deploy.`,
 			}
 		}
 
+		// UCM's phases.Bind needs a Backend + TerraformFactory that ProcessUcm
+		// does not yet plumb (tracked in #103).
 		opts, err := buildPhaseOptions(ctx, u)
 		if err != nil {
 			return fmt.Errorf("resolve bind options: %w", err)
 		}
-		opts.ForceLock = forceLock
+		opts.ForceLock = u.ForceLock
 
 		phases.Bind(ctx, u, opts, phases.BindRequest{Kind: kind, Name: ucName, Key: key})
 		if logdiag.HasError(ctx) {

--- a/cmd/ucm/deployment/unbind.go
+++ b/cmd/ucm/deployment/unbind.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/spf13/cobra"
 )
@@ -47,10 +48,14 @@ To re-bind later, use:
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		key := args[0]
-		ctx := cmd.Context()
 
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{})
-		ctx = cmd.Context()
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
+			InitFunc: func(u *ucm.Ucm) {
+				u.ForceLock = forceLock
+			},
+			InitIDs: true,
+		})
+		ctx := cmd.Context()
 		if err != nil {
 			return err
 		}
@@ -76,11 +81,13 @@ To re-bind later, use:
 			}
 		}
 
+		// UCM's phases.Unbind needs a Backend + TerraformFactory that
+		// ProcessUcm does not yet plumb (tracked in #103).
 		opts, err := buildPhaseOptions(ctx, u)
 		if err != nil {
 			return fmt.Errorf("resolve unbind options: %w", err)
 		}
-		opts.ForceLock = forceLock
+		opts.ForceLock = u.ForceLock
 
 		phases.Unbind(ctx, u, opts, phases.UnbindRequest{Kind: kind, Key: key})
 		if logdiag.HasError(ctx) {

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/spf13/cobra"
 )
@@ -39,7 +40,13 @@ Common invocations:
 			return errors.New("please specify --auto-approve since terminal does not support interactive prompts")
 		}
 
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
+			InitFunc: func(u *ucm.Ucm) {
+				u.ForceLock = forceLock
+				u.AutoApprove = autoApprove
+			},
+			AlwaysPull: true,
+		})
 		ctx = cmd.Context()
 		if err != nil {
 			return err
@@ -48,12 +55,15 @@ Common invocations:
 			return root.ErrAlreadyPrinted
 		}
 
+		// UCM's phases.Destroy needs a Backend + TerraformFactory that
+		// ProcessUcm does not yet plumb (tracked in #103). Until then the verb
+		// assembles phases.Options here and runs Destroy directly.
 		opts, err := buildPhaseOptions(ctx, u)
 		if err != nil {
 			return fmt.Errorf("resolve deploy options: %w", err)
 		}
-		opts.ForceLock = forceLock
-		opts.AutoApprove = autoApprove
+		opts.ForceLock = u.ForceLock
+		opts.AutoApprove = u.AutoApprove
 
 		phases.Destroy(ctx, u, opts)
 		if logdiag.HasError(ctx) {

--- a/cmd/ucm/destroy.go
+++ b/cmd/ucm/destroy.go
@@ -60,7 +60,7 @@ Common invocations:
 		// assembles phases.Options here and runs Destroy directly.
 		opts, err := buildPhaseOptions(ctx, u)
 		if err != nil {
-			return fmt.Errorf("resolve deploy options: %w", err)
+			return fmt.Errorf("resolve destroy options: %w", err)
 		}
 		opts.ForceLock = u.ForceLock
 		opts.AutoApprove = u.AutoApprove

--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -50,7 +50,7 @@ Common invocations:
 
 		opts, err := buildPhaseOptions(ctx, u)
 		if err != nil {
-			return fmt.Errorf("resolve deploy options: %w", err)
+			return fmt.Errorf("resolve plan options: %w", err)
 		}
 		opts.ForceLock = forceLock
 

--- a/ucm/ucm.go
+++ b/ucm/ucm.go
@@ -43,6 +43,17 @@ type Ucm struct {
 	// mutator applies.
 	CurrentUser *config.User
 
+	// AutoApprove mirrors --auto-approve. Set by verb InitFuncs and read by
+	// the verb body to populate phases.Options.AutoApprove. Bundle parity:
+	// bundle.Bundle has the same field at the same level.
+	AutoApprove bool
+
+	// ForceLock mirrors --force-lock. Set by verb InitFuncs and read by the
+	// verb body to populate phases.Options.ForceLock. Bundle's equivalent
+	// lives at b.Config.Bundle.Deployment.Lock.Force; ucm has no Deployment
+	// config block today, so the field lives directly on Ucm.
+	ForceLock bool
+
 	// getClient memoizes the workspace client built from Config.Workspace.
 	// Initialized lazily by WorkspaceClientE via initClientOnce.
 	getClient func() (*databricks.WorkspaceClient, error)


### PR DESCRIPTION
Closes #108

## Summary

First PR in sub-project C — establishes the per-verb body pattern that subsequent C.* PRs follow.

- **`cmd/ucm/deploy.go`** (61 → 82 LOC): adds `--verbose` (hidden) and `--plan <path>` flags. Wires `Verbose, ReadPlanPath, AlwaysPull, FastValidate, Build` into `ProcessOptions`. `InitFunc` pushes `--force-lock`/`--auto-approve` onto new `*ucm.Ucm` fields. Drops bundle-only flags that don't apply to UCM (`--force`, `--fail-on-active-runs`, `--cluster-id`/`--compute-id`).
- **`cmd/ucm/destroy.go`** (68 → 78 LOC): wires `AlwaysPull: true`. `InitFunc` pushes flag values.
- **`cmd/ucm/deployment/{bind,unbind}.go`** (114→121 / 95→102 LOC): wires `InitIDs: true`. `InitFunc` pushes `--force-lock`.
- **`ucm/ucm.go`** (159 → 170 LOC): adds `Ucm.AutoApprove` and `Ucm.ForceLock` top-level fields (bundle has `b.AutoApprove` top-level and `b.Config.Bundle.Deployment.Lock.Force` under config; UCM has no Deployment config block today, so both live on `Ucm`).
- **`cmd/ucm/{schema,debug/*,deployment/{deployment,options}}.go`** — verified already aligned, no changes needed.

## Notable adaptation

`Deploy: true` (and `Destroy`/`Bind`/`Unbind` analogues) intentionally NOT set on `ProcessOptions`. Until #103 plumbs `Backend` through `ProcessOptions`, `ProcessUcm`'s `Deploy: true` path would call `phases.Deploy` with zero-value `phases.Options{}` and fail. Verb bodies continue to call `phases.<X>(ctx, u, opts)` directly with `buildPhaseOptions`-built opts. Inline comments in each touched verb file reference #103. Once #103 lands, the verb bodies fold into `ProcessUcm` automatically.

## Bundle-parity drops

- `--force` (no git-branch deploy validation in UCM)
- `--fail-on-active-runs` (no jobs/pipelines)
- `--cluster-id`/`--compute-id` (no clusters)

## Why

Spec at `docs/superpowers/specs/2026-04-28-ucm-bundle-alignment-per-verb-design.md`. Sub-project A (PR #105) aligned the foundation; sub-project B (PR #107) the rendering. C.1 is the first per-verb cleanup, establishing the canonical verb body pattern: `InitFunc` pushes flag values onto `u.Config`/`u`, opts struct drives `ProcessUcm`, verb body completes any phase work not yet plumbed through ProcessOptions.

## Hard constraints honored

- No edits to `cmd/cmd.go`, `cmd/root/**`, `bundle/**`, `libs/**`. `git diff --name-only origin/main..HEAD | grep -E '^(bundle/|cmd/root/|cmd/cmd\.go|libs/)'` → empty.
- Faithful copy/fork — adaptations called out at the call site, not just in commit bodies.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./cmd/ucm/... ./ucm/...` — clean
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...` — all packages pass uncached
- [x] Behavior-preservation diff: `--help` for each touched verb is identical to pre-PR build apart from documented flag additions (deploy gains `--plan`; `--verbose` is hidden)
- [x] No edits to `bundle/**`, `cmd/root/**`, `cmd/cmd.go`, `libs/**`

This pull request and its description were written by Isaac.