### PR TITLE
ucm: BuildArtifacts is a permanent no-op (close #101)

### DIFF
--- a/cmd/ucm/utils/process.go
+++ b/cmd/ucm/utils/process.go
@@ -287,9 +287,8 @@ func ProcessUcm(cmd *cobra.Command, opts ProcessOptions) (*ucm.Ucm, error) {
 
 	if opts.Build {
 		t2 := time.Now()
-		// TODO(#101): wire real artifact build; ucm has no artifacts today.
 		// libs is the LibLocationMap bundle threads into phases.Deploy; ucm
-		// has no library concept yet so we discard it.
+		// has no library concept (UC objects are metadata) so we discard it.
 		_ = phases.BuildArtifacts(ctx, u)
 		u.Metrics.ExecutionTimes = append(u.Metrics.ExecutionTimes, protos.IntMapEntry{
 			Key:   "phases.Build",

--- a/ucm/phases/foundation_stubs.go
+++ b/ucm/phases/foundation_stubs.go
@@ -9,18 +9,21 @@ import (
 // LibLocationMap mirrors bundle/phases.LibLocationMap. Maps a library
 // reference (path or coordinate) to its uploaded location.
 //
-// UCM does not yet have an artifact/library concept, so the type ships as a
-// placeholder used only to keep the cmd/ucm/utils.ProcessUcm fork (#98)
-// shape-aligned with bundle. Tracked in #101.
+// UCM resources are pure Unity Catalog metadata (catalogs, schemas, volumes,
+// external locations, storage credentials, connections, grants, tag
+// validation rules) — none of which carry uploaded artifacts. The type is
+// retained as a permanent no-op shape-aligner for the cmd/ucm/utils.ProcessUcm
+// fork (#98), not as a placeholder for future implementation.
 type LibLocationMap map[string]string
 
-// BuildArtifacts is a no-op stub for the bundle.phases.Build artifact-walk
-// step. Bundle's Build returns a LibLocationMap describing every uploaded
-// library; UCM has no artifact tree today and returns nil.
+// BuildArtifacts is a permanent no-op. Bundle's phases.Build walks
+// jobs/pipelines/etc. for libraries and uploads them; UCM has no
+// artifact-bearing resource type and doesn't intend to gain one — UC
+// objects are metadata. The function is retained so cmd/ucm/utils.ProcessUcm
+// can call it under opts.Build without divergence from bundle's flow shape.
 //
-// Tracked in #101 — replace with a real implementation when ucm gains
-// artifacts. Named BuildArtifacts (not Build) to avoid colliding with the
-// existing terraform-render phase Build(ctx, u, opts).
+// Named BuildArtifacts (not Build) to avoid colliding with the existing
+// terraform-render phase Build(ctx, u, opts).
 func BuildArtifacts(_ context.Context, _ *ucm.Ucm) LibLocationMap {
 	return nil
 }


### PR DESCRIPTION
Closes #101

## Summary

Sub-project E.6b. Documents that `ucm/phases.BuildArtifacts` is a permanent no-op for UCM, not a placeholder for future implementation.

## Why

UCM resources are pure Unity Catalog metadata (catalogs, schemas, volumes, external locations, storage credentials, connections, grants, tag validation rules). None carry uploaded artifacts the way bundle's jobs/pipelines/wheels/notebooks do, and there's no plan to grow such resource types — UC objects are metadata.

The function is retained so `cmd/ucm/utils.ProcessUcm` can keep its `opts.Build` block shape-aligned with bundle's `phases.Build` flow (execution-time telemetry parity). It returns `nil` and that is the final answer.

## What changed

- `ucm/phases/foundation_stubs.go` — doc comments on `LibLocationMap` and `BuildArtifacts` rewritten to reflect "permanent no-op shape-aligner" intent rather than "future implementation."
- `cmd/ucm/utils/process.go` — `TODO(#101)` removed; inline comment dropped "yet" phrasing.

No code-path changes; this PR is doc-only.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run 'TestAccept/ucm' -count=1`

This pull request and its description were written by Isaac.