### PR TITLE
ucm: Acceptance fixtures for drift/import (D.2 medium tier subset)

### DIFF
--- a/acceptance/ucm/drift/happy/out.test.toml
+++ b/acceptance/ucm/drift/happy/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/drift/happy/output.txt
+++ b/acceptance/ucm/drift/happy/output.txt
@@ -1,0 +1,5 @@
+
+>>> [CLI] ucm drift
+Warning: cannot initialize resource URLs: workspace.host is not set
+
+No drift detected.

--- a/acceptance/ucm/drift/happy/script
+++ b/acceptance/ucm/drift/happy/script
@@ -1,0 +1,1 @@
+trace $CLI ucm drift

--- a/acceptance/ucm/drift/happy/test.toml
+++ b/acceptance/ucm/drift/happy/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/drift/happy/ucm.yml
+++ b/acceptance/ucm/drift/happy/ucm.yml
@@ -1,0 +1,9 @@
+ucm:
+  name: drift-happy
+  engine: terraform
+
+resources:
+  catalogs:
+    main:
+      name: main
+      comment: drift-happy catalog

--- a/acceptance/ucm/import/happy/out.test.toml
+++ b/acceptance/ucm/import/happy/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/import/happy/output.txt
+++ b/acceptance/ucm/import/happy/output.txt
@@ -1,0 +1,6 @@
+
+>>> [CLI] ucm import catalog test_catalog --auto-approve
+Error: ucm: direct engine is not yet supported via ProcessUcm; set engine: terraform or unset DATABRICKS_UCM_ENGINE
+
+
+Exit code: 1

--- a/acceptance/ucm/import/happy/script
+++ b/acceptance/ucm/import/happy/script
@@ -1,0 +1,1 @@
+trace $CLI ucm import catalog test_catalog --auto-approve

--- a/acceptance/ucm/import/happy/test.toml
+++ b/acceptance/ucm/import/happy/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+Ignore = [".databricks"]

--- a/acceptance/ucm/import/happy/ucm.yml
+++ b/acceptance/ucm/import/happy/ucm.yml
@@ -1,0 +1,9 @@
+ucm:
+  name: import-happy
+  engine: direct
+
+resources:
+  catalogs:
+    test_catalog:
+      name: test_catalog
+      comment: imported test catalog


### PR DESCRIPTION
Closes #121

## Summary
Adds acceptance fixtures for `drift` and `import`. Authored in parallel with #120 (easy tier).

After this PR:
- `acceptance/ucm/drift/happy/` — locks the empty-state "No drift detected." path on the terraform engine.
- `acceptance/ucm/import/happy/` — locks the user-facing "direct engine is not yet supported via ProcessUcm" message on the direct engine.

Each fixture includes `test.toml`, `script`, `ucm.yml`, and the generated `output.txt` + `out.test.toml`.

## Why
Sub-project D.2 medium tier subset. Closes #121.

Drift's verb sets `ProcessOptions{InitIDs: true}`, which the current ProcessUcm rejects for the direct engine (tracked in #95). Pinning `engine: terraform` in the fixture exercises the verb's empty-state path through `phases.Drift` -> `direct.LoadState` -> `direct.ComputeDrift` without any UC API calls.

Import's verb has the same `InitIDs: true` constraint. Switching to terraform from there chains into `terraform init` against the offline plugin mirror, which currently mismatches (1.112.0 hardcoded in `tfdyn` vs 1.113.0 vendored under `acceptance/build`). That's an infrastructure problem outside this PR's scope. Pinning `engine: direct` keeps the fixture small and locks in the actual error users see today, so any future change to that text gets caught.

## Test plan
- [x] `go test ./acceptance -run 'TestAccept/ucm' -count=1` — all UCM fixtures pass without `-update`
- [x] `go build ./...` — clean
- [x] `go vet ./cmd/ucm/... ./ucm/...` — clean
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...` — all packages pass
- [x] No edits to `bundle/**`, `cmd/root/**`, `cmd/cmd.go`, `libs/**`

## Out of scope
- Deployment bind/unbind (also medium tier, but not in this PR's scope)
- Hard tier (deploy, destroy, generate, init, diff)
- Successful import path through the terraform engine — needs the 1.112/1.113 provider mismatch resolved first.

This pull request and its description were written by Isaac.