### PR TITLE
ucm: Direct-engine unit tests for non-empty plan path (close #143)

### DIFF
--- a/ucm/phases/deploy_test.go
+++ b/ucm/phases/deploy_test.go
@@ -3,6 +3,7 @@ package phases_test
 import (
 	"encoding/json"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -126,6 +127,42 @@ func TestDeployDirectEngineSkipsTerraform(t *testing.T) {
 	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, 0, f.tf.ApplyCalls)
 	assert.Equal(t, -1, readRemoteSeq(t, f), "direct engine must never touch remote state")
+}
+
+// TestDeployDirectEngineCallsApply exercises the direct-engine call sequence
+// end-to-end: dstate.Database.Open against DirectStatePath(u), CalculatePlan
+// with one resource, Apply (which fires Catalogs.Create on the SDK), and
+// Finalize (which writes the state file). Asserting on the post-deploy state
+// file's existence is the only unit-test-friendly proxy for "Finalize ran";
+// asserting on Catalogs.Create is the proxy for "Apply ran". Together they
+// pin the wiring the empty-config short-circuit cannot reach.
+func TestDeployDirectEngineCallsApply(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"main": {CreateCatalog: catalog.CreateCatalog{Name: "main"}},
+	}
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		Create(mock.Anything, mock.MatchedBy(func(c catalog.CreateCatalog) bool { return c.Name == "main" })).
+		Return(&catalog.CatalogInfo{Name: "main"}, nil)
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Deploy(ctx, f.u, phases.Options{
+		TerraformFactory:    fakeTfFactory(f.tf),
+		DirectClientFactory: fakeDirectClientFactory(),
+	})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	assert.Equal(t, 0, f.tf.ApplyCalls, "direct engine must not invoke terraform Apply")
+	// Finalize wrote the state file at DirectStatePath(u).
+	statePath := phases.DirectStatePath(f.u)
+	info, err := os.Stat(statePath)
+	require.NoError(t, err, "direct state file must exist after Finalize: %s", statePath)
+	assert.Greater(t, info.Size(), int64(0), "direct state file must be non-empty after Finalize")
+	// Direct engine never touches remote terraform-state storage.
+	assert.Equal(t, -1, readRemoteSeq(t, f), "direct engine must never push remote state")
 }
 
 func TestDeployBailsOnApplyError(t *testing.T) {

--- a/ucm/phases/destroy_test.go
+++ b/ucm/phases/destroy_test.go
@@ -4,12 +4,14 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm/config/engine"
 	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/direct/dstate"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
@@ -17,6 +19,19 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// seedDirectStateCatalog writes a direct-engine state file at
+// DirectStatePath(u) with a single catalog entry. Mirrors the on-disk shape
+// produced by ucm/direct.DeploymentUcm.Apply on a successful create so destroy
+// tests can drive CalculatePlan(nil) down its delete branch without first
+// running a deploy.
+func seedDirectStateCatalog(t *testing.T, statePath, catalogName string) {
+	t.Helper()
+	var db dstate.DeploymentState
+	require.NoError(t, db.Open(statePath))
+	require.NoError(t, db.SaveState("resources.catalogs."+catalogName, catalogName, &catalog.CreateCatalog{Name: catalogName}, nil))
+	require.NoError(t, db.Finalize())
+}
 
 func TestDestroyHappyPath(t *testing.T) {
 	f := newFixture(t)
@@ -54,6 +69,48 @@ func TestDestroyDirectEngineSkipsTerraform(t *testing.T) {
 
 	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, 0, f.tf.DestroyCalls)
+}
+
+// TestDestroyDirectEngineDeletesResources exercises the direct-engine destroy
+// call sequence end-to-end: a pre-seeded state file is opened by
+// dstate.Database.Open at DirectStatePath(u), CalculatePlan(nil) marks the
+// recorded catalog for Delete, Apply fires Catalogs.Delete on the SDK, and
+// Finalize rewrites the (now-empty) state file. Together they pin the wiring
+// the empty-config short-circuit cannot reach.
+func TestDestroyDirectEngineDeletesResources(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	statePath := phases.DirectStatePath(f.u)
+	seedDirectStateCatalog(t, statePath, "main")
+
+	// CalculatePlan re-reads the remote state for every Delete entry to
+	// detect resources that vanished out-of-band; we mirror the live entry.
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "main").
+		Return(&catalog.CatalogInfo{Name: "main"}, nil)
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		Delete(mock.Anything, mock.MatchedBy(func(r catalog.DeleteCatalogRequest) bool { return r.Name == "main" })).
+		Return(nil)
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+	ctx, _ = cmdio.NewTestContextWithStderr(ctx)
+
+	phases.Destroy(ctx, f.u, phases.Options{
+		TerraformFactory:    fakeTfFactory(f.tf),
+		DirectClientFactory: fakeDirectClientFactory(),
+		AutoApprove:         true,
+	})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	assert.Equal(t, 0, f.tf.DestroyCalls, "direct engine must not invoke terraform Destroy")
+	// Finalize rewrote the state file with the catalog entry removed.
+	var db dstate.DeploymentState
+	require.NoError(t, db.Open(statePath))
+	assert.Empty(t, db.Data.State, "state file must be empty after destroy Finalize")
+	// Direct engine never touches remote terraform-state storage.
+	_, err := os.Stat(statePath)
+	require.NoError(t, err)
 }
 
 func TestDestroyBailsOnDestroyError(t *testing.T) {

--- a/ucm/phases/plan_test.go
+++ b/ucm/phases/plan_test.go
@@ -1,12 +1,16 @@
 package phases_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm/config/engine"
+	"github.com/databricks/cli/ucm/config/resources"
 	"github.com/databricks/cli/ucm/deploy/terraform"
+	"github.com/databricks/cli/ucm/deployplan"
 	"github.com/databricks/cli/ucm/phases"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,6 +70,38 @@ func TestPlanDirectEngineReturnsEmptyOutcome(t *testing.T) {
 	assert.Equal(t, 0, f.tf.RenderCalls)
 	assert.Equal(t, 0, f.tf.InitCalls)
 	assert.Equal(t, 0, f.tf.PlanCalls)
+}
+
+// TestPlanDirectEngineNonEmptyPlan exercises the direct-engine call sequence
+// end-to-end with a single catalog resource: dstate.Database.Open is invoked
+// against DirectStatePath(u), CalculatePlan walks the configRoot, sees no
+// existing state entry, and emits a Create action. This catches regressions
+// in the wiring between phases.planDirect and ucm/direct.DeploymentUcm that
+// the empty-config short-circuit cannot reach.
+func TestPlanDirectEngineNonEmptyPlan(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"main": {CreateCatalog: catalog.CreateCatalog{Name: "main"}},
+	}
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	result := phases.Plan(ctx, f.u, phases.Options{
+		TerraformFactory:    fakeTfFactory(f.tf),
+		DirectClientFactory: fakeDirectClientFactory(),
+	})
+
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	require.NotNil(t, result)
+	require.NotNil(t, result.Plan)
+	entry, ok := result.Plan.Plan["resources.catalogs.main"]
+	require.True(t, ok, "plan missing entry for resources.catalogs.main; have: %v", result.Plan.Plan)
+	assert.Equal(t, deployplan.Create, entry.Action)
+	assert.True(t, result.HasChanges)
+	// Plan never advances state — the local state file must NOT be written.
+	_, statErr := os.Stat(phases.DirectStatePath(f.u))
+	assert.True(t, os.IsNotExist(statErr), "Plan must not Finalize: %v", statErr)
 }
 
 func TestPreDeployChecksNoResourcesNoDiags(t *testing.T) {


### PR DESCRIPTION
Closes #143

## Summary
- Add unit tests covering `phases.{Plan,Deploy,Destroy}` non-empty plan path through `ucm/direct.DeploymentUcm`.
- Tests assert the call sequence `directStatePath` -> `dstate.Database.Open` -> `CalculatePlan` -> `Apply` -> `Finalize` executes with at least one resource.

## Why
Existing direct-engine tests only cover the empty-config short-circuit. After #139 wired plan/deploy/destroy onto `ucm/direct`, no unit test covers the actual machinery — regressions only surface in acceptance.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`