### PR TITLE
Feat #132: Implement phases.LogDeployTelemetry

### DIFF
--- a/cmd/ucm/utils/process.go
+++ b/cmd/ucm/utils/process.go
@@ -128,7 +128,6 @@ func ProcessUcm(cmd *cobra.Command, opts ProcessOptions) (*ucm.Ucm, error) {
 			if errMsg == "" && err != nil && !errors.Is(err, root.ErrAlreadyPrinted) {
 				errMsg = err.Error()
 			}
-			// TODO(#100): wire real LogDeployTelemetry; this is a no-op stub.
 			phases.LogDeployTelemetry(ctx, u, errMsg)
 		}()
 	}

--- a/ucm/phases/foundation_stubs.go
+++ b/ucm/phases/foundation_stubs.go
@@ -24,13 +24,3 @@ type LibLocationMap map[string]string
 func BuildArtifacts(_ context.Context, _ *ucm.Ucm) LibLocationMap {
 	return nil
 }
-
-// LogDeployTelemetry is a no-op stub for bundle.phases.LogDeployTelemetry.
-// Bundle's implementation records deploy outcome telemetry on every exit
-// path. UCM has no telemetry pipeline yet; the cmd/ucm/utils.ProcessUcm fork
-// (#98) defers this stub on Deploy=true so the function shape stays parallel
-// to bundle's ProcessBundleRet.
-//
-// Tracked in #100.
-func LogDeployTelemetry(_ context.Context, _ *ucm.Ucm, _ string) {
-}

--- a/ucm/phases/log_deploy_telemetry.go
+++ b/ucm/phases/log_deploy_telemetry.go
@@ -1,0 +1,121 @@
+package phases
+
+import (
+	"cmp"
+	"context"
+	"slices"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/telemetry"
+	"github.com/databricks/cli/libs/telemetry/protos"
+	"github.com/databricks/cli/ucm"
+)
+
+// ResourceIdLimit caps how many per-resource IDs we attach to a deploy
+// telemetry event. Mirrors bundle.phases.ResourceIdLimit; declared here
+// rather than imported so ucm/** carries no bundle/** dependency.
+//
+// No ucm resource kind currently emits IDs into the telemetry event (see
+// LogDeployTelemetry's package comment), so this constant is exported for
+// parity and future use rather than read in this file today.
+const ResourceIdLimit = 1000
+
+// maxErrorMessageLength caps the scrubbed error message attached to deploy
+// telemetry. Mirrors the same constant in bundle/phases/telemetry.go.
+const maxErrorMessageLength = 500
+
+// getExecutionTimes mirrors bundle/phases.getExecutionTimes: sort the
+// per-mutator execution times in descending order and keep the top 250
+// entries to keep the telemetry event size bounded regardless of how
+// many mutators ran.
+func getExecutionTimes(u *ucm.Ucm) []protos.IntMapEntry {
+	executionTimes := u.Metrics.ExecutionTimes
+
+	slices.SortFunc(executionTimes, func(a, b protos.IntMapEntry) int {
+		return cmp.Compare(b.Value, a.Value)
+	})
+
+	if len(executionTimes) > 250 {
+		executionTimes = executionTimes[:250]
+	}
+
+	return executionTimes
+}
+
+// LogDeployTelemetry logs a telemetry event for a ucm deploy command.
+//
+// Forked from bundle/phases.LogDeployTelemetry. The wire format reuses
+// protos.BundleDeployEvent — a dedicated UcmDeployEvent would require a
+// libs/telemetry/protos edit, which is owned by upstream and out of scope
+// here. ucm fills the proto fields that have ucm analogues and leaves
+// the rest at their zero values.
+//
+// UCM-specific deviations from the bundle implementation:
+//   - bundle.Bundle.Uuid: ucm has no top-level uuid; the event records
+//     the all-zero UUID as bundle does in the unset case.
+//   - bundle.Metrics.DeploymentId / ConfigurationFileCount / TargetCount /
+//     BoolValues / LocalCacheMeasurementsMs / Python* are zero — ucm
+//     does not collect those metrics today. They will populate naturally
+//     as the matching plumbing lands.
+//   - bundle.Workspace.ArtifactPath, bundle.Bundle.Mode, the python /
+//     experimental config blocks: no ucm equivalent, reported as
+//     "unspecified".
+//   - The proto's resource_*_ids slots are jobs / pipelines / clusters /
+//     dashboards — none of which are ucm resource kinds. Catalog,
+//     schema, volume, etc. names are PII (matching bundle's stance on
+//     schemas and volumes), so ucm emits no per-resource IDs into this
+//     event today; resource counts still reflect the declared
+//     configuration.
+func LogDeployTelemetry(ctx context.Context, u *ucm.Ucm, errMsg string) {
+	errMsg = scrubForTelemetry(errMsg)
+
+	if len(errMsg) > maxErrorMessageLength {
+		errMsg = errMsg[:maxErrorMessageLength]
+	}
+
+	resourcesCount := int64(0)
+	_, err := dyn.MapByPattern(u.Config.Value(), dyn.NewPattern(dyn.Key("resources"), dyn.AnyKey(), dyn.AnyKey()), func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+		resourcesCount++
+		return v, nil
+	})
+	if err != nil {
+		log.Debugf(ctx, "failed to count resources: %s", err)
+	}
+
+	resources := u.Config.Resources
+
+	variableCount := len(u.Config.Variables)
+	complexVariableCount := int64(0)
+	lookupVariableCount := int64(0)
+	for _, v := range u.Config.Variables {
+		// Resolved value drives complexity classification — the optional
+		// "type: complex" annotation can be omitted in ucm.yml.
+		if v.IsComplexValued() {
+			complexVariableCount++
+		}
+		if v.Lookup != nil {
+			lookupVariableCount++
+		}
+	}
+
+	telemetry.Log(ctx, protos.DatabricksCliLog{
+		BundleDeployEvent: &protos.BundleDeployEvent{
+			BundleUuid:   "00000000-0000-0000-0000-000000000000",
+			ErrorMessage: errMsg,
+
+			ResourceCount:       resourcesCount,
+			ResourceSchemaCount: int64(len(resources.Schemas)),
+			ResourceVolumeCount: int64(len(resources.Volumes)),
+
+			Experimental: &protos.BundleDeployExperimental{
+				BundleMode:                   protos.BundleModeUnspecified,
+				WorkspaceArtifactPathType:    protos.BundleDeployArtifactPathTypeUnspecified,
+				VariableCount:                int64(variableCount),
+				ComplexVariableCount:         complexVariableCount,
+				LookupVariableCount:          lookupVariableCount,
+				BundleMutatorExecutionTimeMs: getExecutionTimes(u),
+			},
+		},
+	})
+}

