### PR TITLE
ucm: Acceptance fixtures for offline verbs (D.2 easy tier)

### DIFF
--- a/acceptance/ucm/policy-check/happy/out.test.toml
+++ b/acceptance/ucm/policy-check/happy/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/policy-check/happy/output.txt
+++ b/acceptance/ucm/policy-check/happy/output.txt
@@ -1,0 +1,9 @@
+
+>>> [CLI] ucm policy-check
+Name: policy-check-happy
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/databricks/ucm/policy-check-happy/default
+
+Validation OK!

--- a/acceptance/ucm/policy-check/happy/script
+++ b/acceptance/ucm/policy-check/happy/script
@@ -1,0 +1,1 @@
+trace $CLI ucm policy-check

--- a/acceptance/ucm/policy-check/happy/test.toml
+++ b/acceptance/ucm/policy-check/happy/test.toml
@@ -1,0 +1,3 @@
+Cloud = false
+Local = true
+Ignore = [".databricks"]

--- a/acceptance/ucm/policy-check/happy/ucm.yml
+++ b/acceptance/ucm/policy-check/happy/ucm.yml
@@ -1,0 +1,19 @@
+ucm:
+  name: policy-check-happy
+
+resources:
+  catalogs:
+    main:
+      name: main
+      comment: policy-check-happy catalog
+
+  schemas:
+    raw:
+      name: raw
+      catalog_name: main
+
+  grants:
+    analysts:
+      securable: {type: schema, name: main.raw}
+      principal: analysts
+      privileges: [USE_SCHEMA, SELECT]

