### PR TITLE
Feat #127: Fork bundle/direct/dstate to ucm/direct/dstate (E.1)

### DIFF
--- a/ucm/direct/dstate/migrate.go
+++ b/ucm/direct/dstate/migrate.go
@@ -1,0 +1,139 @@
+package dstate
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/databricks/cli/libs/structs/structpath"
+	"github.com/databricks/cli/ucm/direct/dresources"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+)
+
+// migrateState runs all necessary migrations on the database.
+// It is called after loading state from disk.
+func migrateState(db *Database) error {
+	if db.StateVersion == currentStateVersion {
+		return nil
+	}
+	if db.StateVersion > currentStateVersion {
+		return fmt.Errorf("state version %d is newer than supported version %d; upgrade the CLI", db.StateVersion, currentStateVersion)
+	}
+
+	for version := db.StateVersion; version < currentStateVersion; version++ {
+		fn, ok := migrations[version]
+		if !ok {
+			return fmt.Errorf("unsupported state version %d (current: %d)", version, currentStateVersion)
+		}
+		if err := fn(db); err != nil {
+			return fmt.Errorf("migrating state from version %d: %w", version, err)
+		}
+		db.StateVersion = version + 1
+	}
+
+	return nil
+}
+
+// migrations maps source version to the function that migrates to version+1.
+// Version 0 means state_version was absent in old state files; treat same as 1.
+var migrations = map[int]func(*Database) error{
+	0: migrateV1ToV2,
+	1: migrateV1ToV2,
+}
+
+// migrateV1ToV2 migrates permissions and grants entries from the old format
+// to the new format (__embed__ keys, permission_level -> level).
+func migrateV1ToV2(db *Database) error {
+	for key, entry := range db.State {
+		if len(entry.State) == 0 {
+			continue
+		}
+
+		path, pathErr := structpath.ParsePath(key)
+		if pathErr != nil || path == nil {
+			continue
+		}
+		// path points to the last node; read its key directly.
+		lastKey, ok := path.StringKey()
+		if !ok {
+			continue
+		}
+
+		var (
+			migrated json.RawMessage
+			err      error
+		)
+
+		switch lastKey {
+		case "permissions":
+			migrated, err = migratePermissionsEntry(entry.State)
+		case "grants":
+			migrated, err = migrateGrantsEntry(entry.State)
+		default:
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("migrating %s: %w", key, err)
+		}
+		entry.State = migrated
+		db.State[key] = entry
+	}
+	return nil
+}
+
+// Old types from main branch — copied here for migration purposes.
+type oldPermissionsStateV1 struct {
+	ObjectID    string            `json:"object_id"`
+	Permissions []oldPermissionV1 `json:"permissions,omitempty"`
+}
+
+type oldPermissionV1 struct {
+	PermissionLevel      string `json:"permission_level,omitempty"`
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
+func migratePermissionsEntry(raw json.RawMessage) (json.RawMessage, error) {
+	var old oldPermissionsStateV1
+	if err := json.Unmarshal(raw, &old); err != nil {
+		return nil, err
+	}
+
+	newState := dresources.PermissionsState{
+		ObjectID: old.ObjectID,
+	}
+	for _, p := range old.Permissions {
+		newState.EmbeddedSlice = append(newState.EmbeddedSlice, dresources.StatePermission{
+			Level:                iam.PermissionLevel(p.PermissionLevel),
+			UserName:             p.UserName,
+			ServicePrincipalName: p.ServicePrincipalName,
+			GroupName:            p.GroupName,
+		})
+	}
+
+	return json.Marshal(newState)
+}
+
+// oldGrantsStateV1 is the grants state format before v2.
+type oldGrantsStateV1 struct {
+	SecurableType string                        `json:"securable_type"`
+	FullName      string                        `json:"full_name"`
+	Grants        []catalog.PrivilegeAssignment `json:"grants,omitempty"`
+}
+
+func migrateGrantsEntry(raw json.RawMessage) (json.RawMessage, error) {
+	var old oldGrantsStateV1
+	if err := json.Unmarshal(raw, &old); err != nil {
+		return nil, err
+	}
+
+	newState := dresources.GrantsState{
+		SecurableType: old.SecurableType,
+		FullName:      old.FullName,
+		EmbeddedSlice: old.Grants,
+	}
+
+	return json.Marshal(newState)
+}

--- a/ucm/direct/dstate/state.go
+++ b/ucm/direct/dstate/state.go
@@ -1,0 +1,207 @@
+package dstate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/databricks/cli/internal/build"
+	"github.com/databricks/cli/ucm/deployplan"
+	"github.com/databricks/cli/ucm/statemgmt/resourcestate"
+	"github.com/google/uuid"
+)
+
+const currentStateVersion = 2
+
+type DeploymentState struct {
+	Path string
+	Data Database
+	mu   sync.Mutex
+}
+
+type Database struct {
+	StateVersion int                      `json:"state_version"`
+	CLIVersion   string                   `json:"cli_version"`
+	Lineage      string                   `json:"lineage"`
+	Serial       int                      `json:"serial"`
+	State        map[string]ResourceEntry `json:"state"`
+}
+
+type ResourceEntry struct {
+	ID        string                      `json:"__id__"`
+	State     json.RawMessage             `json:"state"`
+	DependsOn []deployplan.DependsOnEntry `json:"depends_on,omitempty"`
+}
+
+func NewDatabase(lineage string, serial int) Database {
+	return Database{
+		StateVersion: currentStateVersion,
+		CLIVersion:   build.GetInfo().Version,
+		Lineage:      lineage,
+		Serial:       serial,
+		State:        make(map[string]ResourceEntry),
+	}
+}
+
+func (db *DeploymentState) SaveState(key, newID string, state any, dependsOn []deployplan.DependsOnEntry) error {
+	db.AssertOpened()
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.Data.State == nil {
+		db.Data.State = make(map[string]ResourceEntry)
+	}
+
+	jsonMessage, err := json.MarshalIndent(state, "  ", " ")
+	if err != nil {
+		return err
+	}
+
+	db.Data.State[key] = ResourceEntry{
+		ID:        newID,
+		State:     json.RawMessage(jsonMessage),
+		DependsOn: dependsOn,
+	}
+
+	return nil
+}
+
+func (db *DeploymentState) DeleteState(key string) error {
+	db.AssertOpened()
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.Data.State == nil {
+		return nil
+	}
+
+	delete(db.Data.State, key)
+
+	return nil
+}
+
+func (db *DeploymentState) getResourceEntry(key string) (ResourceEntry, bool) {
+	db.AssertOpened()
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.Data.State == nil {
+		return ResourceEntry{}, false
+	}
+
+	result, ok := db.Data.State[key]
+	return result, ok
+}
+
+// GetResourceEntry returns the full resource entry for the given key.
+func (db *DeploymentState) GetResourceEntry(key string) (ResourceEntry, bool) {
+	return db.getResourceEntry(key)
+}
+
+// GetResourceID returns the ID of the resource for the given key, or an empty string if not found.
+func (db *DeploymentState) GetResourceID(key string) string {
+	entry, _ := db.getResourceEntry(key)
+	return entry.ID
+}
+
+func (db *DeploymentState) Open(path string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.Path != "" {
+		panic(fmt.Sprintf("state already opened: %v, cannot open %v", db.Path, path))
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// Create new database with serial=0, will be incremented to 1 in Finalize()
+			db.Data = NewDatabase("", 0)
+			db.Path = path
+			return nil
+		}
+		return err
+	}
+
+	err = json.Unmarshal(data, &db.Data)
+	if err != nil {
+		return err
+	}
+
+	if err := migrateState(&db.Data); err != nil {
+		return fmt.Errorf("migrating state %s: %w", path, err)
+	}
+
+	db.Path = path
+	return nil
+}
+
+func (db *DeploymentState) Finalize() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	// Generate lineage on first save
+	if db.Data.Lineage == "" {
+		db.Data.Lineage = uuid.New().String()
+	}
+
+	db.Data.Serial++
+
+	return db.unlockedSave()
+}
+
+func (db *DeploymentState) AssertOpened() {
+	if db.Path == "" {
+		panic("internal error: DeploymentState must be opened first")
+	}
+}
+
+func (db *DeploymentState) ExportState(ctx context.Context) resourcestate.ExportedResourcesMap {
+	result := make(resourcestate.ExportedResourcesMap)
+	for key, entry := range db.Data.State {
+		var etag string
+		// Extract etag for dashboards.
+		// covered by test case: bundle/deploy/dashboard/detect-change
+		if strings.Contains(key, ".dashboards.") && len(entry.State) > 0 {
+			var holder struct {
+				Etag string `json:"etag"`
+			}
+			if err := json.Unmarshal(entry.State, &holder); err == nil {
+				etag = holder.Etag
+			}
+		}
+
+		result[key] = resourcestate.ResourceState{
+			ID:   entry.ID,
+			ETag: etag,
+		}
+	}
+	return result
+}
+
+func (db *DeploymentState) unlockedSave() error {
+	db.AssertOpened()
+	data, err := json.MarshalIndent(db.Data, "", " ")
+	if err != nil {
+		return err
+	}
+
+	// Create parent directories if they don't exist
+	dir := filepath.Dir(db.Path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %#v: %w", dir, err)
+	}
+
+	err = os.WriteFile(db.Path, data, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to save resources state to %#v: %w", db.Path, err)
+	}
+
+	return nil
+}

