### PR TITLE
ucm: Cover migrate's missing-tfstate and existing-direct-state guards (close #147)

### DIFF
--- a/cmd/ucm/deployment/migrate.go
+++ b/cmd/ucm/deployment/migrate.go
@@ -150,6 +150,37 @@ func getCommonArgs(cmd *cobra.Command) ([]string, string) {
 	return args, argsStr
 }
 
+// checkLocalTerraformStatePresent returns nil when terraform.tfstate exists at
+// path. If the file is absent it logs the user-facing guidance and returns
+// root.ErrAlreadyPrinted so the caller surfaces the printed message verbatim.
+// Any other stat error is wrapped.
+func checkLocalTerraformStatePresent(ctx context.Context, path string) error {
+	_, err := os.Stat(path)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		cmdio.LogString(ctx, `Error: This command migrates the existing Terraform state file (terraform.tfstate) to a direct deployment state file (resources.json). However, no existing local state was found.
+
+To start using direct engine, set "engine: direct" under ucm in your ucm.yml or deploy with DATABRICKS_UCM_ENGINE=direct env var set.`)
+		return root.ErrAlreadyPrinted
+	}
+	return fmt.Errorf("reading %s: %w", path, err)
+}
+
+// checkDirectStateAbsent fails when either the in-progress temp state file or
+// the final direct state file already exists. The temp file means a previous
+// migration was interrupted; the final file means migration already ran.
+func checkDirectStateAbsent(localPath, tempStatePath string) error {
+	if _, err := os.Stat(tempStatePath); err == nil {
+		return fmt.Errorf("temporary state file %s already exists, another migration is in progress or was interrupted. In the latter case, delete the file", tempStatePath)
+	}
+	if _, err := os.Stat(localPath); err == nil {
+		return fmt.Errorf("state file %s already exists", localPath)
+	}
+	return nil
+}
+
 // newMigrateCommand returns `databricks ucm deployment migrate`.
 //
 // Migrates a ucm project from the terraform engine to the direct engine by
@@ -209,14 +240,8 @@ to the workspace so that subsequent deploys of this project use direct deploymen
 		// reads via state pull. The direct state file is fresh (we error if
 		// it already exists), so there is no second source to reconcile.
 		localTerraformPath := deploy.LocalTfStatePath(u)
-		if _, err = os.Stat(localTerraformPath); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				cmdio.LogString(ctx, `Error: This command migrates the existing Terraform state file (terraform.tfstate) to a direct deployment state file (resources.json). However, no existing local state was found.
-
-To start using direct engine, set "engine: direct" under ucm in your ucm.yml or deploy with DATABRICKS_UCM_ENGINE=direct env var set.`)
-				return root.ErrAlreadyPrinted
-			}
-			return fmt.Errorf("reading %s: %w", localTerraformPath, err)
+		if err := checkLocalTerraformStatePresent(ctx, localTerraformPath); err != nil {
+			return err
 		}
 
 		header, err := readTerraformStateHeader(localTerraformPath)
@@ -243,16 +268,13 @@ To start using direct engine, set "engine: direct" under ucm in your ucm.yml or 
 
 		localPath := phases.DirectStatePath(u)
 		tempStatePath := localPath + ".temp-migration"
-		if _, err = os.Stat(tempStatePath); err == nil {
-			return fmt.Errorf("temporary state file %s already exists, another migration is in progress or was interrupted. In the latter case, delete the file", tempStatePath)
-		}
 		// "Already using direct" is detected by the local resources.json
 		// file, not via StateDesc (which UCM does not have today; see #145).
 		// A user who deletes resources.json and re-runs migrate against a
 		// still-present terraform.tfstate.backup would re-create the direct
 		// state cleanly.
-		if _, err = os.Stat(localPath); err == nil {
-			return fmt.Errorf("state file %s already exists", localPath)
+		if err := checkDirectStateAbsent(localPath, tempStatePath); err != nil {
+			return err
 		}
 
 		// Run plan check unless --noplancheck is set.

--- a/cmd/ucm/deployment/migrate_test.go
+++ b/cmd/ucm/deployment/migrate_test.go
@@ -1,11 +1,16 @@
 package deployment
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/phases"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,4 +87,45 @@ func TestReadTerraformStateHeader_RejectsMalformed(t *testing.T) {
 	_, err := readTerraformStateHeader(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse")
+}
+
+// TestMigrateAbortsWhenTerraformStateMissing exercises the "no existing
+// local state" guidance path: when terraform.tfstate is absent at the
+// canonical local path, migrate must print the user-facing guidance and
+// return root.ErrAlreadyPrinted (so the printed message is not duplicated
+// by the root error renderer).
+func TestMigrateAbortsWhenTerraformStateMissing(t *testing.T) {
+	u := setupUcmFixture(t)
+	ctx, stderr := cmdio.NewTestContextWithStderr(t.Context())
+
+	localTerraformPath := deploy.LocalTfStatePath(u)
+	// Sanity: fixture must not pre-create the tfstate; the guard relies on
+	// os.ErrNotExist as the trigger.
+	_, statErr := os.Stat(localTerraformPath)
+	require.True(t, errors.Is(statErr, os.ErrNotExist), "fixture leaked a terraform.tfstate at %s", localTerraformPath)
+
+	err := checkLocalTerraformStatePresent(ctx, localTerraformPath)
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+	assert.Contains(t, stderr.String(), "no existing local state was found")
+	assert.Contains(t, stderr.String(), "DATABRICKS_UCM_ENGINE=direct")
+}
+
+// TestMigrateAbortsWhenDirectStateAlreadyExists exercises the
+// "resources.json already exists" guard. A user who has already migrated
+// (or deployed direct from scratch) must not have their direct state
+// silently overwritten — the verb errors out with a wrapped, non-printed
+// error so the standard error renderer surfaces it.
+func TestMigrateAbortsWhenDirectStateAlreadyExists(t *testing.T) {
+	u := setupUcmFixture(t)
+
+	localPath := phases.DirectStatePath(u)
+	tempStatePath := localPath + ".temp-migration"
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0o755))
+	require.NoError(t, os.WriteFile(localPath, []byte("{}"), 0o644))
+
+	err := checkDirectStateAbsent(localPath, tempStatePath)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, root.ErrAlreadyPrinted)
+	assert.Contains(t, err.Error(), "state file "+localPath+" already exists")
 }


### PR DESCRIPTION
Closes #147

## Summary
- Add unit tests for the two PR #146 review-flagged guards in `cmd/ucm/deployment/migrate.go`:
  - `TestMigrateAbortsWhenTerraformStateMissing` — verifies the user-facing guidance and `root.ErrAlreadyPrinted` are emitted when `terraform.tfstate` is absent.
  - `TestMigrateAbortsWhenDirectStateAlreadyExists` — verifies the wrapped error fires when `resources.json` already exists.

## Why
Both guards were untested at unit level; only end-to-end paths exercised them. Filling these gaps catches regressions in the migrate flow.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`