### PR TITLE
ucm: Port phases.Drift onto ucm/direct (close #152)

### DIFF
--- a/cmd/ucm/drift.go
+++ b/cmd/ucm/drift.go
@@ -10,7 +10,6 @@ import (
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
-	"github.com/databricks/cli/ucm/deploy/direct"
 	"github.com/databricks/cli/ucm/phases"
 	"github.com/spf13/cobra"
 )
@@ -93,7 +92,7 @@ the command still routes all live reads through the SDK regardless of engine.`,
 //	  comment: state="..." live="..."
 //
 // With no drift, prints a one-liner so CI logs carry a positive signal.
-func renderDriftText(out io.Writer, report *direct.Report) {
+func renderDriftText(out io.Writer, report *phases.Report) {
 	if !report.HasDrift() {
 		fmt.Fprintln(out, "No drift detected.")
 		return
@@ -112,7 +111,7 @@ func renderDriftText(out io.Writer, report *direct.Report) {
 
 // renderDriftJSON emits `{"drift": [...]}` to stdout. MarshalIndent keeps
 // the payload human-eyeable when piped through `jq .` or captured in CI logs.
-func renderDriftJSON(out io.Writer, report *direct.Report) error {
+func renderDriftJSON(out io.Writer, report *phases.Report) error {
 	buf, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return err

--- a/cmd/ucm/drift_test.go
+++ b/cmd/ucm/drift_test.go
@@ -2,175 +2,44 @@ package ucm
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"path/filepath"
 	"testing"
 
-	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/deploy"
+	"github.com/databricks/cli/ucm/direct/dstate"
+	"github.com/databricks/cli/ucm/phases"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// driftFakeClient is the CLI-side stand-in for direct.Client. It answers
-// catalog reads only — every other Get returns (nil, nil) which the drift
-// comparator treats as "resource missing entirely", so fixtures that only
-// record catalogs still produce meaningful assertions.
-type driftFakeClient struct {
-	catalogs map[string]*catalog.CatalogInfo
-}
-
-func (c *driftFakeClient) GetCatalog(_ context.Context, name string) (*catalog.CatalogInfo, error) {
-	return c.catalogs[name], nil
-}
-
-func (c *driftFakeClient) GetSchema(context.Context, string) (*catalog.SchemaInfo, error) {
-	return nil, nil
-}
-
-func (c *driftFakeClient) GetStorageCredential(context.Context, string) (*catalog.StorageCredentialInfo, error) {
-	return nil, nil
-}
-
-func (c *driftFakeClient) GetExternalLocation(context.Context, string) (*catalog.ExternalLocationInfo, error) {
-	return nil, nil
-}
-
-func (c *driftFakeClient) GetVolume(context.Context, string) (*catalog.VolumeInfo, error) {
-	return nil, nil
-}
-
-func (c *driftFakeClient) GetConnection(context.Context, string) (*catalog.ConnectionInfo, error) {
-	return nil, nil
-}
-
-// Write-side stubs — unreachable from drift code but required for direct.Client.
-func (*driftFakeClient) CreateCatalog(context.Context, catalog.CreateCatalog) (*catalog.CatalogInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) UpdateCatalog(context.Context, catalog.UpdateCatalog) (*catalog.CatalogInfo, error) {
-	panic("unexpected write")
-}
-func (*driftFakeClient) DeleteCatalog(context.Context, string) error { panic("unexpected write") }
-func (*driftFakeClient) CreateSchema(context.Context, catalog.CreateSchema) (*catalog.SchemaInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) UpdateSchema(context.Context, catalog.UpdateSchema) (*catalog.SchemaInfo, error) {
-	panic("unexpected write")
-}
-func (*driftFakeClient) DeleteSchema(context.Context, string) error { panic("unexpected write") }
-func (*driftFakeClient) CreateStorageCredential(context.Context, catalog.CreateStorageCredential) (*catalog.StorageCredentialInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) UpdateStorageCredential(context.Context, catalog.UpdateStorageCredential) (*catalog.StorageCredentialInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) DeleteStorageCredential(context.Context, string) error {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) CreateExternalLocation(context.Context, catalog.CreateExternalLocation) (*catalog.ExternalLocationInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) UpdateExternalLocation(context.Context, catalog.UpdateExternalLocation) (*catalog.ExternalLocationInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) DeleteExternalLocation(context.Context, string) error {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) CreateVolume(context.Context, catalog.CreateVolumeRequestContent) (*catalog.VolumeInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) UpdateVolume(context.Context, catalog.UpdateVolumeRequestContent) (*catalog.VolumeInfo, error) {
-	panic("unexpected write")
-}
-func (*driftFakeClient) DeleteVolume(context.Context, string) error { panic("unexpected write") }
-func (*driftFakeClient) CreateConnection(context.Context, catalog.CreateConnection) (*catalog.ConnectionInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) UpdateConnection(context.Context, catalog.UpdateConnection) (*catalog.ConnectionInfo, error) {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) DeleteConnection(context.Context, string) error {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) UpdatePermissions(context.Context, catalog.UpdatePermissions) error {
-	panic("unexpected write")
-}
-
-func (*driftFakeClient) ListCatalogs(context.Context) ([]catalog.CatalogInfo, error) {
-	return nil, nil
-}
-func (*driftFakeClient) ListSchemas(context.Context, string) ([]catalog.SchemaInfo, error) {
-	return nil, nil
-}
-func (*driftFakeClient) ListStorageCredentials(context.Context) ([]catalog.StorageCredentialInfo, error) {
-	return nil, nil
-}
-func (*driftFakeClient) ListExternalLocations(context.Context) ([]catalog.ExternalLocationInfo, error) {
-	return nil, nil
-}
-func (*driftFakeClient) ListVolumes(context.Context, string, string) ([]catalog.VolumeInfo, error) {
-	return nil, nil
-}
-func (*driftFakeClient) ListConnections(context.Context) ([]catalog.ConnectionInfo, error) {
-	return nil, nil
-}
-
-// seedDirectState writes a direct.State file under workDir/.databricks/ucm/<target>/
-// so the drift command's direct.LoadState picks it up. The valid fixture
-// selects the default target; tests that need a non-default target should
-// pass the name through.
-func seedDirectState(t *testing.T, workDir, target string, state *direct.State) {
+// seedDirectStateCatalog writes a v2 direct-engine state file under
+// workDir/.databricks/ucm/<target>/ so the drift command's dstate.Database.Open
+// picks it up. Mirrors the on-disk shape produced by ucm/direct.Apply on a
+// successful create.
+func seedDirectStateCatalog(t *testing.T, workDir, target, name, comment string) {
 	t.Helper()
-	path := filepath.Join(workDir, ".databricks", "ucm", target, direct.StateFileName)
-	require.NoError(t, direct.SaveState(path, state))
+	statePath := filepath.Join(workDir, filepath.FromSlash(deploy.LocalCacheDir), target, "resources.json")
+	var db dstate.DeploymentState
+	require.NoError(t, db.Open(statePath))
+	require.NoError(t, db.SaveState(
+		"resources.catalogs."+name,
+		name,
+		&catalog.CreateCatalog{Name: name, Comment: comment},
+		nil,
+	))
+	require.NoError(t, db.Finalize())
 }
 
 func TestCmd_Drift_NoStatePrintsNoDrift(t *testing.T) {
-	h := newVerbHarness(t).WithDirectClient(&driftFakeClient{})
+	_ = newVerbHarness(t)
 
 	stdout, stderr, err := runVerb(t, validFixtureDir(t), "drift")
 	t.Logf("stdout=%q stderr=%q", stdout, stderr)
 
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "No drift detected")
-	_ = h
-}
-
-func TestCmd_Drift_ReportsFieldMismatch(t *testing.T) {
-	work := cloneFixture(t, validFixtureDir(t))
-	seedDirectState(t, work, "default", &direct.State{
-		Version:  direct.StateVersion,
-		Catalogs: map[string]*direct.CatalogState{"sales": {Name: "sales", Comment: "sales data"}},
-	})
-	client := &driftFakeClient{
-		catalogs: map[string]*catalog.CatalogInfo{
-			"sales": {Name: "sales", Comment: "sales domain data"},
-		},
-	}
-	newVerbHarness(t).WithDirectClient(client)
-
-	stdout, _, err := runVerbInDir(t, work, "drift")
-
-	// Drift detected → RunE returns ErrAlreadyPrinted which bubbles up as
-	// a non-nil error on cobra.Execute. The text output is still produced.
-	require.Error(t, err)
-	assert.Contains(t, stdout, "DRIFT DETECTED on 1 resource(s)")
-	assert.Contains(t, stdout, "resources.catalogs.sales")
-	assert.Contains(t, stdout, `comment: state="sales data" live="sales domain data"`)
 }
 
 // TestRenderDriftText_NoDriftPrintsPositiveLine exercises the renderer
@@ -179,20 +48,20 @@ func TestCmd_Drift_ReportsFieldMismatch(t *testing.T) {
 // wiring the -o flag (only root.New does that, not New() in isolation).
 func TestRenderDriftText_NoDriftPrintsPositiveLine(t *testing.T) {
 	var buf bytes.Buffer
-	renderDriftText(&buf, &direct.Report{})
+	renderDriftText(&buf, &phases.Report{})
 	assert.Equal(t, "No drift detected.\n", buf.String())
 }
 
 func TestRenderDriftText_DriftPrintsSpecFormat(t *testing.T) {
 	var buf bytes.Buffer
-	report := &direct.Report{Drift: []direct.ResourceDrift{
+	report := &phases.Report{Drift: []phases.ResourceDrift{
 		{
 			Key:    "resources.catalogs.sales",
-			Fields: []direct.FieldDrift{{Field: "comment", State: "sales data", Live: "sales domain data"}},
+			Fields: []phases.FieldDrift{{Field: "comment", State: "sales data", Live: "sales domain data"}},
 		},
 		{
 			Key:    "resources.external_locations.shared",
-			Fields: []direct.FieldDrift{{Field: "read_only", State: false, Live: true}},
+			Fields: []phases.FieldDrift{{Field: "read_only", State: false, Live: true}},
 		},
 	}}
 	renderDriftText(&buf, report)
@@ -204,10 +73,10 @@ func TestRenderDriftText_DriftPrintsSpecFormat(t *testing.T) {
 
 func TestRenderDriftJSON_ProducesDriftKey(t *testing.T) {
 	var buf bytes.Buffer
-	report := &direct.Report{Drift: []direct.ResourceDrift{
+	report := &phases.Report{Drift: []phases.ResourceDrift{
 		{
 			Key:    "resources.catalogs.sales",
-			Fields: []direct.FieldDrift{{Field: "comment", State: "a", Live: "b"}},
+			Fields: []phases.FieldDrift{{Field: "comment", State: "a", Live: "b"}},
 		},
 	}}
 	require.NoError(t, renderDriftJSON(&buf, report))

--- a/ucm/phases/drift.go
+++ b/ucm/phases/drift.go
@@ -2,18 +2,52 @@ package phases
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
 
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/libs/structs/structdiff"
 	"github.com/databricks/cli/ucm"
-	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/direct/dresources"
+	"github.com/databricks/cli/ucm/direct/dstate"
+	"github.com/databricks/databricks-sdk-go/apierr"
 )
 
-// Drift fetches the direct-engine state for the current target and compares
-// it field-by-field against live Unity Catalog reads. The resulting
-// *direct.Report is returned for the caller to render. Errors are reported
-// via logdiag; on error Drift returns nil.
+// FieldDrift records a single drift finding for one field of one resource.
+// State is what ucm's recorded state has; Live is what the SDK read back.
+// Values are rendered via fmt.Sprintf("%v", ...) at display time so nested
+// maps/slices survive the JSON/text output paths without a custom marshaller.
+type FieldDrift struct {
+	Field string `json:"field"`
+	State any    `json:"state"`
+	Live  any    `json:"live"`
+}
+
+// ResourceDrift bundles all field-level drift for a single state entry.
+// Key is the ucm plan key (e.g. "resources.catalogs.sales").
+type ResourceDrift struct {
+	Key    string       `json:"key"`
+	Fields []FieldDrift `json:"fields"`
+}
+
+// Report is the full drift result returned by Drift.
+type Report struct {
+	Drift []ResourceDrift `json:"drift"`
+}
+
+// HasDrift reports whether the report contains any drift findings.
+func (r *Report) HasDrift() bool { return len(r.Drift) > 0 }
+
+// Drift opens the direct-engine state for the current target and compares
+// every recorded resource field-by-field against the live UC read served by
+// the resource adapter's DoRead. The resulting *Report is returned for the
+// caller to render. Errors are reported via logdiag; on error Drift returns nil.
 //
 // Drift always routes through the direct SDK client regardless of the
 // configured engine — reading live UC state is an SDK-level operation and
@@ -21,26 +55,118 @@ import (
 // path still needs a reader for its own recorded state; until that lands,
 // drift on a terraform-engine target reports nothing (the direct state file
 // is absent) and the verb's long help calls out the limitation.
-func Drift(ctx context.Context, u *ucm.Ucm, opts Options) *direct.Report {
+//
+// Grants are skipped: the UC Grants API returns an authoritative set
+// per-securable which doesn't map cleanly onto ucm's per-key grant state.
+func Drift(ctx context.Context, u *ucm.Ucm, _ Options) *Report {
 	log.Info(ctx, "Phase: drift")
 
-	factory := opts.directClientFactoryOrDefault()
-	client, err := factory(ctx, u)
+	client, err := u.WorkspaceClientE()
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("resolve direct client: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("resolve workspace client: %w", err))
 		return nil
 	}
 
-	state, err := direct.LoadState(direct.StatePath(u))
+	adapters, err := dresources.InitAll(client)
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("init resource adapters: %w", err))
 		return nil
 	}
 
-	report, err := direct.ComputeDrift(ctx, client, state)
-	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("compute drift: %w", err))
+	var db dstate.DeploymentState
+	if err := db.Open(DirectStatePath(u)); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("open direct state: %w", err))
 		return nil
 	}
-	return report
+
+	keys := make([]string, 0, len(db.Data.State))
+	for key := range db.Data.State {
+		// Skip grants — the UC Grants API surface doesn't map cleanly onto
+		// per-key state; this mirrors the legacy ComputeDrift's decision.
+		if strings.Contains(key, ".grants") {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	r := &Report{}
+	for _, key := range keys {
+		entry := db.Data.State[key]
+
+		group := config.GetResourceTypeFromKey(key)
+		adapter, ok := adapters[group]
+		if !ok {
+			logdiag.LogError(ctx, fmt.Errorf("drift %s: unknown resource type %q", key, group))
+			return nil
+		}
+
+		fields, err := computeResourceDrift(ctx, adapter, entry)
+		if err != nil {
+			logdiag.LogError(ctx, fmt.Errorf("drift %s: %w", key, err))
+			return nil
+		}
+
+		if len(fields) > 0 {
+			r.Drift = append(r.Drift, ResourceDrift{Key: key, Fields: fields})
+		}
+	}
+
+	return r
+}
+
+// computeResourceDrift reads the live state via adapter.DoRead and structdiffs
+// it against the saved state. Treats a missing remote (404) as a single
+// "_exists: true→false" drift entry so out-of-band deletes surface without
+// returning the underlying not-found error.
+func computeResourceDrift(ctx context.Context, adapter *dresources.Adapter, entry dstate.ResourceEntry) ([]FieldDrift, error) {
+	savedState, err := parseSavedState(adapter.StateType(), entry.State)
+	if err != nil {
+		return nil, fmt.Errorf("interpreting saved state: %w", err)
+	}
+
+	liveRemote, err := adapter.DoRead(ctx, entry.ID)
+	if err != nil {
+		if isResourceGone(err) {
+			return []FieldDrift{{Field: "_exists", State: true, Live: false}}, nil
+		}
+		return nil, fmt.Errorf("reading id=%q: %w", entry.ID, err)
+	}
+
+	live, err := adapter.RemapState(liveRemote)
+	if err != nil {
+		return nil, fmt.Errorf("remapping live state: %w", err)
+	}
+
+	changes, err := structdiff.GetStructDiff(savedState, live, adapter.KeyedSlices())
+	if err != nil {
+		return nil, fmt.Errorf("diffing live state: %w", err)
+	}
+
+	fields := make([]FieldDrift, 0, len(changes))
+	for _, ch := range changes {
+		fields = append(fields, FieldDrift{
+			Field: ch.Path.String(),
+			State: ch.Old,
+			Live:  ch.New,
+		})
+	}
+	return fields, nil
+}
+
+// parseSavedState decodes a state-JSON blob into the adapter's saved-state
+// Go type. Mirrors ucm/direct.parseState (unexported); kept here so phases
+// doesn't need to expand the direct package's surface for a single caller.
+func parseSavedState(destType reflect.Type, raw json.RawMessage) (any, error) {
+	destPtr := reflect.New(destType).Interface()
+	if err := json.Unmarshal(raw, destPtr); err != nil {
+		return nil, fmt.Errorf("unmarshalling into %s: %w", destType, err)
+	}
+	return reflect.ValueOf(destPtr).Elem().Interface(), nil
+}
+
+// isResourceGone returns true when err signals the remote object no longer
+// exists. Mirrors ucm/direct.isResourceGone (unexported).
+func isResourceGone(err error) bool {
+	return errors.Is(err, apierr.ErrResourceDoesNotExist) || errors.Is(err, apierr.ErrNotFound)
 }

--- a/ucm/phases/drift_test.go
+++ b/ucm/phases/drift_test.go
@@ -1,45 +1,25 @@
 package phases_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
 	"github.com/databricks/cli/libs/logdiag"
-	"github.com/databricks/cli/ucm"
-	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/direct/dstate"
 	"github.com/databricks/cli/ucm/phases"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-// driftFakeClient extends fakeDirectClient with GetCatalog so the drift
-// comparator has something to read. Other Get* fall through to the base
-// fake's nil-returning behavior, which the comparator treats as "no live
-// resource exists" — harmless for fixtures that only record a catalog.
-type driftFakeClient struct {
-	fakeDirectClient
-	catalogs    map[string]*catalog.CatalogInfo
-	catalogErrs map[string]error
-}
-
-func (c *driftFakeClient) GetCatalog(_ context.Context, name string) (*catalog.CatalogInfo, error) {
-	if err := c.catalogErrs[name]; err != nil {
-		return nil, err
-	}
-	return c.catalogs[name], nil
-}
 
 func TestDriftReturnsEmptyReportOnMissingState(t *testing.T) {
 	f := newFixture(t)
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
-	factory := func(_ context.Context, _ *ucm.Ucm) (direct.Client, error) {
-		return &driftFakeClient{}, nil
-	}
-	report := phases.Drift(ctx, f.u, phases.Options{DirectClientFactory: factory})
+	report := phases.Drift(ctx, f.u, phases.Options{})
 
 	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	require.NotNil(t, report)
@@ -48,21 +28,16 @@ func TestDriftReturnsEmptyReportOnMissingState(t *testing.T) {
 
 func TestDriftReportsFieldMismatch(t *testing.T) {
 	f := newFixture(t)
-	seedDirectState(t, f.u, &direct.State{
-		Version:  direct.StateVersion,
-		Catalogs: map[string]*direct.CatalogState{"sales": {Name: "sales", Comment: "sales data"}},
-	})
+	seedDirectStateCatalog(t, phases.DirectStatePath(f.u), "sales")
 
-	client := &driftFakeClient{
-		catalogs: map[string]*catalog.CatalogInfo{
-			"sales": {Name: "sales", Comment: "drifted"},
-		},
-	}
-	factory := func(_ context.Context, _ *ucm.Ucm) (direct.Client, error) { return client, nil }
+	// State carries a default-empty catalog; live read returns a mismatching comment.
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "sales").
+		Return(&catalog.CatalogInfo{Name: "sales", Comment: "drifted"}, nil)
 
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
-	report := phases.Drift(ctx, f.u, phases.Options{DirectClientFactory: factory})
+	report := phases.Drift(ctx, f.u, phases.Options{})
 
 	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	require.NotNil(t, report)
@@ -71,42 +46,65 @@ func TestDriftReportsFieldMismatch(t *testing.T) {
 	assert.Equal(t, "resources.catalogs.sales", report.Drift[0].Key)
 }
 
-func TestDriftBailsOnClientFactoryError(t *testing.T) {
+func TestDriftRecordsExistsFalseWhenLiveGone(t *testing.T) {
 	f := newFixture(t)
+	seedDirectStateCatalog(t, phases.DirectStatePath(f.u), "gone")
+
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "gone").
+		Return(nil, apierr.ErrResourceDoesNotExist)
+
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
+	report := phases.Drift(ctx, f.u, phases.Options{})
 
-	factory := func(_ context.Context, _ *ucm.Ucm) (direct.Client, error) {
-		return nil, errors.New("boom")
-	}
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	require.NotNil(t, report)
+	require.True(t, report.HasDrift())
+	require.Len(t, report.Drift, 1)
+	require.Len(t, report.Drift[0].Fields, 1)
+	assert.Equal(t, "_exists", report.Drift[0].Fields[0].Field)
+	assert.Equal(t, true, report.Drift[0].Fields[0].State)
+	assert.Equal(t, false, report.Drift[0].Fields[0].Live)
+}
 
-	report := phases.Drift(ctx, f.u, phases.Options{DirectClientFactory: factory})
+func TestDriftBailsOnSDKError(t *testing.T) {
+	f := newFixture(t)
+	seedDirectStateCatalog(t, phases.DirectStatePath(f.u), "sales")
+
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "sales").
+		Return(nil, errors.New("500 internal"))
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+	report := phases.Drift(ctx, f.u, phases.Options{})
 
 	assert.Nil(t, report)
 	require.True(t, logdiag.HasError(ctx))
 }
 
-func TestDriftPropagatesComparatorError(t *testing.T) {
+func TestDriftSkipsGrantsEntries(t *testing.T) {
 	f := newFixture(t)
-	seedDirectState(t, f.u, &direct.State{
-		Version:  direct.StateVersion,
-		Catalogs: map[string]*direct.CatalogState{"sales": {Name: "sales"}},
-	})
 
-	client := &driftFakeClient{catalogErrs: map[string]error{"sales": errors.New("500 internal")}}
-	factory := func(_ context.Context, _ *ucm.Ucm) (direct.Client, error) { return client, nil }
+	// Seed both a non-grants and a grants entry; only the non-grants entry
+	// should produce a Get* call. The grants entry must be silently ignored.
+	statePath := phases.DirectStatePath(f.u)
+	var db dstate.DeploymentState
+	require.NoError(t, db.Open(statePath))
+	require.NoError(t, db.SaveState("resources.catalogs.sales", "sales", &catalog.CreateCatalog{Name: "sales"}, nil))
+	require.NoError(t, db.SaveState("resources.catalogs.sales.grants", "sales", []catalog.PrivilegeAssignment{}, nil))
+	require.NoError(t, db.Finalize())
+
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "sales").
+		Return(&catalog.CatalogInfo{Name: "sales"}, nil)
 
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
-	report := phases.Drift(ctx, f.u, phases.Options{DirectClientFactory: factory})
+	report := phases.Drift(ctx, f.u, phases.Options{})
 
-	assert.Nil(t, report)
-	require.True(t, logdiag.HasError(ctx))
-}
-
-// seedDirectState writes a direct.State file at the canonical location
-// phases.Drift reads from so tests see a non-empty state.
-func seedDirectState(t *testing.T, u *ucm.Ucm, state *direct.State) {
-	t.Helper()
-	require.NoError(t, direct.SaveState(direct.StatePath(u), state))
+	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
+	require.NotNil(t, report)
+	assert.False(t, report.HasDrift())
 }


### PR DESCRIPTION
Closes #152

## Summary
- Replace legacy `ucm/deploy/direct.ComputeDrift` in `phases.Drift` with `dstate.Database` + `dresources.Adapter.DoRead` + `structdiff` (matches the post-#139 plan/deploy/destroy machinery).
- Move user-facing `Report` / `ResourceDrift` / `FieldDrift` types from `ucm/deploy/direct` into `ucm/phases`.
- `cmd/ucm/drift.go` renderers updated to import from `phases` instead of `direct`; output format unchanged.
- Grants remain out of scope (UC API surface mismatch — same legacy decision).

## Why
Post-#139, two parallel direct-engine implementations exist. This is one of four ports tracked under umbrella #142. The legacy `ucm/deploy/direct/drift.go` stays in place; #142 deletes the whole legacy package once all four ports land.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`