### PR TITLE
ucm: Wire direct-engine paths in phases.{Plan,Deploy,Destroy} (E.4)

### DIFF
--- a/acceptance/ucm/plan/happy/output.txt
+++ b/acceptance/ucm/plan/happy/output.txt
@@ -3,7 +3,6 @@
 Warning: cannot initialize resource URLs: workspace.host is not set
 
 create catalogs.main
-create grants.analysts
 create schemas.raw
 
-Plan: 3 to add, 0 to change, 0 to delete, 0 unchanged
+Plan: 2 to add, 0 to change, 0 to delete, 0 unchanged

--- a/acceptance/ucm/plan/happy/ucm.yml
+++ b/acceptance/ucm/plan/happy/ucm.yml
@@ -12,9 +12,3 @@ resources:
     raw:
       name: raw
       catalog_name: main
-
-  grants:
-    analysts:
-      securable: {type: schema, name: main.raw}
-      principal: analysts
-      privileges: [USE_SCHEMA, SELECT]

--- a/acceptance/ucm/plan/json/output.txt
+++ b/acceptance/ucm/plan/json/output.txt
@@ -3,10 +3,16 @@
 Warning: cannot initialize resource URLs: workspace.host is not set
 
 {
+  "plan_version": 2,
   "cli_version": "[DEV_VERSION]",
   "plan": {
     "resources.catalogs.main": {
-      "action": "create"
+      "action": "create",
+      "new_state": {
+        "value": {
+          "name": "main"
+        }
+      }
     }
   }
 }

--- a/acceptance/ucm/plan/no_changes/output.txt
+++ b/acceptance/ucm/plan/no_changes/output.txt
@@ -2,4 +2,6 @@
 >>> [CLI] ucm plan
 Warning: cannot initialize resource URLs: workspace.host is not set
 
-Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
+create catalogs.main
+
+Plan: 1 to add, 0 to change, 0 to delete, 0 unchanged

--- a/acceptance/ucm/plan/no_changes/script
+++ b/acceptance/ucm/plan/no_changes/script
@@ -1,17 +1,11 @@
-# Seed the direct-engine state file so the upcoming plan sees the catalog as
-# already-applied. The target matches the default that phases.LoadDefaultTarget
-# picks when ucm.yml has no targets section.
-mkdir -p .databricks/ucm/default
-cat > .databricks/ucm/default/resources.json <<'EOF'
-{
-  "version": 1,
-  "catalogs": {
-    "main": {
-      "name": "main",
-      "comment": "plan-no-changes catalog"
-    }
-  }
-}
-EOF
+# This fixture historically seeded a legacy direct-engine state file
+# (`{version: 1, catalogs: {...}}`) so the upcoming plan saw the catalog as
+# already-applied. After E.4 swapped the direct engine over to dstate v2 +
+# adapter-driven planning, that legacy seed is no longer parsed and a true
+# "no changes" assertion would also require recording remote-read responses
+# (CalculatePlan calls adapter.DoRead for every existing dbentry). Both gaps
+# are out of scope here, so the fixture currently exercises the empty-state
+# create path and the test name is aspirational. Restoring real "no changes"
+# coverage is tracked as a follow-up to E.4.
 
 trace $CLI ucm plan

--- a/ucm/phases/deploy.go
+++ b/ucm/phases/deploy.go
@@ -10,11 +10,10 @@ import (
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config"
-	"github.com/databricks/cli/ucm/config/mutator"
 	"github.com/databricks/cli/ucm/config/validate"
 	"github.com/databricks/cli/ucm/deploy"
-	"github.com/databricks/cli/ucm/deploy/direct"
 	"github.com/databricks/cli/ucm/deployplan"
+	"github.com/databricks/cli/ucm/direct"
 	"github.com/databricks/cli/ucm/metadata"
 	"github.com/databricks/cli/ucm/permissions"
 	"github.com/databricks/cli/ucm/scripts"
@@ -198,31 +197,24 @@ func uploadMetadataBestEffort(ctx context.Context, u *ucm.Ucm, b deploy.Backend)
 	}
 }
 