--- a/ucm/phases/log_deploy_telemetry_test.go
+++ b/ucm/phases/log_deploy_telemetry_test.go
@@ -1,0 +1,156 @@
+package phases_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/telemetry"
+	"github.com/databricks/cli/libs/telemetry/protos"
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/config/variable"
+	"github.com/databricks/cli/ucm/phases"
+	sdkconfig "github.com/databricks/databricks-sdk-go/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureEvent runs LogDeployTelemetry against an in-process testserver and
+// returns the BundleDeployEvent that ucm uploads. The logger's logs slice is
+// unexported, so a round-trip through Upload is the only inspection path.
+func captureEvent(t *testing.T, u *ucm.Ucm, errMsg string) *protos.BundleDeployEvent {
+	t.Helper()
+
+	server := testserver.New(t)
+	t.Cleanup(server.Close)
+
+	var captured []byte
+	server.Handle("POST", "/telemetry-ext", func(req testserver.Request) any {
+		captured = append([]byte(nil), req.Body...)
+		return map[string]any{
+			"errors":          []string{},
+			"numProtoSuccess": 1,
+		}
+	})
+
+	ctx := telemetry.WithNewLogger(t.Context())
+	phases.LogDeployTelemetry(ctx, u, errMsg)
+	ctx = cmdctx.SetConfigUsed(ctx, &sdkconfig.Config{Host: server.URL, Token: "token"})
+	require.NoError(t, telemetry.Upload(ctx, protos.ExecutionContext{}))
+
+	var body struct {
+		ProtoLogs []string `json:"protoLogs"`
+	}
+	require.NoError(t, json.Unmarshal(captured, &body))
+	require.Len(t, body.ProtoLogs, 1)
+
+	var fl protos.FrontendLog
+	require.NoError(t, json.Unmarshal([]byte(body.ProtoLogs[0]), &fl))
+	return fl.Entry.DatabricksCliLog.BundleDeployEvent
+}
+
+func TestLogDeployTelemetry_EmptyUcm(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte("ucm:\n  name: example\n"))
+	require.Empty(t, diags)
+	u := &ucm.Ucm{Config: *cfg}
+
+	ev := captureEvent(t, u, "")
+	require.NotNil(t, ev)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000000", ev.BundleUuid)
+	assert.Empty(t, ev.ErrorMessage)
+	assert.Equal(t, int64(0), ev.ResourceCount)
+	assert.Equal(t, int64(0), ev.ResourceSchemaCount)
+	assert.Equal(t, int64(0), ev.ResourceVolumeCount)
+	require.NotNil(t, ev.Experimental)
+	assert.Equal(t, protos.BundleModeUnspecified, ev.Experimental.BundleMode)
+	assert.Equal(t, protos.BundleDeployArtifactPathTypeUnspecified, ev.Experimental.WorkspaceArtifactPathType)
+}
+
+func TestLogDeployTelemetry_CountsResources(t *testing.T) {
+	cfg, diags := config.LoadFromBytes("/test/ucm.yml", []byte(`
+ucm:
+  name: example
+resources:
+  catalogs:
+    a: { name: a }
+    b: { name: b }
+  schemas:
+    s1: { name: s1, catalog_name: a }
+    s2: { name: s2, catalog_name: a }
+    s3: { name: s3, catalog_name: a }
+  volumes:
+    v1: { name: v1, catalog_name: a, schema_name: s1 }
+`))
+	require.Empty(t, diags)
+	u := &ucm.Ucm{Config: *cfg}
+
+	ev := captureEvent(t, u, "")
+	require.NotNil(t, ev)
+	// ResourceCount mirrors bundle's pattern walk: every resource under
+	// resources.<kind>.<name> is counted regardless of kind.
+	assert.Equal(t, int64(6), ev.ResourceCount)
+	assert.Equal(t, int64(3), ev.ResourceSchemaCount)
+	assert.Equal(t, int64(1), ev.ResourceVolumeCount)
+}
+
+func TestLogDeployTelemetry_ScrubsAndTruncatesErrorMessage(t *testing.T) {
+	u := &ucm.Ucm{Config: config.Root{}}
+
+	// Path scrubbing kicks in: the absolute path is replaced with a token.
+	ev := captureEvent(t, u, "failed to read /home/user/secrets/keyfile")
+	require.NotNil(t, ev)
+	assert.NotContains(t, ev.ErrorMessage, "/home/user/secrets")
+	assert.Contains(t, ev.ErrorMessage, "REDACTED")
+
+	// Truncation kicks in at 500 chars (post-scrub).
+	long := strings.Repeat("x", 1000)
+	ev = captureEvent(t, u, long)
+	require.NotNil(t, ev)
+	assert.Len(t, ev.ErrorMessage, 500)
+}
+
+func TestLogDeployTelemetry_VariableCounts(t *testing.T) {
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Variables: map[string]*variable.Variable{
+				"plain":   {Value: "v"},
+				"complex": {Value: map[string]any{"k": "v"}},
+				"lookup":  {Lookup: &variable.Lookup{}},
+			},
+		},
+	}
+
+	ev := captureEvent(t, u, "")
+	require.NotNil(t, ev)
+	require.NotNil(t, ev.Experimental)
+	assert.Equal(t, int64(3), ev.Experimental.VariableCount)
+	assert.Equal(t, int64(1), ev.Experimental.ComplexVariableCount)
+	assert.Equal(t, int64(1), ev.Experimental.LookupVariableCount)
+}
+
+func TestLogDeployTelemetry_CountsIncludeUndeployedResources(t *testing.T) {
+	// Counts reflect the declared configuration regardless of whether the
+	// resource carries a populated state ID — matches bundle's policy.
+	u := &ucm.Ucm{
+		Config: config.Root{
+			Resources: config.Resources{
+				Schemas: map[string]*resources.Schema{
+					"a": {ID: "deployed-id"},
+					"b": {ID: ""}, // not yet deployed
+				},
+				Volumes: map[string]*resources.Volume{
+					"v": {ID: ""},
+				},
+			},
+		},
+	}
+
+	ev := captureEvent(t, u, "")
+	require.NotNil(t, ev)
+	assert.Equal(t, int64(2), ev.ResourceSchemaCount)
+	assert.Equal(t, int64(1), ev.ResourceVolumeCount)
+}

