### PR TITLE
ucm: Port phases.Import onto ucm/direct (close #153)

### DIFF
--- a/acceptance/ucm/import/missing_catalog/output.txt
+++ b/acceptance/ucm/import/missing_catalog/output.txt
@@ -4,12 +4,7 @@ Warning: cannot initialize resource URLs: workspace.host is not set
 
 Warning: cannot initialize resource URLs: workspace.host is not set
 
-Error: direct import: get catalog test_catalog: Resource catalog.CatalogInfo not found: test_catalog (404 <nil>)
-
-Endpoint: GET [DATABRICKS_URL]/api/2.1/unity-catalog/catalogs/test_catalog?
-HTTP Status: 404 Not Found
-API error_code: <nil>
-API message: Resource catalog.CatalogInfo not found: test_catalog
+Error: ucm import: catalog "test_catalog" not found in Unity Catalog
 
 
 Exit code: 1

--- a/ucm/phases/import.go
+++ b/ucm/phases/import.go
@@ -2,6 +2,7 @@ package phases
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/databricks/cli/libs/log"
@@ -9,7 +10,9 @@ import (
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config/mutator"
 	"github.com/databricks/cli/ucm/deploy"
-	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/direct/dresources"
+	"github.com/databricks/cli/ucm/direct/dstate"
+	"github.com/databricks/databricks-sdk-go/apierr"
 )
 
 // ImportKind identifies the resource kind an Import call targets.
@@ -150,32 +153,77 @@ func importTerraform(ctx context.Context, u *ucm.Ucm, opts Options, req ImportRe
 	}
 }
 
-func importDirect(ctx context.Context, u *ucm.Ucm, opts Options, req ImportRequest) {
+// importDirect resolves the dresources adapter for the requested kind, reads
+// the live UC object via the SDK, RemapState's it into the saved-state shape
+// that ucm/direct.Apply persists on a normal create, and writes it through
+// dstate.DeploymentState.SaveState. Refuses to overwrite an entry that is
+// already bound — operators must `ucm deployment unbind` first to make the
+// imported state match a re-discovered live object.
+func importDirect(ctx context.Context, u *ucm.Ucm, _ Options, req ImportRequest) {
 	ucm.ApplyContext(ctx, u, mutator.ResolveVariableReferencesOnlyResources("resources"))
 	if logdiag.HasError(ctx) {
 		return
 	}
 
-	factory := opts.directClientFactoryOrDefault()
-	client, err := factory(ctx, u)
+	client, err := u.WorkspaceClientE()
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("resolve direct client: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("resolve workspace client: %w", err))
 		return
 	}
 
-	statePath := direct.StatePath(u)
-	state, err := direct.LoadState(statePath)
+	adapters, err := dresources.InitAll(client)
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("init resource adapters: %w", err))
+		return
+	}
+	plural := pluralKind(req.Kind)
+	adapter, ok := adapters[plural]
+	if !ok {
+		logdiag.LogError(ctx, fmt.Errorf("ucm import: no adapter for kind %q", req.Kind))
 		return
 	}
 
-	if err := direct.ImportResource(ctx, u, client, state, string(req.Kind), req.Name, req.Key); err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("direct import: %w", err))
+	var db dstate.DeploymentState
+	if err := db.Open(DirectStatePath(u)); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("open direct state: %w", err))
 		return
 	}
 
-	if err := direct.SaveState(statePath, state); err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("save direct state: %w", err))
+	stateKey := fmt.Sprintf("resources.%s.%s", plural, req.Key)
+	if _, exists := db.Data.State[stateKey]; exists {
+		logdiag.LogError(ctx, fmt.Errorf("ucm import: %s is already bound in state — use `ucm deployment unbind` first", stateKey))
+		return
 	}
+
+	live, err := adapter.DoRead(ctx, req.Name)
+	if err != nil {
+		if errors.Is(err, apierr.ErrResourceDoesNotExist) || errors.Is(err, apierr.ErrNotFound) {
+			logdiag.LogError(ctx, fmt.Errorf("ucm import: %s %q not found in Unity Catalog", req.Kind, req.Name))
+			return
+		}
+		logdiag.LogError(ctx, fmt.Errorf("read %s %q: %w", req.Kind, req.Name, err))
+		return
+	}
+	if live == nil {
+		logdiag.LogError(ctx, fmt.Errorf("ucm import: %s %q not found in Unity Catalog", req.Kind, req.Name))
+		return
+	}
+
+	saved, err := adapter.RemapState(live)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("remap %s state: %w", req.Kind, err))
+		return
+	}
+
+	if err := db.SaveState(stateKey, req.Name, saved, nil); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("save state for %s: %w", stateKey, err))
+		return
+	}
+
+	if err := db.Finalize(); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("finalize direct state: %w", err))
+		return
+	}
+
+	log.Infof(ctx, "direct: imported %s %s as %s", req.Kind, req.Name, stateKey)
 }