--- a/ucm/direct/dstate/state_test.go
+++ b/ucm/direct/dstate/state_test.go
@@ -1,0 +1,53 @@
+package dstate
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenSaveFinalizeRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+
+	var db DeploymentState
+	require.NoError(t, db.Open(path))
+
+	require.NoError(t, db.SaveState("jobs.my_job", "123", map[string]string{"key": "val"}, nil))
+	require.NoError(t, db.Finalize())
+
+	// Re-open and verify persisted data.
+	var db2 DeploymentState
+	require.NoError(t, db2.Open(path))
+	assert.Equal(t, 1, db2.Data.Serial)
+	assert.Equal(t, "123", db2.GetResourceID("jobs.my_job"))
+}
+
+func TestPanicOnDoubleOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+
+	var db DeploymentState
+	require.NoError(t, db.Open(path))
+
+	assert.Panics(t, func() {
+		_ = db.Open(path)
+	})
+}
+
+func TestDeleteState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+
+	var db DeploymentState
+	require.NoError(t, db.Open(path))
+	require.NoError(t, db.SaveState("jobs.my_job", "123", map[string]string{}, nil))
+	require.NoError(t, db.Finalize())
+
+	require.NoError(t, db.DeleteState("jobs.my_job"))
+	require.NoError(t, db.Finalize())
+
+	var db2 DeploymentState
+	require.NoError(t, db2.Open(path))
+	assert.Equal(t, 2, db2.Data.Serial)
+	assert.Equal(t, "", db2.GetResourceID("jobs.my_job"))
+}