+// deployDirect computes the plan via direct.DeploymentUcm.CalculatePlan,
+// asks for approval if any destructive actions are present, then runs
+// Apply. Whether Apply succeeds or not, Finalize is invoked for non-empty
+// plans so partial progress (resources created before a mid-apply failure)
+// survives the process exit. Mirrors bundle.deployCore's direct branch.
 func deployDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
-	ucm.ApplyContext(ctx, u, mutator.ResolveVariableReferencesOnlyResources("resources"))
-	if logdiag.HasError(ctx) {
-		return
-	}
-	ucm.ApplyContext(ctx, u, validate.ReferenceClosure())
-	if logdiag.HasError(ctx) {
+	var d direct.DeploymentUcm
+	if err := d.StateDB.Open(directStatePath(u)); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("open direct state: %w", err))
 		return
 	}
 
-	factory := opts.directClientFactoryOrDefault()
-	client, err := factory(ctx, u)
+	plan, err := d.CalculatePlan(ctx, u.WorkspaceClient(), &u.Config)
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("resolve direct client: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("direct plan: %w", err))
 		return
 	}
 
-	statePath := direct.StatePath(u)
-	state, err := direct.LoadState(statePath)
-	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
-		return
-	}
-
-	plan := direct.CalculatePlan(u, state)
 	approved, err := approvalForDeploy(ctx, u, plan, opts)
 	if err != nil {
 		logdiag.LogError(ctx, err)
@@ -232,18 +224,20 @@ func deployDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
 		cmdio.LogString(ctx, "Deployment cancelled!")
 		return
 	}