--- a/ucm/phases/telemetry_scrub.go
+++ b/ucm/phases/telemetry_scrub.go
@@ -1,0 +1,160 @@
+package phases
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+// Scrub sensitive information from error messages before sending to
+// telemetry. Forked verbatim from bundle/phases/telemetry_scrub.go.
+//
+// Path regexes use [\s:,"'] as boundary characters to delimit where a path
+// ends. While these characters are technically valid in file paths, in
+// error messages they act as delimiters (e.g. "error: /path/to/file: not
+// found", or "failed to read '/some/path', skipping"). This is a practical
+// tradeoff: paths containing colons, commas, or quotes are extremely rare,
+// and without these boundaries the regexes would over-match into surrounding
+// message text.
+//
+// References:
+// - VS Code: https://github.com/microsoft/vscode/blob/main/src/vs/platform/telemetry/common/telemetryUtils.ts
+// - Sentry: https://github.com/getsentry/relay (PII rule: @userpath)
+var (
+	// Matches Windows absolute paths with backslashes and at least two
+	// components (e.g., C:\foo\bar, D:\Users\project).
+	windowsBackslashPathRegexp = regexp.MustCompile(`[A-Za-z]:\\[^\s:,"'/\\]+\\[^\s:,"']+`)
+
+	// Matches Windows absolute paths with forward slashes and at least two
+	// components (e.g., C:/foo/bar, D:/Users/project).
+	windowsFwdslashPathRegexp = regexp.MustCompile(`[A-Za-z]:/[^\s:,"'/\\]+/[^\s:,"']+`)
+
+	// Matches Databricks workspace paths (/Workspace/...).
+	workspacePathRegexp = regexp.MustCompile(`(^|[\s:,"'])(/Workspace/[^\s:,"']+)`)
+
+	// Matches absolute Unix paths with at least two components
+	// (e.g., /home/user/..., /tmp/foo, ~/.config/databricks).
+	absPathRegexp = regexp.MustCompile(`(^|[\s:,"'])(~?/[^\s:,"'/]+/[^\s:,"']+)`)
+
+	// Matches relative paths:
+	// - Explicit: ./foo, ../foo
+	// - Dot-prefixed directories: .databricks/bundle/..., .cache/foo
+	explicitRelPathRegexp = regexp.MustCompile(`(^|[\s:,"'])((?:\.\.?|\.[a-zA-Z][^\s:,"'/]*)/[^\s:,"']+)`)
+
+	// Matches implicit relative paths: at least two path components where
+	// the last component has a file extension (e.g., "resources/job.yml",
+	// "bundle/dev/state.json").
+	implicitRelPathRegexp = regexp.MustCompile(`(^|[\s:,"'])([a-zA-Z0-9_][^\s:,"']*/[^\s:,"']*\.[a-zA-Z][^\s:,"']*)`)
+
+	// Matches email addresses. Workspace paths in Databricks often contain
+	// emails (e.g., /Workspace/Users/user@example.com/.bundle/dev).
+	emailRegexp = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+)
+
+// Known file extensions that are safe to retain in redacted paths. These
+// help understand usage patterns without capturing sensitive information.
+var knownExtensions = map[string]bool{
+	// Configuration and data formats
+	".yml":        true,
+	".yaml":       true,
+	".json":       true,
+	".toml":       true,
+	".cfg":        true,
+	".ini":        true,
+	".env":        true,
+	".xml":        true,
+	".properties": true,
+	".conf":       true,
+
+	// Notebook and script languages
+	".py":    true,
+	".r":     true,
+	".scala": true,
+	".sql":   true,
+	".ipynb": true,
+	".sh":    true,
+
+	// Web / Apps
+	".js":   true,
+	".ts":   true,
+	".jsx":  true,
+	".tsx":  true,
+	".html": true,
+	".css":  true,
+
+	// Terraform
+	".tf":      true,
+	".hcl":     true,
+	".tfstate": true,
+	".tfvars":  true,
+
+	// Build artifacts and archives
+	".whl": true,
+	".jar": true,
+	".egg": true,
+	".zip": true,
+	".tar": true,
+	".gz":  true,
+	".tgz": true,
+	".dbc": true,
+
+	// Data formats
+	".txt":     true,
+	".csv":     true,
+	".md":      true,
+	".parquet": true,
+	".avro":    true,
+
+	// Logs and locks
+	".log":  true,
+	".lock": true,
+
+	// Certificates and keys
+	".pem": true,
+	".crt": true,
+}
+
+// scrubForTelemetry is a best-effort scrubber that removes sensitive path
+// and PII information from error messages before they are sent to
+// telemetry. The error message is treated as PII by the logging
+// infrastructure but we scrub to avoid collecting more information than
+// necessary.
+func scrubForTelemetry(msg string) string {
+	// Redact absolute paths.
+	msg = replacePathRegexp(msg, windowsBackslashPathRegexp, "[REDACTED_WIN_PATH]", false)
+	msg = replacePathRegexp(msg, windowsFwdslashPathRegexp, "[REDACTED_WIN_FPATH]", false)
+	msg = replacePathRegexp(msg, workspacePathRegexp, "[REDACTED_WORKSPACE_PATH]", true)
+	msg = replacePathRegexp(msg, absPathRegexp, "[REDACTED_PATH]", true)
+
+	// Redact relative paths.
+	msg = replacePathRegexp(msg, explicitRelPathRegexp, "[REDACTED_REL_PATH]", true)
+	msg = replacePathRegexp(msg, implicitRelPathRegexp, "[REDACTED_REL_PATH]", true)
+
+	// Redact email addresses.
+	msg = emailRegexp.ReplaceAllString(msg, "[REDACTED_EMAIL]")
+
+	return msg
+}
+
+// replacePathRegexp replaces path matches with the given label, retaining
+// known file extensions. When hasDelimiterGroup is true, the first
+// character of the match is preserved as a delimiter prefix.
+func replacePathRegexp(msg string, re *regexp.Regexp, label string, hasDelimiterGroup bool) string {
+	return re.ReplaceAllStringFunc(msg, func(match string) string {
+		prefix := ""
+		p := match
+		if hasDelimiterGroup && len(match) > 0 {
+			first := match[0]
+			if strings.ContainsRune(" \t\n:,\"'", rune(first)) {
+				prefix = match[:1]
+				p = match[1:]
+			}
+		}
+
+		ext := path.Ext(p)
+		if knownExtensions[ext] {
+			return prefix + label + "(" + ext[1:] + ")"
+		}
+		return prefix + label
+	})
+}