--- a/acceptance/ucm/schema/out.test.toml
+++ b/acceptance/ucm/schema/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/schema/output.txt
+++ b/acceptance/ucm/schema/output.txt
@@ -1,0 +1,42 @@
+
+>>> [CLI] ucm schema --help
+Print the JSON schema for ucm.yml.
+
+Pipe into a file and point your editor at it for autocomplete and validation:
+
+  databricks ucm schema > ucm.schema.json
+
+Usage:
+  databricks ucm schema [flags]
+
+Flags:
+  -h, --help   help for schema
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    ucm target to use (if applicable)
+      --var strings      set values for variables defined in ucm config. Example: --var="foo=bar"
+
+>>> [CLI] ucm schema
+{
+  "$defs": {
+    "bool": {
+      "type": "boolean"
+    },
+    "github.com": {
+      "databricks": {
+        "cli": {
+          "libs": {
+            "dyn": {
+              "dynloc.Locations": {
+                "type": "object",
+                "properties": {
+                  "files": {
+                    "$ref": "#/$defs/slice/string"
+                  },
+                  "locations": {
+                    "$ref": "#/$defs/map/slice/slice/int"
+                  },
+                  "version": {

--- a/acceptance/ucm/schema/script
+++ b/acceptance/ucm/schema/script
@@ -1,0 +1,2 @@
+trace $CLI ucm schema --help
+trace $CLI ucm schema | head -20

--- a/acceptance/ucm/schema/test.toml
+++ b/acceptance/ucm/schema/test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+Local = true

--- a/acceptance/ucm/summary/happy/out.test.toml
+++ b/acceptance/ucm/summary/happy/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/summary/happy/output.txt
+++ b/acceptance/ucm/summary/happy/output.txt
@@ -1,0 +1,22 @@
+
+>>> [CLI] ucm summary
+Warning: cannot initialize resource URLs: workspace.host is not set
+
+Name: summary-happy
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/databricks/ucm/summary-happy/default
+Resources:
+  Catalogs:
+    main:
+      Name: main
+      URL:  (not deployed)
+  Grants:
+    analysts:
+      Name: schema main.raw -> analysts
+      URL:  (not deployed)
+  Schemas:
+    raw:
+      Name: main.raw
+      URL:  (not deployed)

--- a/acceptance/ucm/summary/happy/script
+++ b/acceptance/ucm/summary/happy/script
@@ -1,0 +1,1 @@
+trace $CLI ucm summary

--- a/acceptance/ucm/summary/happy/test.toml
+++ b/acceptance/ucm/summary/happy/test.toml
@@ -1,0 +1,3 @@
+Cloud = false
+Local = true
+Ignore = [".databricks"]

--- a/acceptance/ucm/summary/happy/ucm.yml
+++ b/acceptance/ucm/summary/happy/ucm.yml
@@ -1,0 +1,19 @@
+ucm:
+  name: summary-happy
+
+resources:
+  catalogs:
+    main:
+      name: main
+      comment: summary-happy catalog
+
+  schemas:
+    raw:
+      name: raw
+      catalog_name: main
+
+  grants:
+    analysts:
+      securable: {type: schema, name: main.raw}
+      principal: analysts
+      privileges: [USE_SCHEMA, SELECT]

--- a/acceptance/ucm/validate/happy/out.test.toml
+++ b/acceptance/ucm/validate/happy/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/validate/happy/output.txt
+++ b/acceptance/ucm/validate/happy/output.txt
@@ -1,0 +1,9 @@
+
+>>> [CLI] ucm validate
+Name: validate-happy
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/databricks/ucm/validate-happy/default
+
+Validation OK!

--- a/acceptance/ucm/validate/happy/script
+++ b/acceptance/ucm/validate/happy/script
@@ -1,0 +1,1 @@
+trace $CLI ucm validate

--- a/acceptance/ucm/validate/happy/test.toml
+++ b/acceptance/ucm/validate/happy/test.toml
@@ -1,0 +1,3 @@
+Cloud = false
+Local = true
+Ignore = [".databricks"]

--- a/acceptance/ucm/validate/happy/ucm.yml
+++ b/acceptance/ucm/validate/happy/ucm.yml
@@ -1,0 +1,19 @@
+ucm:
+  name: validate-happy
+
+resources:
+  catalogs:
+    main:
+      name: main
+      comment: validate-happy catalog
+
+  schemas:
+    raw:
+      name: raw
+      catalog_name: main
+
+  grants:
+    analysts:
+      securable: {type: schema, name: main.raw}
+      principal: analysts
+      privileges: [USE_SCHEMA, SELECT]


### PR DESCRIPTION
Closes #120

## Summary
Adds acceptance fixtures for the four UCM verbs that didn't have any and don't need fake-workspace infrastructure: `schema`, `validate`, `summary`, `policy-check`.

After this PR:
- `acceptance/ucm/schema/`
- `acceptance/ucm/validate/happy/`
- `acceptance/ucm/summary/happy/`
- `acceptance/ucm/policy-check/happy/`

Each fixture includes `test.toml`, `script`, possibly `ucm.yml`, and the generated `output.txt` + `out.test.toml`. Coverage locks in current text-mode output for these verbs.

## Why
Sub-project D.2 easy tier. Closes #120.

## Notes
- `ucm.yml` files for validate/summary/policy-check intentionally omit `engine: direct`. The summary verb sets `InitIDs: true` which triggers the "direct engine not yet supported via ProcessUcm" guard (tracked as #95 in tree). DATABRICKS_BUNDLE_ENGINE matrix is a no-op for ucm anyway (ucm reads DATABRICKS_UCM_ENGINE), so both matrix variants share one output.
- Schema fixture pipes through `head -20` to keep the locked region small while still asserting the JSON-schema shape.

## Test plan
- [x] `go test ./acceptance -run 'TestAccept/ucm' -count=1` — all UCM fixtures (existing + new) pass without `-update`
- [x] `go build ./...` — clean
- [x] `go vet ./cmd/ucm/... ./ucm/...` — clean
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...` — all packages pass
- [x] No edits to `bundle/**`, `cmd/root/**`, `cmd/cmd.go`, `libs/**`

## Out of scope
- Medium tier (drift, import, deployment bind/unbind) — follow-up.
- Hard tier (deploy, destroy, generate, init, diff) — needs fake-workspace harness; separate follow-up.

This pull request and its description were written by Isaac.