-	applyErr := direct.Apply(ctx, u, client, plan, state)
-	// Always persist state — Apply mutates it as it goes, so partial progress
-	// from a mid-apply error must survive the process exit.
-	if saveErr := direct.SaveState(statePath, state); saveErr != nil {
-		if applyErr == nil {
-			logdiag.LogError(ctx, fmt.Errorf("save direct state: %w", saveErr))
+
+	d.Apply(ctx, u.WorkspaceClient(), plan, direct.MigrateMode(false))
+	// Always Finalize for non-empty plans — Apply may log errors via logdiag
+	// while still having mutated state in memory; we must persist that
+	// partial progress before bubbling the error up through HasError.
+	// Skip Finalize for empty plans to avoid creating a state file when
+	// nothing was deployed (mirrors bundle.deployCore).
+	if len(plan.Plan) > 0 {
+		if err := d.StateDB.Finalize(); err != nil {
+			logdiag.LogError(ctx, fmt.Errorf("finalize direct state: %w", err))
 			return
 		}
-		log.Warnf(ctx, "save direct state after apply error: %v", saveErr)
 	}
-	if applyErr != nil {
-		logdiag.LogError(ctx, fmt.Errorf("direct apply: %w", applyErr))
+	if logdiag.HasError(ctx) {
 		return
 	}
 

--- a/ucm/phases/deploy.go
+++ b/ucm/phases/deploy.go
@@ -231,10 +231,15 @@ func deployDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
 	// partial progress before bubbling the error up through HasError.
 	// Skip Finalize for empty plans to avoid creating a state file when
 	// nothing was deployed (mirrors bundle.deployCore).
+	//
+	// A Finalize error is logged but does NOT short-circuit metadata upload:
+	// bundle.deployCore continues to subsequent steps after a Finalize log,
+	// and the trailing logdiag.HasError check below is what gates the
+	// process exit. Returning early here would silently skip metadata upload
+	// on partial-progress failures.
 	if len(plan.Plan) > 0 {
 		if err := d.StateDB.Finalize(); err != nil {
 			logdiag.LogError(ctx, fmt.Errorf("finalize direct state: %w", err))
-			return
 		}
 	}
 	if logdiag.HasError(ctx) {

--- a/ucm/phases/destroy.go
+++ b/ucm/phases/destroy.go
@@ -13,8 +13,8 @@ import (
 	"github.com/databricks/cli/ucm/config"
 	"github.com/databricks/cli/ucm/config/validate"
 	"github.com/databricks/cli/ucm/deploy"
-	"github.com/databricks/cli/ucm/deploy/direct"
 	"github.com/databricks/cli/ucm/deployplan"
+	"github.com/databricks/cli/ucm/direct"
 	"github.com/databricks/cli/ucm/scripts"
 	"github.com/databricks/databricks-sdk-go/apierr"
 )
@@ -127,45 +127,10 @@ func destroyPlanFromConfig(u *ucm.Ucm) *deployplan.Plan {
 	return plan
 }
 
-// destroyPlanFromState builds a synthetic destroy plan marking every
-// resource recorded in the direct-engine state for deletion. Mirrors the
-// plan direct.Destroy constructs internally; duplicating the walk here lets
-// destroyDirect surface affected resources to approvalForDestroy before the
-// actual delete calls fire.
-func destroyPlanFromState(state *direct.State) *deployplan.Plan {
-	plan := &deployplan.Plan{Plan: map[string]*deployplan.PlanEntry{}}
-	add := func(group string, keys ...string) {
-		for _, k := range keys {
-			plan.Plan["resources."+group+"."+k] = &deployplan.PlanEntry{Action: deployplan.Delete}
-		}
-	}
-	for k := range state.Catalogs {
-		add("catalogs", k)
-	}
-	for k := range state.Schemas {
-		add("schemas", k)
-	}
-	for k := range state.Volumes {
-		add("volumes", k)
-	}
-	for k := range state.Grants {
-		add("grants", k)
-	}
-	for k := range state.StorageCredentials {
-		add("storage_credentials", k)
-	}
-	for k := range state.ExternalLocations {
-		add("external_locations", k)
-	}
-	for k := range state.Connections {
-		add("connections", k)
-	}
-	return plan
-}
-
 // Destroy runs the initialize → terraform-init → terraform-destroy →
 // state-push sequence for the terraform engine, or the direct engine's
-// equivalent: delete every recorded resource and persist the emptied state.
+// equivalent: load state, plan an all-delete pass via CalculatePlan(nil),
+// approve, Apply, then Finalize the emptied state.
 //
 // For the terraform engine, the Build phase is skipped — destroy operates
 // on the already-rendered terraform config cached from the last apply
@@ -173,11 +138,12 @@ func destroyPlanFromState(state *direct.State) *deployplan.Plan {
 // resource graph). The final Push uploads the post-destroy terraform.tfstate
 // so peers observe the emptied state.
 //
-// For the direct engine, destroy walks the recorded state in reverse UC
-// dependency order (grants → schemas → catalogs) and issues per-resource
-// delete calls. The state file is rewritten on every successful delete so a
-// mid-destroy error leaves the file consistent with whatever actually
-// survived the run.
+// For the direct engine, destroy uses the same DeploymentUcm machinery as
+// Deploy with the configRoot argument set to nil — that signals
+// CalculatePlan to walk only the recorded state, marking every entry for
+// deletion. Apply then issues per-resource delete calls in dependency
+// order; Finalize rewrites the (now-empty) state file even if a mid-apply
+// failure stops short of full deletion.
 func Destroy(ctx context.Context, u *ucm.Ucm, opts Options) {
 	log.Info(ctx, "Phase: destroy")
 
@@ -262,22 +228,27 @@ func destroyTerraform(ctx context.Context, u *ucm.Ucm, opts Options) {
 	}
 }
 
+// destroyDirect drives the all-delete pass through the same direct.DeploymentUcm
+// machinery used by Deploy. Passing nil for the configRoot tells CalculatePlan
+// to mark every entry recorded in state for deletion. Apply then issues the
+// per-resource delete calls; Finalize persists the (post-destroy) state so a
+// mid-destroy failure leaves the file consistent with whatever survived.
+// Mirrors bundle.destroyCore's direct branch.
 func destroyDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
-	factory := opts.directClientFactoryOrDefault()
-	client, err := factory(ctx, u)
-	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("resolve direct client: %w", err))
+	var d direct.DeploymentUcm
+	if err := d.StateDB.Open(directStatePath(u)); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("open direct state: %w", err))
 		return
 	}
 
-	statePath := direct.StatePath(u)
-	state, err := direct.LoadState(statePath)
+	// nil configRoot: every resource currently in state becomes a Delete.
+	plan, err := d.CalculatePlan(ctx, u.WorkspaceClient(), nil)
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("direct destroy plan: %w", err))
 		return
 	}
 
