### PR TITLE
ucm: Add downgradeWarningToError to PreDeployChecks (E.6c)

### DIFF
--- a/cmd/ucm/utils/process.go
+++ b/cmd/ucm/utils/process.go
@@ -302,10 +302,8 @@ func ProcessUcm(cmd *cobra.Command, opts ProcessOptions) (*ucm.Ucm, error) {
 	}
 
 	if opts.PreDeployChecks {
-		// UCM's PreDeployChecks today takes only (ctx, u, EngineType) —
-		// the downgradeWarningToError toggle bundle exposes maps to the
-		// pre-deploy validator pack and will land with #102.
-		phases.PreDeployChecks(ctx, u, stateEngine.Type)
+		downgradeWarningToError := !opts.Deploy
+		phases.PreDeployChecks(ctx, u, downgradeWarningToError, stateEngine.Type)
 
 		if logdiag.HasError(ctx) {
 			return u, root.ErrAlreadyPrinted

--- a/ucm/phases/plan.go
+++ b/ucm/phases/plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
@@ -17,11 +18,16 @@ import (
 )
 
 // PreDeployChecks is common set of mutators between "ucm plan" and "ucm deploy".
-// Note, it is not run in "ucm migrate" so it must not modify the config
-func PreDeployChecks(ctx context.Context, u *ucm.Ucm, e engine.EngineType) {
+// Note, it is not run in "ucm migrate" so it must not modify the config.
+//
+// When downgradeWarningToError is true, any warning emitted by the validator
+// pack is promoted to an error. Mirrors bundle's PreDeployChecks contract:
+// the plan path passes true (warnings during planning should fail) while the
+// deploy path passes false (warnings during deploy are tolerated).
+func PreDeployChecks(ctx context.Context, u *ucm.Ucm, downgradeWarningToError bool, e engine.EngineType) {
 	ucm.ApplySeqContext(ctx, u,
-		mutator.ValidateDirectOnlyResources(e),
-		mutator.ValidateLifecycleStarted(e),
+		promoteWarningsIfRequested(mutator.ValidateDirectOnlyResources(e), downgradeWarningToError),
+		promoteWarningsIfRequested(mutator.ValidateLifecycleStarted(e), downgradeWarningToError),
 	)
 	if logdiag.HasError(ctx) {
 		return
@@ -30,8 +36,37 @@ func PreDeployChecks(ctx context.Context, u *ucm.Ucm, e engine.EngineType) {
 	// drift phase (ucm/phases/drift.go). Empty kinds today keeps this a no-op
 	// scaffold — concrete UC resource kinds get wired here in later tasks.
 	if !e.IsDirect() {
-		ucm.ApplyContext(ctx, u, terraform.CheckResourcesModifiedRemotely(nil))
+		ucm.ApplyContext(ctx, u, promoteWarningsIfRequested(terraform.CheckResourcesModifiedRemotely(nil), downgradeWarningToError))
 	}
+}
+
+// promoteWarningsIfRequested returns m unchanged when promote is false. When
+// promote is true it wraps m so warning-severity diagnostics are rewritten to
+// errors before being forwarded. This is how PreDeployChecks honours the
+// downgradeWarningToError contract without each validator needing a flag.
+func promoteWarningsIfRequested(m ucm.Mutator, promote bool) ucm.Mutator {
+	if !promote {
+		return m
+	}
+	return &warningPromoter{wrapped: m}
+}
+
+type warningPromoter struct {
+	wrapped ucm.Mutator
+}
+
+func (w *warningPromoter) Name() string {
+	return w.wrapped.Name()
+}
+
+func (w *warningPromoter) Apply(ctx context.Context, u *ucm.Ucm) diag.Diagnostics {
+	diags := w.wrapped.Apply(ctx, u)
+	for i := range diags {
+		if diags[i].Severity == diag.Warning {
+			diags[i].Severity = diag.Error
+		}
+	}
+	return diags
 }
 
 // Plan runs the initialize → build → engine-specific plan sequence and
@@ -53,7 +88,7 @@ func Plan(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
 		return nil
 	}
 
-	PreDeployChecks(ctx, u, setting.Type)
+	PreDeployChecks(ctx, u, true, setting.Type)
 	if logdiag.HasError(ctx) {
 		return nil
 	}

--- a/ucm/phases/plan_internal_test.go
+++ b/ucm/phases/plan_internal_test.go
@@ -1,0 +1,53 @@
+package phases
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/ucm"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeDiagMutator emits a fixed diagnostics slice; used to exercise the
+// warning→error promotion wrapper without depending on a real validator.
+type fakeDiagMutator struct {
+	diags diag.Diagnostics
+}
+
+func (f *fakeDiagMutator) Name() string { return "fakeDiagMutator" }
+
+func (f *fakeDiagMutator) Apply(_ context.Context, _ *ucm.Ucm) diag.Diagnostics {
+	return f.diags
+}
+
+func TestPromoteWarningsIfRequestedNoOpWhenDisabled(t *testing.T) {
+	inner := &fakeDiagMutator{diags: diag.Diagnostics{
+		{Severity: diag.Warning, Summary: "w"},
+		{Severity: diag.Error, Summary: "e"},
+		{Severity: diag.Recommendation, Summary: "r"},
+	}}
+
+	wrapped := promoteWarningsIfRequested(inner, false)
+
+	out := wrapped.Apply(t.Context(), nil)
+	assert.Equal(t, diag.Warning, out[0].Severity)
+	assert.Equal(t, diag.Error, out[1].Severity)
+	assert.Equal(t, diag.Recommendation, out[2].Severity)
+}
+
+func TestPromoteWarningsIfRequestedRewritesWarningSeverity(t *testing.T) {
+	inner := &fakeDiagMutator{diags: diag.Diagnostics{
+		{Severity: diag.Warning, Summary: "w"},
+		{Severity: diag.Error, Summary: "e"},
+		{Severity: diag.Recommendation, Summary: "r"},
+	}}
+
+	wrapped := promoteWarningsIfRequested(inner, true)
+	assert.Equal(t, inner.Name(), wrapped.Name(), "wrapper must preserve Name() for telemetry")
+
+	out := wrapped.Apply(t.Context(), nil)
+	assert.Equal(t, diag.Error, out[0].Severity, "warning must be promoted to error")
+	assert.Equal(t, diag.Error, out[1].Severity, "errors stay as errors")
+	assert.Equal(t, diag.Recommendation, out[2].Severity, "recommendations are not promoted")
+}

--- a/ucm/phases/plan_test.go
+++ b/ucm/phases/plan_test.go
@@ -73,7 +73,7 @@ func TestPreDeployChecksNoResourcesNoDiags(t *testing.T) {
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
-	phases.PreDeployChecks(ctx, f.u, engine.EngineTerraform)
+	phases.PreDeployChecks(ctx, f.u, false, engine.EngineTerraform)
 
 	assert.False(t, logdiag.HasError(ctx))
 }
@@ -88,7 +88,7 @@ func TestPreDeployChecksTerraformInvokesRemoteDriftScaffold(t *testing.T) {
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
-	phases.PreDeployChecks(ctx, f.u, engine.EngineTerraform)
+	phases.PreDeployChecks(ctx, f.u, false, engine.EngineTerraform)
 
 	require.False(t, logdiag.HasError(ctx))
 	assert.Empty(t, logdiag.FlushCollected(ctx))
@@ -99,7 +99,7 @@ func TestPreDeployChecksDirectEngineNoDiags(t *testing.T) {
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
-	phases.PreDeployChecks(ctx, f.u, engine.EngineDirect)
+	phases.PreDeployChecks(ctx, f.u, false, engine.EngineDirect)
 
 	assert.False(t, logdiag.HasError(ctx))
 }


### PR DESCRIPTION
## Summary

- Adds `downgradeWarningToError bool` to `ucm/phases.PreDeployChecks`, mirroring bundle's signature so the plan path can fail on warnings while deploy tolerates them.
- Promotion is implemented as a per-mutator wrapper that rewrites `diag.Warning` to `diag.Error` after the mutator returns, leaving today's error-only validators unchanged but covering any warning a future validator adds.
- Wires the new flag at both UCM call sites: `ucm.phases.Plan` passes `true` (warnings during planning should fail), and `cmd/ucm/utils.ProcessUcm` passes `!opts.Deploy` so the deploy path passes `false`.

Closes #102. Tracked as sub-project E.6c of the UCM ↔ Bundle alignment effort (#137).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run 'TestAccept/ucm' -count=1`
- [x] New unit tests cover both no-op (promote=false) and promotion (promote=true) paths.

This pull request and its description were written by Isaac.