### PR DESCRIPTION
Closes #132
Closes #100

## Summary
- Forks `bundle/phases/telemetry.go` and `telemetry_scrub.go` into `ucm/phases/` as `log_deploy_telemetry.go` + `telemetry_scrub.go`, replacing the no-op `LogDeployTelemetry` stub from sub-project A. The proto wire format reuses `BundleDeployEvent` because `libs/telemetry/protos` is upstream-owned; ucm fills the fields it has analogues for and leaves bundle-only fields at their zero values, all documented in the package comment.
- Drops the `LogDeployTelemetry` no-op out of `ucm/phases/foundation_stubs.go` and clears the stale `TODO(#100)` next to the deferred call site in `cmd/ucm/utils/process.go`.
- Adds `ucm/phases/log_deploy_telemetry_test.go` covering empty-config emit, resource counts (UC pattern walk), error-message scrubbing + 500-char truncation, variable counts (plain / complex / lookup), and the bundle-style "counts include undeployed resources" rule. Tests round-trip the event through the in-process `testserver` since the telemetry logger's slice is unexported.

## Why
The defer inside `ProcessUcm` was already shaped to call `phases.LogDeployTelemetry` on every Deploy exit path, so ucm's verb plumbing carried the bundle-parity surface but emitted nothing. With this commit, every `ucm deploy` (success or failure) records the same observability proto DAB does, modulo bundle-specific fields that have no ucm analogue today.