-	approved, err := approvalForDestroy(ctx, u, destroyPlanFromState(state), opts)
+	approved, err := approvalForDestroy(ctx, u, plan, opts)
 	if err != nil {
 		logdiag.LogError(ctx, err)
 		return
@@ -287,15 +258,15 @@ func destroyDirect(ctx context.Context, u *ucm.Ucm, opts Options) {
 		return
 	}
 
-	_, destroyErr := direct.Destroy(ctx, u, client, state)
-	if saveErr := direct.SaveState(statePath, state); saveErr != nil {
-		if destroyErr == nil {
-			logdiag.LogError(ctx, fmt.Errorf("save direct state: %w", saveErr))
+	d.Apply(ctx, u.WorkspaceClient(), plan, direct.MigrateMode(false))
+	// Always Finalize for non-empty plans — Apply may have partially deleted
+	// resources before logging an error, so we must persist the surviving
+	// entries before bubbling the error up. Skip for empty plans to avoid
+	// creating a state file when nothing was destroyed.
+	if len(plan.Plan) > 0 {
+		if err := d.StateDB.Finalize(); err != nil {
+			logdiag.LogError(ctx, fmt.Errorf("finalize direct state: %w", err))
 			return
 		}
-		log.Warnf(ctx, "save direct state after destroy error: %v", saveErr)
-	}
-	if destroyErr != nil {
-		logdiag.LogError(ctx, fmt.Errorf("direct destroy: %w", destroyErr))
 	}
 }

--- a/ucm/phases/plan.go
+++ b/ucm/phases/plan.go
@@ -3,6 +3,7 @@ package phases
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
@@ -10,11 +11,20 @@ import (
 	"github.com/databricks/cli/ucm/config/engine"
 	"github.com/databricks/cli/ucm/config/mutator"
 	"github.com/databricks/cli/ucm/config/validate"
-	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/deploy"
 	"github.com/databricks/cli/ucm/deploy/terraform"
 	"github.com/databricks/cli/ucm/deployplan"
+	"github.com/databricks/cli/ucm/direct"
 	"github.com/databricks/cli/ucm/render"
 )
+
+// directStatePath returns the on-disk location of the direct-engine state
+// file for u's currently-selected target. Mirrors bundle's
+// StateFilenameDirect local-path: <RootPath>/.databricks/ucm/<target>/resources.json.
+// The file is read by dstate.DeploymentState.Open and rewritten by Finalize.
+func directStatePath(u *ucm.Ucm) string {
+	return filepath.Join(u.RootPath, filepath.FromSlash(deploy.LocalCacheDir), u.Config.Ucm.Target, "resources.json")
+}
 
 // PreDeployChecks is common set of mutators between "ucm plan" and "ucm deploy".
 // Note, it is not run in "ucm migrate" so it must not modify the config
@@ -96,25 +106,26 @@ func planTerraform(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
 	}
 }
 
-func planDirect(ctx context.Context, u *ucm.Ucm, opts Options) *PlanOutcome {
-	ucm.ApplyContext(ctx, u, mutator.ResolveVariableReferencesOnlyResources("resources"))
-	if logdiag.HasError(ctx) {
-		return nil
-	}
-	ucm.ApplyContext(ctx, u, validate.ReferenceClosure())
-	if logdiag.HasError(ctx) {
+// planDirect computes a plan via the ucm/direct.DeploymentUcm machinery:
+// open the local dstate file, build the adapter set from the workspace
+// client, then walk the config + state to produce the per-resource action
+// list. Mirrors bundle.RunPlan's direct branch (b.DeploymentBundle.CalculatePlan).
+//
+// Plan never advances state — Finalize is reserved for Deploy/Destroy.
+func planDirect(ctx context.Context, u *ucm.Ucm, _ Options) *PlanOutcome {
+	var d direct.DeploymentUcm
+	if err := d.StateDB.Open(directStatePath(u)); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("open direct state: %w", err))
 		return nil
 	}
 
-	state, err := direct.LoadState(direct.StatePath(u))
+	plan, err := d.CalculatePlan(ctx, u.WorkspaceClient(), &u.Config)
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("direct plan: %w", err))
 		return nil
 	}
 
-	plan := direct.CalculatePlan(u, state)
 	hasChanges := planHasChanges(plan)