--- a/ucm/statemgmt/resourcestate/resourcestate.go
+++ b/ucm/statemgmt/resourcestate/resourcestate.go
@@ -1,0 +1,14 @@
+// This is in a separate package to avoid import cycles because it is imported by both terraform and statemgmt.
+package resourcestate
+
+// ResourceState stores relevant from terraform/direct state for one resoruce
+type ResourceState struct {
+	ID string
+
+	// For dashboards
+	ETag string
+}
+
+// ExportedResourcesMap stores relevant attributes from terraform/direct state for all resources
+// Maps resource key (e.g. "resources.jobs.foo", "resources.jobs.foo.permissions") -> ResourceState
+type ExportedResourcesMap map[string]ResourceState


### PR DESCRIPTION
Closes #127

## Summary
- Forks `bundle/direct/dstate/{state.go,migrate.go,state_test.go}` into `ucm/direct/dstate/` as a faithful 1:1 copy with import-only adaptations.
- Precursor: forks `bundle/statemgmt/resourcestate/resourcestate.go` (14 LOC) into `ucm/statemgmt/resourcestate/resourcestate.go`. Required because `dstate.ExportState` returns `resourcestate.ExportedResourcesMap` and UCM had no analog.
- Adapts imports: `bundle/deployplan`->`ucm/deployplan`, `bundle/statemgmt/resourcestate`->`ucm/statemgmt/resourcestate`, `bundle/direct/dresources`->`ucm/direct/dresources`. SDK + `internal/build` + `libs/structs/structpath` + `uuid` are shared, no change.

## Why
Sub-project E.1 of the UCM/Bundle alignment plan (#95). UCM's direct-engine paths reference these state types through `IsDirect()` stubs, but the package itself doesn't exist on the UCM side. Landing the fork now (mechanical, low-risk) lets E.2 (port of `bundle/direct/{apply,bundle_plan,bundle_apply,graph}.go`) be a straight copy/rename without dragging in package-creation noise. The dstate package is intentionally not yet called from `phases.*` — that's E.4's job.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...` — clean.
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...` — clean.
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test -count=1 ./cmd/ucm/... ./ucm/...` — all UCM unit tests pass, including the three round-trip tests (`TestOpenSaveFinalizeRoundTrip`, `TestPanicOnDoubleOpen`, `TestDeleteState`) on the new `ucm/direct/dstate/` package.
- [ ] `go test ./acceptance -run 'TestAccept/ucm' -count=1` — **pre-existing failure** in `TestAccept/ucm/import/happy/DATABRICKS_BUNDLE_ENGINE={direct,terraform}` reproduces on `main` at `a5e78e730` without these changes (likely fixture drift after PR #126). Unrelated to dstate; a separate fix-up issue should regenerate that fixture.

## Fork-divergence notes
- Edits to upstream files: none.
- New touchpoints outside `cmd/ucm/**`, `ucm/**`, `.claude/**`, `.github/workflows/upstream-sync.yml`: none.
- New UCM packages introduced by this PR: `ucm/direct/dstate/` (faithful fork) and `ucm/statemgmt/resourcestate/` (14-LOC precursor — option (a) per the design note, keeps E.1 self-contained and makes E.2 a straight port).

## Base branch
`main` — not stacked.

This pull request and its description were written by Isaac.