### PR TITLE
ucm: Acceptance EnvMatrix uses DATABRICKS_UCM_ENGINE (close #124)

### DIFF
--- a/acceptance/ucm/drift/happy/out.test.toml
+++ b/acceptance/ucm/drift/happy/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/import/missing_catalog/out.test.toml
+++ b/acceptance/ucm/import/missing_catalog/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/plan/connection/out.test.toml
+++ b/acceptance/ucm/plan/connection/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/plan/external_location/out.test.toml
+++ b/acceptance/ucm/plan/external_location/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/plan/happy/out.test.toml
+++ b/acceptance/ucm/plan/happy/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/plan/json/out.test.toml
+++ b/acceptance/ucm/plan/json/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/plan/no_changes/out.test.toml
+++ b/acceptance/ucm/plan/no_changes/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/plan/storage_credential/out.test.toml
+++ b/acceptance/ucm/plan/storage_credential/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/plan/volume/out.test.toml
+++ b/acceptance/ucm/plan/volume/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/policy-check/happy/out.test.toml
+++ b/acceptance/ucm/policy-check/happy/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/refschema/out.test.toml
+++ b/acceptance/ucm/refschema/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/schema/out.test.toml
+++ b/acceptance/ucm/schema/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/summary/happy/out.test.toml
+++ b/acceptance/ucm/summary/happy/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]

--- a/acceptance/ucm/test.toml
+++ b/acceptance/ucm/test.toml
@@ -1,0 +1,8 @@
+# UCM reads DATABRICKS_UCM_ENGINE, not DATABRICKS_BUNDLE_ENGINE — override the
+# matrix inherited from acceptance/test.toml so UCM fixtures actually exercise
+# both engines instead of running the same code path twice. Setting an empty
+# list drops the inherited key from the matrix per acceptance/internal/config.go.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+EnvMatrix.DATABRICKS_UCM_ENGINE = ["terraform", "direct"]
+EnvRepl.DATABRICKS_UCM_ENGINE = false
+EnvVaryOutput = "DATABRICKS_UCM_ENGINE"

--- a/acceptance/ucm/validate/happy/out.test.toml
+++ b/acceptance/ucm/validate/happy/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = ["terraform", "direct"]


### PR DESCRIPTION
Closes #124

## Summary
- Add `acceptance/ucm/test.toml` to clear the inherited `DATABRICKS_BUNDLE_ENGINE` matrix and set `DATABRICKS_UCM_ENGINE = ["terraform", "direct"]` (the env var UCM actually reads).
- Set `EnvVaryOutput = "DATABRICKS_UCM_ENGINE"` so per-engine output files are picked up automatically (parity with `acceptance/bundle/test.toml`).
- Regenerate UCM acceptance outputs with `-update`.

## Why
UCM fixtures ran the matrix twice but both variants exercised the same code path because UCM ignores `DATABRICKS_BUNDLE_ENGINE`. Now the matrix actually flips between `terraform` and `direct` engines.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`