### PR TITLE
ucm: Port phases.{Bind,Unbind} onto ucm/direct (close #154, #155)

### DIFF
--- a/ucm/phases/bind.go
+++ b/ucm/phases/bind.go
@@ -2,6 +2,7 @@ package phases
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/databricks/cli/libs/log"
@@ -9,7 +10,9 @@ import (
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/config/mutator"
 	"github.com/databricks/cli/ucm/deploy"
-	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/direct/dresources"
+	"github.com/databricks/cli/ucm/direct/dstate"
+	"github.com/databricks/databricks-sdk-go/apierr"
 )
 
 // BindRequest bundles the operator-supplied inputs for a single bind. Name is
@@ -113,34 +116,80 @@ func bindTerraform(ctx context.Context, u *ucm.Ucm, opts Options, req BindReques
 	}
 }
 
-func bindDirect(ctx context.Context, u *ucm.Ucm, opts Options, req BindRequest) {
+// bindDirect resolves the dresources adapter for the requested kind, reads
+// the live UC object via the SDK, RemapState's it into the saved-state shape
+// that ucm/direct.Apply persists on a normal create, and writes it through
+// dstate.DeploymentState.SaveState. Refuses to overwrite an entry that is
+// already bound — operators must `ucm deployment unbind` first to rebind a
+// re-discovered live object. Mirrors importDirect; bind and import share the
+// same per-resource primitives.
+func bindDirect(ctx context.Context, u *ucm.Ucm, _ Options, req BindRequest) {
 	ucm.ApplyContext(ctx, u, mutator.ResolveVariableReferencesOnlyResources("resources"))
 	if logdiag.HasError(ctx) {
 		return
 	}
 
-	factory := opts.directClientFactoryOrDefault()
-	client, err := factory(ctx, u)
+	client, err := u.WorkspaceClientE()
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("resolve direct client: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("resolve workspace client: %w", err))
 		return
 	}
 
-	statePath := direct.StatePath(u)
-	state, err := direct.LoadState(statePath)
+	adapters, err := dresources.InitAll(client)
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+		logdiag.LogError(ctx, fmt.Errorf("init resource adapters: %w", err))
+		return
+	}
+	plural := pluralKind(req.Kind)
+	adapter, ok := adapters[plural]
+	if !ok {
+		logdiag.LogError(ctx, fmt.Errorf("ucm bind: no adapter for kind %q", req.Kind))
 		return
 	}
 
-	if err := direct.ImportResource(ctx, u, client, state, string(req.Kind), req.Name, req.Key); err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("direct bind: %w", err))
+	var db dstate.DeploymentState
+	if err := db.Open(DirectStatePath(u)); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("open direct state: %w", err))
 		return
 	}
 
-	if err := direct.SaveState(statePath, state); err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("save direct state: %w", err))
+	stateKey := fmt.Sprintf("resources.%s.%s", plural, req.Key)
+	if _, exists := db.Data.State[stateKey]; exists {
+		logdiag.LogError(ctx, fmt.Errorf("ucm bind: %s is already bound in state — use `ucm deployment unbind` first", stateKey))
+		return
 	}
+
+	live, err := adapter.DoRead(ctx, req.Name)
+	if err != nil {
+		if errors.Is(err, apierr.ErrResourceDoesNotExist) || errors.Is(err, apierr.ErrNotFound) {
+			logdiag.LogError(ctx, fmt.Errorf("ucm bind: %s %q not found in Unity Catalog", req.Kind, req.Name))
+			return
+		}
+		logdiag.LogError(ctx, fmt.Errorf("read %s %q: %w", req.Kind, req.Name, err))
+		return
+	}
+	if live == nil {
+		logdiag.LogError(ctx, fmt.Errorf("ucm bind: %s %q not found in Unity Catalog", req.Kind, req.Name))
+		return
+	}
+
+	saved, err := adapter.RemapState(live)
+	if err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("remap %s state: %w", req.Kind, err))
+		return
+	}
+
+	if err := db.SaveState(stateKey, req.Name, saved, nil); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("save state for %s: %w", stateKey, err))
+		return
+	}
+
+	if err := db.Finalize(); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("finalize direct state: %w", err))
+		return
+	}
+
+	log.Infof(ctx, "direct: bound %s %s as %s", req.Kind, req.Name, stateKey)
 }
 
 func unbindTerraform(ctx context.Context, u *ucm.Ucm, opts Options, req UnbindRequest) {
@@ -180,21 +229,32 @@ func unbindTerraform(ctx context.Context, u *ucm.Ucm, opts Options, req UnbindRe
 	}
 }
 
-func unbindDirect(ctx context.Context, u *ucm.Ucm, opts Options, req UnbindRequest) {
-	_ = opts // direct-engine unbind does not need Options.Backend
-	statePath := direct.StatePath(u)
-	state, err := direct.LoadState(statePath)
-	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("load direct state: %w", err))
+// unbindDirect drops the recorded state entry for req.Key without touching
+// the remote UC object. It is a state-only operation: open the database,
+// guard against a missing key, DeleteState, Finalize. The Initialize step
+// has already validated that the engine is direct.
+func unbindDirect(ctx context.Context, u *ucm.Ucm, _ Options, req UnbindRequest) {
+	var db dstate.DeploymentState
+	if err := db.Open(DirectStatePath(u)); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("open direct state: %w", err))
 		return
 	}
 