## Test plan
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go vet ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `GOPROXY=direct GOTOOLCHAIN=local GOSUMDB=off go test ./acceptance -run 'TestAccept/ucm' -count=1`

## Fork-divergence notes
- Edits to upstream files: none. The single non-`ucm/**` edit is `cmd/ucm/utils/process.go` — only a stale `TODO(#100)` comment removal next to the existing defer.
- New touchpoints outside `cmd/ucm/**`, `ucm/**`, `.claude/**`, `.github/workflows/upstream-sync.yml`: none.

## UCM-specific telemetry-key adaptations
- Reuses `protos.BundleDeployEvent` rather than introducing a `UcmDeployEvent` (would require editing `libs/telemetry/protos`, owned by upstream).
- `BundleUuid` is hardcoded to the all-zero UUID — ucm has no top-level uuid field today, matching bundle's behavior when its uuid is unset.
- `DeploymentId`, `Experimental.ConfigurationFileCount`, `Experimental.TargetCount`, `Experimental.BoolValues`, `Experimental.LocalCacheMeasurementsMs`, `Experimental.Python*` are left at their zero values: ucm does not collect those metrics yet. They will populate naturally as the matching plumbing lands.
- `Experimental.BundleMode` is reported as `BundleModeUnspecified`; `Experimental.WorkspaceArtifactPathType` is reported as `BundleDeployArtifactPathTypeUnspecified`. ucm has neither concept (no `bundle.mode`, no artifact upload path).
- The proto's per-resource ID slots (`ResourceJobIDs` / `ResourcePipelineIDs` / `ResourceClusterIDs` / `ResourceDashboardIDs`) cover bundle resource kinds that ucm does not have. ucm's UC-native catalog/schema/volume names are PII (matching bundle's stance for schemas and volumes), so ucm emits no per-resource IDs into the event today; resource counts still reflect the declared configuration.

## Base branch
`main`. Independent of E.1/E.2/E.3/E.4/E.5; no stacking.