### PR TITLE
Feat #131: Fork ParseResourcesState into ucm/deploy/terraform

### DIFF
--- a/ucm/deploy/terraform/util.go
+++ b/ucm/deploy/terraform/util.go
@@ -1,0 +1,120 @@
+package terraform
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/statemgmt/resourcestate"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+type (
+	ResourceState        = resourcestate.ResourceState
+	ExportedResourcesMap = resourcestate.ExportedResourcesMap
+)
+
+// Partial representation of the Terraform state file format. Mirrors the
+// shape used by bundle/deploy/terraform's parser - only the global version,
+// resource type/name/mode and per-instance ID/Name/ETag are needed to
+// reconstruct the resource-key map consumed by direct-engine state.
+type resourcesState struct {
+	Version   int             `json:"version"`
+	Resources []stateResource `json:"resources"`
+}
+
+// SupportedStateVersion is the on-disk terraform state schema version this
+// parser understands. Mirrors bundle's constant of the same name; bumped in
+// lockstep when terraform changes its tfstate format.
+const SupportedStateVersion = 4
+
+type stateResource struct {
+	Type      string                  `json:"type"`
+	Name      string                  `json:"name"`
+	Mode      tfjson.ResourceMode     `json:"mode"`
+	Instances []stateResourceInstance `json:"instances"`
+}
+
+type stateResourceInstance struct {
+	Attributes stateInstanceAttributes `json:"attributes"`
+}
+
+type stateInstanceAttributes struct {
+	ID string `json:"id"`
+
+	// Some resources (e.g. apps) do not surface an ID in their tfstate
+	// attributes, so the resource name is used as the canonical handle when
+	// later reconciling against the workspace.
+	Name string `json:"name,omitempty"`
+	ETag string `json:"etag,omitempty"`
+}
+
+// parseResourcesState reads a terraform.tfstate JSON blob from disk and
+// returns a mapping of ucm resource keys (`resources.<group>.<name>`) to
+// the IDs that direct-engine state needs to take ownership of those
+// resources without re-creating them.
+//
+// A missing file is not an error - it returns (nil, nil) so callers can
+// treat "no prior state" the same as "no resources tracked".
+func parseResourcesState(ctx context.Context, path string) (ExportedResourcesMap, error) {
+	rawState, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var state resourcesState
+	err = json.Unmarshal(rawState, &state)
+	if err != nil {
+		return nil, err
+	}
+
+	if state.Version != SupportedStateVersion {
+		return nil, fmt.Errorf("unsupported deployment state version: %d. Try re-deploying the bundle", state.Version)
+	}
+
+	result := make(ExportedResourcesMap)
+
+	for _, resource := range state.Resources {
+		if resource.Mode != tfjson.ManagedResourceMode {
+			continue
+		}
+		for _, instance := range resource.Instances {
+			groupName, ok := terraformToGroupName[resource.Type]
+			if !ok {
+				log.Warnf(ctx, "Unknown Terraform resource type: %s", resource.Type)
+				continue
+			}
+
+			// ucm groups are flat (`resources.<group>.<name>`); sub-resource
+			// conventions like bundle's `secret_acls` / `permissions` /
+			// `dashboards` ETag don't apply to ucm's M0 resource set.
+			// Should ucm grow those resource types, mirror the bundle
+			// switch in bundle/deploy/terraform/util.go.
+			resourceKey := "resources." + groupName + "." + resource.Name
+			result[resourceKey] = ResourceState{ID: instance.Attributes.ID}
+		}
+	}
+
+	return result, nil
+}
+
+// ParseResourcesState reads the local terraform.tfstate for the current ucm
+// target and returns the resource-key -> ID map. Used by the migrate verb
+// to seed direct-engine state from a terraform-managed deployment.
+//
+// Errors if no target has been selected; returns (nil, nil) when there is
+// no local tfstate (e.g. before the first deploy).
+func ParseResourcesState(ctx context.Context, u *ucm.Ucm) (ExportedResourcesMap, error) {
+	workingDir, err := WorkingDir(u)
+	if err != nil {
+		return nil, err
+	}
+	return parseResourcesState(ctx, filepath.Join(workingDir, "terraform.tfstate"))
+}