--- a/ucm/phases/import_test.go
+++ b/ucm/phases/import_test.go
@@ -1,14 +1,19 @@
 package phases_test
 
 import (
-	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm/config/engine"
 	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/databricks/cli/ucm/direct/dstate"
 	"github.com/databricks/cli/ucm/phases"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,21 +51,92 @@ func TestImportRequiresDeclaredResource(t *testing.T) {
 	assert.Equal(t, 0, f.tf.ImportCalls)
 }
 
-func TestImportDirectEngineSkipsTerraform(t *testing.T) {
+// TestImportDirectEnginePersistsState exercises the new direct-engine import
+// flow end-to-end: GetByName via mock, RemapState into the catalog state shape,
+// SaveState under resources.catalogs.<key>, Finalize writes the state file.
+func TestImportDirectEnginePersistsState(t *testing.T) {
 	f := newFixture(t)
 	f.u.Config.Ucm.Engine = engine.EngineDirect
 	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
 		"main": {CreateCatalog: catalog.CreateCatalog{Name: "main"}},
 	}
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "main").
+		Return(&catalog.CatalogInfo{Name: "main", Comment: "imported"}, nil)
+
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
 	phases.Import(ctx, f.u, phases.Options{
-		TerraformFactory:    fakeTfFactory(f.tf),
-		DirectClientFactory: fakeDirectClientFactory(),
+		TerraformFactory: fakeTfFactory(f.tf),
 	}, phases.ImportRequest{Kind: phases.ImportCatalog, Name: "main", Key: "main"})
 
 	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, 0, f.tf.ImportCalls, "direct engine must not invoke the terraform wrapper")
 	assert.Equal(t, -1, readRemoteSeq(t, f), "direct engine must never push remote state")
+
+	// Finalize wrote the state file with the imported catalog entry.
+	statePath := phases.DirectStatePath(f.u)
+	info, err := os.Stat(statePath)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+
+	var db dstate.DeploymentState
+	require.NoError(t, db.Open(statePath))
+	entry, ok := db.Data.State["resources.catalogs.main"]
+	require.True(t, ok, "expected resources.catalogs.main entry after import")
+	assert.Equal(t, "main", entry.ID)
+}
+
+// TestImportDirectEngineRefusesAlreadyBound asserts the pre-DoRead state
+// lookup short-circuits when the key is already in state, so re-imports
+// surface a clean error instead of silently overwriting recorded fields.
+func TestImportDirectEngineRefusesAlreadyBound(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"main": {CreateCatalog: catalog.CreateCatalog{Name: "main"}},
+	}
+	seedDirectStateCatalog(t, phases.DirectStatePath(f.u), "main")
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Import(ctx, f.u, phases.Options{
+		TerraformFactory: fakeTfFactory(f.tf),
+	}, phases.ImportRequest{Kind: phases.ImportCatalog, Name: "main", Key: "main"})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "already bound in state")
+}
+
+// TestImportDirectEngineSurfacesNotFound asserts a 404 from the SDK is
+// translated into a friendly diagnostic instead of being wrapped raw.
+func TestImportDirectEngineSurfacesNotFound(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"missing": {CreateCatalog: catalog.CreateCatalog{Name: "missing"}},
+	}
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "missing").
+		Return(nil, apierr.ErrResourceDoesNotExist)
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Import(ctx, f.u, phases.Options{
+		TerraformFactory: fakeTfFactory(f.tf),
+	}, phases.ImportRequest{Kind: phases.ImportCatalog, Name: "missing", Key: "missing"})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "not found in Unity Catalog")
+
+	// Finalize must not have run — no state file created.
+	_, err := os.Stat(phases.DirectStatePath(f.u))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 }


### PR DESCRIPTION
Closes #153

## Summary
- Replace legacy `ucm/deploy/direct.ImportResource` in `phases.importDirect` with `dstate.Database` + `dresources.Adapter` flow (matches the post-#139 architecture and #152's drift port).
- Keep terraform-engine import path (`importTerraform`) unchanged.
- Add already-bound state-lookup guard before the SDK call so re-imports surface a clean error.
- Existing `acceptance/ucm/import/missing_catalog` continues to pass (validation runs upstream of engine selection).

## Why
Post-#139, two parallel direct-engine implementations exist. This is the second of four ports tracked under umbrella #142 (after #152 drift). Legacy `ucm/deploy/direct/import.go` stays in place; #142 deletes the whole package once all four ports land.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`