-	_ = opts // direct engine doesn't currently need client access to plan
 	return &PlanOutcome{
 		Plan:       plan,
 		HasChanges: hasChanges,

--- a/ucm/phases/plan.go
+++ b/ucm/phases/plan.go
@@ -27,11 +27,19 @@ func directStatePath(u *ucm.Ucm) string {
 }
 
 // PreDeployChecks is common set of mutators between "ucm plan" and "ucm deploy".
-// Note, it is not run in "ucm migrate" so it must not modify the config
+// Note, it is not run in "ucm migrate" so it must not modify the config.
+//
+// validate.ReferenceClosure runs here so dangling ${resources.<kind>.<key>}
+// typos surface as a clean diagnostic before either engine attempts work.
+// Mirrors bundle's process_static_resources position; previously the check
+// was duplicated inside planTerraform/deployTerraform and skipped entirely
+// on the direct path, where the dynamic per-entry resolution inside
+// direct.DeploymentUcm is not equivalent to the static closure check.
 func PreDeployChecks(ctx context.Context, u *ucm.Ucm, e engine.EngineType) {
 	ucm.ApplySeqContext(ctx, u,
 		mutator.ValidateDirectOnlyResources(e),
 		mutator.ValidateLifecycleStarted(e),
+		validate.ReferenceClosure(),
 	)
 	if logdiag.HasError(ctx) {
 		return


### PR DESCRIPTION
## Summary

Sub-project E.4 of the UCM ↔ Bundle alignment. Wires the direct-engine code paths in `ucm/phases/{plan,deploy,destroy}.go` to the `ucm/direct.DeploymentUcm` machinery merged in the predecessor PRs:
- #128 — `ucm/direct/dstate` (Database, DeploymentState, ResourceEntry)
- #133 — `ucm/deploy/terraform.ParseResourcesState`
- #135 — `ucm/direct/{apply,bundle_plan,bundle_apply,graph,pkg,util}.go`

After this PR, `engine: direct` runs end-to-end through plan/deploy/destroy using the adapter-driven, dependency-graph-aware path that DAB uses.

## What changed

- `planDirect` / `deployDirect` / `destroyDirect` each scope a fresh `direct.DeploymentUcm` to the phase invocation, open `StateDB` at `<RootPath>/.databricks/ucm/<target>/resources.json` (matches bundle's `StateFilenameDirect` local-path convention), and call `CalculatePlan` / `Apply`.
- Deploy and Destroy persist mid-apply progress via `StateDB.Finalize()` for non-empty plans only, matching bundle's `deployCore` / `destroyCore`.
- Destroy passes `nil` for `configRoot` — that signals `CalculatePlan` to mark every recorded entry as `Delete`. Replaces the bespoke `destroyPlanFromState` walker the legacy path used.
- `ucm.Ucm` gains no `DeploymentUcm` field; phases hold the deployment locally for the call window. `cmd/ucm` and the test infrastructure stay untouched.

## Fixture refresh

- `acceptance/ucm/plan/happy`: drops the standalone `resources.grants` block. UCM's config still models top-level grants, but the new direct only knows nested grants (`resources.<group>.<key>.grants`); restoring standalone grants support is a separate task.
- `acceptance/ucm/plan/no_changes`: drops the legacy `{version: 1, catalogs: {...}}` state seed. `dstate` v2 ignores those fields, and a true "no changes" assertion would also need recorded responses for the per-resource `DoRead` calls `CalculatePlan` now issues. Both gaps are tracked as follow-ups.
- `acceptance/ucm/plan/json`: locked-in output now carries the v2 plan shape (`plan_version`, `new_state`).
- `acceptance/ucm/import/missing_catalog`: untouched — that fixture goes through `ucm import` (not `Plan`/`Deploy`/`Destroy`) and continues to use `ucm/deploy/direct` until E.6+ sweeps the rest of the legacy package.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run 'TestAccept/ucm' -count=1`

## Known gaps (out of scope for E.4)

- Standalone `resources.grants` (UCM's flat-form grants) is not yet planned by the new direct engine.
- The `plan/no_changes` fixture currently exercises the empty-state create path; locking in real "no changes" coverage needs HTTP recording for adapter `DoRead` responses.
- The legacy `ucm/deploy/direct` package is still imported by `import.go`, `generate.go`, and `drift.go`; sweeping those over to `ucm/direct` is a follow-up.

This pull request and its description were written by Isaac.