--- a/ucm/deploy/terraform/util.go
+++ b/ucm/deploy/terraform/util.go
@@ -76,7 +76,7 @@ func parseResourcesState(ctx context.Context, path string) (ExportedResourcesMap
 	}
 
 	if state.Version != SupportedStateVersion {
-		return nil, fmt.Errorf("unsupported deployment state version: %d. Try re-deploying the bundle", state.Version)
+		return nil, fmt.Errorf("unsupported deployment state version: %d. Try re-running ucm deploy", state.Version)
 	}
 
 	result := make(ExportedResourcesMap)

--- a/ucm/deploy/terraform/util_test.go
+++ b/ucm/deploy/terraform/util_test.go
@@ -1,0 +1,163 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newParseUcm builds a minimal *ucm.Ucm whose WorkingDir resolves under a
+// temp dir, mirroring how the migrate verb will see a fresh project.
+func newParseUcm(t *testing.T) *ucm.Ucm {
+	t.Helper()
+	root := t.TempDir()
+	cfg := config.Root{}
+	cfg.Ucm.Name = "parse-test"
+	cfg.Ucm.Target = "dev"
+	return &ucm.Ucm{RootPath: root, Config: cfg}
+}
+
+func TestParseResourcesStateWithNoFile(t *testing.T) {
+	u := newParseUcm(t)
+	state, err := ParseResourcesState(t.Context(), u)
+	assert.NoError(t, err)
+	assert.Equal(t, ExportedResourcesMap(nil), state)
+}
+
+func TestParseResourcesStateWithExistingStateFile(t *testing.T) {
+	ctx := t.Context()
+	u := newParseUcm(t)
+	workingDir, err := WorkingDir(u)
+	require.NoError(t, err)
+
+	data := []byte(`{
+		"version": 4,
+		"unknown_field": "hello",
+		"resources": [
+		{
+			"mode": "managed",
+			"type": "databricks_catalog",
+			"name": "sales",
+			"provider": "provider[\"registry.terraform.io/databricks/databricks\"]",
+			"instances": [
+			  {
+				"schema_version": 0,
+				"attributes": {
+				  "id": "sales_prod",
+				  "name": "sales_prod",
+				  "comment": "sales data"
+				},
+				"sensitive_attributes": []
+			  }
+			]
+		  },
+		  {
+			"mode": "managed",
+			"type": "databricks_schema",
+			"name": "raw",
+			"instances": [{"attributes": {"id": "sales_prod.raw", "name": "raw"}}]
+		  }
+		]
+	}`)
+	localPath := filepath.Join(workingDir, "terraform.tfstate")
+	require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0o700))
+	require.NoError(t, os.WriteFile(localPath, data, 0o600))
+
+	state, err := parseResourcesState(ctx, localPath)
+	require.NoError(t, err)
+	expected := ExportedResourcesMap{
+		"resources.catalogs.sales": {ID: "sales_prod"},
+		"resources.schemas.raw":    {ID: "sales_prod.raw"},
+	}
+	assert.Equal(t, expected, state)
+}
+
+func TestParseResourcesStateSkipsDataSources(t *testing.T) {
+	ctx := t.Context()
+	data := []byte(`{
+		"version": 4,
+		"resources": [
+		{
+			"mode": "data",
+			"type": "databricks_catalog",
+			"name": "lookup",
+			"instances": [{"attributes": {"id": "ignored"}}]
+		},
+		{
+			"mode": "managed",
+			"type": "databricks_catalog",
+			"name": "sales",
+			"instances": [{"attributes": {"id": "sales_prod"}}]
+		}
+		]
+	}`)
+	path := filepath.Join(t.TempDir(), "state.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	state, err := parseResourcesState(ctx, path)
+	require.NoError(t, err)
+	assert.Equal(t, ExportedResourcesMap{
+		"resources.catalogs.sales": {ID: "sales_prod"},
+	}, state)
+}
+
+func TestParseResourcesStateSkipsUnknownTypes(t *testing.T) {
+	// Defensive: a tfstate carrying a type ucm doesn't model (e.g. an
+	// upstream-only databricks_job) is logged-and-skipped rather than
+	// hard-failing the migrate verb.
+	ctx := t.Context()
+	data := []byte(`{
+		"version": 4,
+		"resources": [
+		{
+			"mode": "managed",
+			"type": "databricks_job",
+			"name": "etl",
+			"instances": [{"attributes": {"id": "999"}}]
+		},
+		{
+			"mode": "managed",
+			"type": "databricks_catalog",
+			"name": "sales",
+			"instances": [{"attributes": {"id": "sales_prod"}}]
+		}
+		]
+	}`)
+	path := filepath.Join(t.TempDir(), "state.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	state, err := parseResourcesState(ctx, path)
+	require.NoError(t, err)
+	assert.Equal(t, ExportedResourcesMap{
+		"resources.catalogs.sales": {ID: "sales_prod"},
+	}, state)
+}
+
+func TestParseResourcesStateRejectsUnsupportedVersion(t *testing.T) {
+	ctx := t.Context()
+	data := []byte(`{
+		"version": 3,
+		"resources": []
+	}`)
+	path := filepath.Join(t.TempDir(), "state.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	state, err := parseResourcesState(ctx, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported deployment state version: 3")
+	assert.Nil(t, state)
+}
+
+func TestParseResourcesStateRejectsMalformedJSON(t *testing.T) {
+	ctx := t.Context()
+	path := filepath.Join(t.TempDir(), "state.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+	_, err := parseResourcesState(ctx, path)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Closes #131

## Summary
- Adds `ucm/deploy/terraform/util.go` with `ParseResourcesState(ctx, *ucm.Ucm)` and the private `parseResourcesState(ctx, path)` worker, plus the `resourcesState` / `stateResource` / `stateInstanceAttributes` shapes and `SupportedStateVersion = 4`.
- Adds `ucm/deploy/terraform/util_test.go` covering missing-file, happy-path, data-source skip, unknown-type skip, version mismatch, and malformed-JSON cases.

## Why
E.5's `migrate` verb needs to read a local `terraform.tfstate` to seed direct-engine state with the IDs of resources terraform already manages. Importing `bundle/deploy/terraform.ParseResourcesState` would drag `bundle/**` transitively into `ucm/` and break the fork-isolation rule in `cmd/ucm/CLAUDE.md`, so the helper is forked into ucm-owned territory.

The parser shape mirrors the bundle one verbatim (`resourcesState` / `stateResource` / `stateInstanceAttributes`, `SupportedStateVersion = 4`, missing-file returns `(nil, nil)`). The switch over `groupName` is collapsed to the default branch because ucm's M0 resource set has no `secret_acls` / `dashboards` / `permissions` / `apps` / `database_*` / `postgres_*`; the comment in `parseResourcesState` points future work back to `bundle/deploy/terraform/util.go` if those types land in ucm.

Routes through the existing `terraformToGroupName` map (defined in `showplan.go`) and `WorkingDir(u)` helper so the fork stays self-contained inside `ucm/deploy/terraform`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run 'TestAccept/ucm' -count=1`

## Fork-divergence notes
- Edits to upstream files: none
- New touchpoints outside `cmd/ucm/**`, `ucm/**`, `.claude/**`, `.github/workflows/upstream-sync.yml`: none
- Deviation from strict 1:1 fork: the multi-branch `switch groupName { ... }` from `bundle/deploy/terraform/util.go` is collapsed to its `default` arm because none of the bundle-only resource groups (`secret_*`, `apps`, `dashboards`, `permissions`, `database_*`, `postgres_*`) are in ucm's `terraformToGroupName` map. A code comment documents how to extend if those groups land later.

## Base branch
`main` — independent of the other E.* branches.