-	if err := direct.UnbindResource(ctx, state, string(req.Kind), req.Key); err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("direct unbind: %w", err))
+	stateKey := fmt.Sprintf("resources.%s.%s", pluralKind(req.Kind), req.Key)
+	if _, exists := db.Data.State[stateKey]; !exists {
+		logdiag.LogError(ctx, fmt.Errorf("ucm unbind: %s is not bound in state", stateKey))
 		return
 	}
 
-	if err := direct.SaveState(statePath, state); err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("save direct state: %w", err))
+	if err := db.DeleteState(stateKey); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("delete state entry %s: %w", stateKey, err))
+		return
 	}
+
+	if err := db.Finalize(); err != nil {
+		logdiag.LogError(ctx, fmt.Errorf("finalize direct state: %w", err))
+		return
+	}
+
+	log.Infof(ctx, "direct: unbound %s", stateKey)
 }

--- a/ucm/phases/bind_test.go
+++ b/ucm/phases/bind_test.go
@@ -1,15 +1,19 @@
 package phases_test
 
 import (
-	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/cli/ucm/config/engine"
 	"github.com/databricks/cli/ucm/config/resources"
-	"github.com/databricks/cli/ucm/deploy/direct"
+	"github.com/databricks/cli/ucm/direct/dstate"
 	"github.com/databricks/cli/ucm/phases"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,32 +51,94 @@ func TestBindRequiresDeclaredResource(t *testing.T) {
 	assert.Equal(t, 0, f.tf.ImportCalls)
 }
 
-func TestBindDirectEngineSkipsTerraform(t *testing.T) {
+// TestBindDirectEnginePersistsState exercises the new direct-engine bind flow
+// end-to-end: GetByName via mock, RemapState into the catalog state shape,
+// SaveState under resources.catalogs.<key>, Finalize writes the state file.
+func TestBindDirectEnginePersistsState(t *testing.T) {
 	f := newFixture(t)
 	f.u.Config.Ucm.Engine = engine.EngineDirect
 	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
 		"main": {CreateCatalog: catalog.CreateCatalog{Name: "main"}},
 	}
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "main").
+		Return(&catalog.CatalogInfo{Name: "main", Comment: "bound"}, nil)
+
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
 	phases.Bind(ctx, f.u, phases.Options{
-		TerraformFactory:    fakeTfFactory(f.tf),
-		DirectClientFactory: fakeDirectClientFactory(),
+		TerraformFactory: fakeTfFactory(f.tf),
 	}, phases.BindRequest{Kind: phases.ImportCatalog, Name: "main", Key: "main"})
 
 	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, 0, f.tf.ImportCalls, "direct engine must not invoke the terraform wrapper")
 	assert.Equal(t, -1, readRemoteSeq(t, f), "direct engine must never push remote state")
 
-	// Verify the direct state was actually written with the expected entry —
-	// skipping terraform and writing nothing would also satisfy the two
-	// assertions above, so the positive assertion is load-bearing.
-	state, err := direct.LoadState(direct.StatePath(f.u))
+	// Finalize wrote the state file with the bound catalog entry.
+	statePath := phases.DirectStatePath(f.u)
+	info, err := os.Stat(statePath)
 	require.NoError(t, err)
