### PR TITLE
ucm: Tag terraform UA with ucm/deploy (close #89)

### DIFF
--- a/ucm/deploy/terraform/env.go
+++ b/ucm/deploy/terraform/env.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/databricks/cli/internal/build"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/ucm"
@@ -155,6 +156,27 @@ func setProxyEnvVars(ctx context.Context, environ map[string]string) error {
 				environ[strings.ToUpper(v)] = val
 			}
 		}
+	}
+	return nil
+}
+
+// setUserAgentExtraEnvVar tags the terraform-provider subprocess so that
+// SDK-side telemetry can attribute UCM-originated traffic. Mirrors
+// bundle/deploy/terraform/init.go's setUserAgentExtraEnvVar — UCM keeps the
+// function shape parallel to ease a future libs/tfenv lift.
+//
+// The "ucm/deploy" suffix distinguishes UCM-originated calls from DAB's,
+// which advertise "cli/<version>" only (plus "databricks-pydabs/<v>" when
+// the bundle has Python). UCM has no pydabs equivalent, so the product
+// list is fixed.
+func setUserAgentExtraEnvVar(environ map[string]string, _ *ucm.Ucm) error {
+	products := []string{
+		"cli/" + build.GetInfo().Version,
+		"ucm/deploy",
+	}
+	userAgentExtra := strings.Join(products, " ")
+	if userAgentExtra != "" {
+		environ["DATABRICKS_USER_AGENT_EXTRA"] = userAgentExtra
 	}
 	return nil
 }

--- a/ucm/deploy/terraform/env_test.go
+++ b/ucm/deploy/terraform/env_test.go
@@ -6,7 +6,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/databricks/cli/internal/build"
 	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/ucm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -250,6 +252,13 @@ func TestSetProxyEnvVarsOmitsUnset(t *testing.T) {
 		_, ok := out[k]
 		assert.False(t, ok, "%s should not be set when neither case is on env", k)
 	}
+}
+
+func TestSetUserAgentExtraEnvVar(t *testing.T) {
+	out := map[string]string{}
+	require.NoError(t, setUserAgentExtraEnvVar(out, &ucm.Ucm{}))
+
+	assert.Equal(t, "cli/"+build.GetInfo().Version+" ucm/deploy", out["DATABRICKS_USER_AGENT_EXTRA"])
 }
 
 func TestResolveDatabricksCliPathLeavesAbsoluteUnchanged(t *testing.T) {

--- a/ucm/deploy/terraform/terraform.go
+++ b/ucm/deploy/terraform/terraform.go
@@ -179,7 +179,9 @@ func resolveAuthConfig(u *ucm.Ucm) (*config.Config, error) {
 //  3. setTempDirEnvVars sets TMP/TEMP/TMPDIR, falling back to
 //     localStateDir("tmp") on Windows to dodge MAX_PATH.
 //  4. setProxyEnvVars forwards HTTP_PROXY / HTTPS_PROXY / NO_PROXY.
-//  5. resolveDatabricksCliPath absolute-izes DATABRICKS_CLI_PATH so the
+//  5. setUserAgentExtraEnvVar sets DATABRICKS_USER_AGENT_EXTRA so SDK
+//     telemetry can attribute UCM-originated terraform-provider calls.
+//  6. resolveDatabricksCliPath absolute-izes DATABRICKS_CLI_PATH so the
 //     terraform subprocess can find the parent CLI from .databricks/ucm/...
 //
 // Cloud-cred env vars (AWS/Azure/GCP) are intentionally NOT forwarded
@@ -201,6 +203,9 @@ func buildEnv(ctx context.Context, u *ucm.Ucm, authCfg *config.Config) (map[stri
 		return nil, err
 	}
 	if err := setProxyEnvVars(ctx, out); err != nil {
+		return nil, err
+	}
+	if err := setUserAgentExtraEnvVar(out, u); err != nil {
 		return nil, err
 	}
 

--- a/ucm/deploy/terraform/terraform_test.go
+++ b/ucm/deploy/terraform/terraform_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/databricks/cli/internal/build"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
@@ -79,6 +80,18 @@ func TestBuildEnvMapsProxyVarsUppercase(t *testing.T) {
 
 	assert.Equal(t, "http://proxy.example:3128", got["HTTP_PROXY"])
 	assert.Equal(t, "http://proxy.example:3129", got["HTTPS_PROXY"])
+}
+
+// TestBuildEnvSetsUserAgentExtra verifies setUserAgentExtraEnvVar is wired
+// into buildEnv so SDK telemetry can attribute UCM-originated terraform
+// traffic.
+func TestBuildEnvSetsUserAgentExtra(t *testing.T) {
+	u, _ := newRenderUcm(t)
+
+	got, err := buildEnv(t.Context(), u, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "cli/"+build.GetInfo().Version+" ucm/deploy", got["DATABRICKS_USER_AGENT_EXTRA"])
 }
 
 // TestBuildEnvResolvedAuthOverridesPassthrough pins the DAB ordering:


### PR DESCRIPTION
Closes #89

## Summary
- Add `setUserAgentExtraEnvVar` in `ucm/deploy/terraform/env.go` that mirrors `bundle/deploy/terraform/init.go`'s helper.
- Wire it into `buildEnv` after `setProxyEnvVars`, matching DAB's ordering.
- Tag the UA as `cli/<version> ucm/deploy` so telemetry can distinguish UCM-originated terraform calls from DAB-originated ones.
- Unit tests: helper-level + `buildEnv` end-to-end.

## Why
Without `DATABRICKS_USER_AGENT_EXTRA`, UCM-originated terraform-provider traffic appears in SDK telemetry as generic `cli/<version>` and is indistinguishable from DAB. This blocks attribution and per-product adoption metrics.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`