### PR TITLE
ucm: Plan verb alignment (sub-project C.2)

### DIFF
--- a/cmd/ucm/plan.go
+++ b/cmd/ucm/plan.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/deployplan"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/databricks/cli/ucm/render"
@@ -35,11 +36,21 @@ Common invocations:
 	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
 
 	var force bool
-	cmd.Flags().BoolVar(&force, "force", false, "Force override of Git branch validation (no-op for UCM; accepted for DAB parity).")
-	_ = cmd.Flags().MarkHidden("force")
+	cmd.Flags().BoolVar(&force, "force", false, "Force-override Git branch validation.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{
+			InitFunc: func(u *ucm.Ucm) {
+				u.Force = force
+			},
+			AlwaysPull:   true,
+			FastValidate: true,
+			// Build and PreDeployChecks are intentionally NOT set: until #103
+			// plumbs Backend through ProcessOptions, those would call
+			// phases.Build / PreDeployChecks with a zero-value phases.Options
+			// that lacks the Backend and TerraformFactory the verb body's
+			// buildPhaseOptions provides below. Once #103 lands, fold them in.
+		})
 		ctx := cmd.Context()
 		if err != nil {
 			return err

--- a/cmd/ucm/plan_test.go
+++ b/cmd/ucm/plan_test.go
@@ -93,15 +93,15 @@ func TestCmd_Plan_SkipCountsUnchanged(t *testing.T) {
 	assert.NotContains(t, stdout, "skip catalogs.main")
 }
 
-// TestCmd_Plan_ForceFlagIsRegisteredAndHidden verifies the DAB-parity hidden
-// --force flag is registered on the plan verb. It is a documented no-op; we
-// only assert the flag is wired and marked hidden so users migrating from
-// `bundle plan --force` don't hit an unknown-flag error.
-func TestCmd_Plan_ForceFlagIsRegisteredAndHidden(t *testing.T) {
+// TestCmd_Plan_ForceFlagIsRegisteredAndVisible verifies the DAB-parity
+// --force flag is registered on the plan verb and visible in --help. The
+// value is pushed onto Ucm.Force via the verb's InitFunc; bundle parallel
+// is b.Config.Bundle.Force.
+func TestCmd_Plan_ForceFlagIsRegisteredAndVisible(t *testing.T) {
 	cmd := newPlanCommand()
 	f := cmd.Flags().Lookup("force")
 	require.NotNil(t, f, "--force flag should be registered on ucm plan")
-	assert.True(t, f.Hidden, "--force flag should be hidden")
+	assert.False(t, f.Hidden, "--force flag should be visible (matches bundle plan)")
 	assert.Equal(t, "false", f.DefValue)
 }
 

--- a/ucm/ucm.go
+++ b/ucm/ucm.go
@@ -54,6 +54,12 @@ type Ucm struct {
 	// config block today, so the field lives directly on Ucm.
 	ForceLock bool
 
+	// Force mirrors --force. Set by verb InitFuncs; read by checks that may
+	// be bypassed when the user passes --force (e.g. modified-remotely
+	// guards). Bundle's equivalent lives at b.Config.Bundle.Force; ucm has
+	// no Bundle config block, so the field lives directly on Ucm.
+	Force bool
+
 	// getClient memoizes the workspace client built from Config.Workspace.
 	// Initialized lazily by WorkspaceClientE via initClientOnce.
 	getClient func() (*databricks.WorkspaceClient, error)


### PR DESCRIPTION
Closes #110

## Summary
Align cmd/ucm/plan.go with bundle scaffolding:
- Wire `AlwaysPull: true, FastValidate: true` into ProcessOptions.
- Fix `--force` flag to push value onto `u.Force` via InitFunc (was a hidden no-op). Mirrors bundle's `b.Config.Bundle.Force` assignment; field added directly on `*ucm.Ucm` since UCM has no Bundle config block.
- `Build` and `PreDeployChecks` opts intentionally deferred until #103 plumbs Backend through ProcessOptions — verb body keeps its existing `buildPhaseOptions` + `phases.Plan` call until then.

## Spec correction
The spec listed `--plan <path>` and `--include-locations` as flags to add. Reading `cmd/bundle/plan.go` directly: bundle has neither. `--plan` is on `deploy` (read-side); `--include-locations` is on `validate`/`summary`. Strict parity says don't add them in C.2.

## Why
Spec at `docs/superpowers/specs/2026-04-28-ucm-bundle-alignment-per-verb-design.md`.
First medium-effort verb cleanup in sub-project C.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `--help` diff: `--force` now visible (no longer hidden); otherwise identical
- [x] No edits to `bundle/**`, `cmd/root/**`, `cmd/cmd.go`, `libs/**`

This pull request and its description were written by Isaac.