-	got := state.Catalogs["main"]
-	require.NotNil(t, got, "direct bind must record catalogs[main]")
-	assert.Equal(t, "main", got.Name)
+	assert.Greater(t, info.Size(), int64(0))
+
+	var db dstate.DeploymentState
+	require.NoError(t, db.Open(statePath))
+	entry, ok := db.Data.State["resources.catalogs.main"]
+	require.True(t, ok, "expected resources.catalogs.main entry after bind")
+	assert.Equal(t, "main", entry.ID)
+}
+
+// TestBindDirectEngineRefusesAlreadyBound asserts the pre-DoRead state lookup
+// short-circuits when the key is already in state, so re-binds surface a
+// clean error instead of silently overwriting recorded fields.
+func TestBindDirectEngineRefusesAlreadyBound(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"main": {CreateCatalog: catalog.CreateCatalog{Name: "main"}},
+	}
+	seedDirectStateCatalog(t, phases.DirectStatePath(f.u), "main")
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Bind(ctx, f.u, phases.Options{
+		TerraformFactory: fakeTfFactory(f.tf),
+	}, phases.BindRequest{Kind: phases.ImportCatalog, Name: "main", Key: "main"})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "already bound in state")
+}
+
+// TestBindDirectEngineSurfacesNotFound asserts a 404 from the SDK is
+// translated into a friendly diagnostic instead of being wrapped raw.
+func TestBindDirectEngineSurfacesNotFound(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
+		"missing": {CreateCatalog: catalog.CreateCatalog{Name: "missing"}},
+	}
+	f.mockWS.GetMockCatalogsAPI().EXPECT().
+		GetByName(mock.Anything, "missing").
+		Return(nil, apierr.ErrResourceDoesNotExist)
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Bind(ctx, f.u, phases.Options{
+		TerraformFactory: fakeTfFactory(f.tf),
+	}, phases.BindRequest{Kind: phases.ImportCatalog, Name: "missing", Key: "missing"})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "not found in Unity Catalog")
+
+	// Finalize must not have run — no state file created.
+	_, err := os.Stat(phases.DirectStatePath(f.u))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 }
 
 func TestUnbindTerraformEngineRunsStateRmAndPushes(t *testing.T) {
@@ -91,28 +157,47 @@ func TestUnbindTerraformEngineRunsStateRmAndPushes(t *testing.T) {
 	assert.Equal(t, 1, readRemoteSeq(t, f), "successful unbind must push remote state")
 }
 
-func TestUnbindDirectEngineSkipsTerraform(t *testing.T) {
+// TestUnbindDirectEngineDeletesState seeds a direct state entry, runs Unbind,
+// and asserts the entry is gone after Finalize. The pre-seeded state ensures
+// the deletion is observable rather than a no-op on an empty file.
+func TestUnbindDirectEngineDeletesState(t *testing.T) {
 	f := newFixture(t)
 	f.u.Config.Ucm.Engine = engine.EngineDirect
+	statePath := phases.DirectStatePath(f.u)
+	seedDirectStateCatalog(t, statePath, "main")
+
 	ctx := logdiag.InitContext(t.Context())
 	logdiag.SetCollect(ctx, true)
 
-	// Seed direct state with the catalog so Unbind has something to remove.
-	f.u.Config.Resources.Catalogs = map[string]*resources.Catalog{
-		"main": {CreateCatalog: catalog.CreateCatalog{Name: "main"}},
-	}
-	phases.Bind(ctx, f.u, phases.Options{
-		TerraformFactory:    fakeTfFactory(f.tf),
-		DirectClientFactory: fakeDirectClientFactory(),
-	}, phases.BindRequest{Kind: phases.ImportCatalog, Name: "main", Key: "main"})
-	require.False(t, logdiag.HasError(ctx), "seed bind failed: %v", logdiag.FlushCollected(ctx))
-
 	phases.Unbind(ctx, f.u, phases.Options{
-		TerraformFactory:    fakeTfFactory(f.tf),
-		DirectClientFactory: fakeDirectClientFactory(),
+		TerraformFactory: fakeTfFactory(f.tf),
 	}, phases.UnbindRequest{Kind: phases.ImportCatalog, Key: "main"})
 
 	require.False(t, logdiag.HasError(ctx), "unexpected errors: %v", logdiag.FlushCollected(ctx))
 	assert.Equal(t, 0, f.tf.StateRmCalls, "direct engine must not invoke the terraform wrapper")
 	assert.Equal(t, -1, readRemoteSeq(t, f), "direct engine must never push remote state")
+
+	var db dstate.DeploymentState
+	require.NoError(t, db.Open(statePath))
+	_, ok := db.Data.State["resources.catalogs.main"]
+	assert.False(t, ok, "expected resources.catalogs.main entry to be removed after unbind")
+}
+
+// TestUnbindDirectEngineRefusesMissing asserts unbind on a key that is not in
+// state surfaces a clean error instead of silently no-op'ing.
+func TestUnbindDirectEngineRefusesMissing(t *testing.T) {
+	f := newFixture(t)
+	f.u.Config.Ucm.Engine = engine.EngineDirect
+
+	ctx := logdiag.InitContext(t.Context())
+	logdiag.SetCollect(ctx, true)
+
+	phases.Unbind(ctx, f.u, phases.Options{
+		TerraformFactory: fakeTfFactory(f.tf),
+	}, phases.UnbindRequest{Kind: phases.ImportCatalog, Key: "ghost"})
+
+	require.True(t, logdiag.HasError(ctx))
+	diags := logdiag.FlushCollected(ctx)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary, "is not bound in state")
 }


### PR DESCRIPTION
Closes #154
Closes #155

## Summary
- Port `phases.bindDirect` to `dstate.Database` + `dresources.Adapter` (mirrors `phases.importDirect` from #163).
- Port `phases.unbindDirect` to a state-only `dstate.DeploymentState.DeleteState` flow.
- Add already-bound (bind) and not-bound (unbind) guards.
- Drop the legacy `ucm/deploy/direct` import from `ucm/phases/bind.go`.
- Terraform-engine paths (`bindTerraform`, `unbindTerraform`) unchanged.

## Why
Combined into one PR because both functions live in `ucm/phases/bind.go`. Splitting would have churned the same imports twice. The legacy `ucm/deploy/direct` package stays in place; #142 deletes it after all four ports (drift, import, bind, unbind) land.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`
- [x] `go test -count=1 ./ucm/deploy/direct/...` (legacy package tests still pass)