### PR TITLE
ucm: UCM-only verbs render-helpers pass (sub-project C.4)

### DIFF
--- a/cmd/ucm/drift.go
+++ b/cmd/ucm/drift.go
@@ -42,7 +42,7 @@ the command still routes all live reads through the SDK regardless of engine.`,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{InitIDs: true})
 		ctx := cmd.Context()
 		if err != nil {
 			return err

--- a/cmd/ucm/import.go
+++ b/cmd/ucm/import.go
@@ -80,7 +80,7 @@ Common invocations:
 			}
 		}
 
-		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{})
+		u, err := utils.ProcessUcm(cmd, utils.ProcessOptions{InitIDs: true})
 		ctx = cmd.Context()
 		if err != nil {
 			return err

--- a/cmd/ucm/policy_check.go
+++ b/cmd/ucm/policy_check.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm/phases"
+	"github.com/databricks/cli/ucm/render"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +41,18 @@ required fields). No network I/O.`,
 			return root.ErrAlreadyPrinted
 		}
 
+		out := cmd.OutOrStdout()
+		if root.OutputType(cmd) == flags.OutputText {
+			if err1 := render.RenderDiagnosticsSummary(ctx, out, u); err1 != nil {
+				return err1
+			}
+		}
+		if root.OutputType(cmd) == flags.OutputJSON {
+			if err1 := renderJsonOutput(cmd, u); err1 != nil {
+				return err1
+			}
+		}
+
 		numWarnings := logdiag.NumWarnings(ctx)
 		if strict && numWarnings > 0 {
 			noun := "warning"
@@ -48,7 +62,6 @@ required fields). No network I/O.`,
 			return fmt.Errorf("%d %s found. Warnings are not allowed in strict mode", numWarnings, noun)
 		}
 
-		fmt.Fprintln(cmd.OutOrStdout(), "Policy check OK!")
 		return nil
 	}
 

--- a/cmd/ucm/policy_check.go
+++ b/cmd/ucm/policy_check.go
@@ -53,13 +53,16 @@ required fields). No network I/O.`,
 			}
 		}
 
+		// err is always nil here (early-return above); guard preserved for parity with validate.go
 		numWarnings := logdiag.NumWarnings(ctx)
 		if strict && numWarnings > 0 {
-			noun := "warning"
-			if numWarnings != 1 {
-				noun = "warnings"
+			prefix := ""
+			if numWarnings == 1 {
+				prefix = "1 warning was found"
+			} else {
+				prefix = fmt.Sprintf("%d warnings were found", numWarnings)
 			}
-			return fmt.Errorf("%d %s found. Warnings are not allowed in strict mode", numWarnings, noun)
+			return fmt.Errorf("%s. Warnings are not allowed in strict mode", prefix)
 		}
 
 		return nil

--- a/cmd/ucm/policy_check_test.go
+++ b/cmd/ucm/policy_check_test.go
@@ -18,7 +18,7 @@ func TestCmd_PolicyCheck_ValidFixturePasses(t *testing.T) {
 	t.Logf("stdout=%q stderr=%q", stdout, stderr)
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "Policy check OK!")
+	assert.Contains(t, stdout, "Validation OK!")
 }
 
 func TestCmd_PolicyCheck_MissingTagFixtureFails(t *testing.T) {
@@ -36,7 +36,7 @@ func TestCmd_PolicyCheck_StrictOffAllowsWarnings(t *testing.T) {
 	stdout, _, err := runVerb(t, validFixtureDir(t), "policy-check")
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "Policy check OK!")
+	assert.Contains(t, stdout, "Found 1 warning")
 }
 
 // TestCmd_PolicyCheck_StrictOnFailsOnWarning verifies that --strict promotes


### PR DESCRIPTION
Closes #117

## Summary
Final per-verb cleanup for sub-project C. The spec assumed all four UCM-only verbs (`diff`, `drift`, `import`, `policy-check`) carried pre-foundation trailer/pluralize/header code; they don't (cleaned up by A/B or never existed). Realistic scope is much smaller.

- `cmd/ucm/policy_check.go`: replace inline `"Policy check OK!"` trailer with `render.RenderDiagnosticsSummary` for consistency with `validate`. Picks up structured JSON output path for free.
- `cmd/ucm/drift.go`: `InitIDs: true` landed — read-only verb, exercises state hydration via existing terraform-engine path; tests pass.
- `cmd/ucm/import.go`: `InitIDs: true` landed — same rationale; tests pass.
- `cmd/ucm/diff.go`: untouched — git-ref-comparison tool, different domain.

## Why
Spec at `docs/superpowers/specs/2026-04-28-ucm-bundle-alignment-per-verb-design.md` (with the documented spec correction).
Wraps up sub-project C.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `--help` diff for all four verbs is empty
- [x] policy-check trailer text matches validate's pattern
- [x] No edits to `bundle/**`, `cmd/root/**`, `cmd/cmd.go`, `libs/**`

This pull request and its description were written by Isaac.