### PR TITLE
ucm: Add AccountClient resolution alongside WorkspaceClient (close #99)

### DIFF
--- a/cmd/ucm/utils/auth.go
+++ b/cmd/ucm/utils/auth.go
@@ -40,6 +40,14 @@ func (e ErrNoWorkspaceProfiles) Error() string {
 	return e.path + " does not contain workspace profiles; please create one by running 'databricks auth login'"
 }
 
+type ErrNoAccountProfiles struct {
+	path string
+}
+
+func (e ErrNoAccountProfiles) Error() string {
+	return e.path + " does not contain account profiles"
+}
+
 // Helper function to create a workspace client or prompt once if the given configuration is not valid.
 func workspaceClientOrPrompt(ctx context.Context, cfg *config.Config, allowPrompt bool) (*databricks.WorkspaceClient, error) {
 	w, err := databricks.NewWorkspaceClient((*databricks.Config)(cfg))
@@ -96,10 +104,6 @@ func workspaceClientOrPrompt(ctx context.Context, cfg *config.Config, allowPromp
 // auth fields layered on top of profile/env), stores it on the command
 // context, and returns. Used as a Cobra (Persistent)PreRunE hook on ucm
 // verbs that need a live SDK client.
-//
-// TODO(#99): port AccountClient resolution here. v1 ucm design (see
-// cmd/ucm/CLAUDE.md "Auth model") requires both clients, but A.iii.1 ships
-// workspace-only to keep the fork mechanically aligned with bundle's shape.
 func MustWorkspaceClient(cmd *cobra.Command, args []string) error {
 	ctx := logdiag.InitContext(cmd.Context())
 	cmd.SetContext(ctx)
@@ -152,6 +156,160 @@ func MustWorkspaceClient(cmd *cobra.Command, args []string) error {
 	ctx = cmdctx.SetWorkspaceClient(ctx, w)
 	cmd.SetContext(ctx)
 	return nil
+}
+
+// accountClientOrPrompt creates an account client and, if the configuration
+// is incomplete, optionally prompts for a profile. Mirrors the workspace
+// counterpart above and the bundle-side cmd/root.accountClientOrPrompt.
+func accountClientOrPrompt(ctx context.Context, cfg *config.Config, allowPrompt bool) (*databricks.AccountClient, error) {
+	a, err := databricks.NewAccountClient((*databricks.Config)(cfg))
+	if err == nil {
+		err = a.Config.Authenticate(emptyHttpRequest(ctx))
+	}
+
+	// If auth succeeded and we have an account ID, trust the SDK's
+	// resolution (host metadata is fetched during config init).
+	if err == nil && cfg.AccountID != "" {
+		return a, nil
+	}
+
+	// Determine if we should prompt for a profile based on host type. The SDK
+	// no longer returns ErrNotAccountClient from NewAccountClient (host-type
+	// validation moved to host metadata resolution in v0.125.0); use
+	// HostType() to detect the wrong host type.
+	var needsPrompt bool
+	switch cfg.HostType() { //nolint:staticcheck // HostType() deprecated in SDK v0.127.0; SDK moving to host-agnostic behavior.
+	case config.AccountHost, config.UnifiedHost:
+		needsPrompt = cfg.AccountID == ""
+	default:
+		needsPrompt = true
+	}
+	if !needsPrompt && err != nil && errors.Is(err, config.ErrCannotConfigureDefault) {
+		needsPrompt = true
+	}
+
+	if !needsPrompt {
+		return a, err
+	}
+
+	if !allowPrompt || !cmdio.IsPromptSupported(ctx) {
+		if err == nil {
+			err = databricks.ErrNotAccountClient
+		}
+		return a, err
+	}
+
+	pr, err := AskForAccountProfile(ctx)
+	if err != nil {
+		return nil, err
+	}
+	a, err = databricks.NewAccountClient(&databricks.Config{Profile: pr})
+	if err == nil {
+		err = a.Config.Authenticate(emptyHttpRequest(ctx))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return a, err
+}
+
+// MustAccountClient resolves an account client (with optional ucm.yml auth
+// fields layered on top of profile/env), stores it on the command context,
+// and returns. Used as a Cobra (Persistent)PreRunE hook on ucm verbs that
+// need account-scoped APIs (metastore CRUD, metastore assignments).
+func MustAccountClient(cmd *cobra.Command, args []string) error {
+	ctx := logdiag.InitContext(cmd.Context())
+	cmd.SetContext(ctx)
+
+	cfg := &config.Config{}
+
+	// The command-line profile flag takes precedence over DATABRICKS_CONFIG_PROFILE.
+	pr, hasProfileFlag := profileFlagValue(cmd)
+	if hasProfileFlag {
+		cfg.Profile = pr
+	}
+
+	resolveDefaultProfile(ctx, cfg)
+
+	_, isTargetFlagSet := targetFlagValue(cmd)
+	// If the profile flag is set but the target flag is not, we should skip loading the ucm configuration.
+	if !isTargetFlagSet && hasProfileFlag {
+		cmd.SetContext(SkipLoadUcm(cmd.Context()))
+	}
+
+	ctx = cmdctx.SetConfigUsed(cmd.Context(), cfg)
+	cmd.SetContext(ctx)
+
+	// Try to load a ucm configuration if we're allowed to by the caller.
+	if !shouldSkipLoadUcm(cmd.Context()) {
+		u := TryConfigureUcm(cmd)
+		ctx = cmd.Context()
+		if logdiag.HasError(ctx) {
+			return root.ErrAlreadyPrinted
+		}
+
+		if u != nil {
+			ctx = cmdctx.SetConfigUsed(ctx, u.Config.Workspace.Config())
+			cmd.SetContext(ctx)
+			client, err := u.AccountClientE()
+			if err != nil {
+				return err
+			}
+			cfg = client.Config
+		}
+	}
+
+	if cfg.Profile == "" {
+		// Mirror cmd/root.MustAccountClient: if no profile is wired, look for
+		// a single account-compatible profile in databrickscfg and adopt it.
+		profiler := profile.GetProfiler(cmd.Context())
+		profiles, err := profiler.LoadProfiles(cmd.Context(), profile.MatchAccountProfiles)
+		if err == nil && len(profiles) == 1 {
+			cfg.Profile = profiles[0].Name
+		}
+		if err != nil && !errors.Is(err, profile.ErrNoConfiguration) {
+			return err
+		}
+	}
+
+	allowPrompt := !hasProfileFlag && !shouldSkipPrompt(cmd.Context())
+	a, err := accountClientOrPrompt(cmd.Context(), cfg, allowPrompt)
+	if err != nil {
+		return renderError(ctx, cfg, err)
+	}
+
+	ctx = cmdctx.SetAccountClient(ctx, a)
+	cmd.SetContext(ctx)
+	return nil
+}
+
+// AskForAccountProfile is the account-scoped sibling of AskForWorkspaceProfile.
+// Loads account profiles from databrickscfg and either auto-selects the only
+// match or surfaces the interactive picker.
+func AskForAccountProfile(ctx context.Context) (string, error) {
+	profiler := profile.GetProfiler(ctx)
+	path, err := profiler.GetPath(ctx)
+	if err != nil {
+		return "", fmt.Errorf("cannot determine Databricks config file path: %w", err)
+	}
+	profiles, err := profiler.LoadProfiles(ctx, profile.MatchAccountProfiles)
+	if err != nil {
+		return "", err
+	}
+	switch len(profiles) {
+	case 0:
+		return "", ErrNoAccountProfiles{path: path}
+	case 1:
+		return profiles[0].Name, nil
+	}
+	return profile.SelectProfile(ctx, profile.SelectConfig{
+		Label:             "Account profiles defined in " + path,
+		Profiles:          profiles,
+		StartInSearchMode: true,
+		ActiveTemplate:    `{{.Name | bold}} ({{.AccountID|faint}} {{.Cloud|faint}})`,
+		InactiveTemplate:  `{{.Name}}`,
+		SelectedTemplate:  `{{ "Using account profile" | faint }}: {{ .Name | bold }}`,
+	})
 }
 
 // resolveDefaultProfile applies the [__settings__].default_profile setting

--- a/cmd/ucm/utils/auth_test.go
+++ b/cmd/ucm/utils/auth_test.go
@@ -166,3 +166,93 @@ func TestMustWorkspaceClient_ProfileInYamlUsedVerbatim(t *testing.T) {
 	w := cmdctx.WorkspaceClient(cmd.Context())
 	assert.Equal(t, "PROFILE-UNIQUE", w.Config.Profile)
 }
+
+// setupAccountDatabricksCfg writes a .databrickscfg with one workspace profile
+// (used by TryConfigureUcm's workspace pass) and account profiles for the
+// account-side resolution.
+func setupAccountDatabricksCfg(t *testing.T) {
+	t.Helper()
+	tempHomeDir := t.TempDir()
+	homeEnvVar := "HOME"
+	if runtime.GOOS == "windows" {
+		homeEnvVar = "USERPROFILE"
+	}
+
+	cfg := []byte(strings.Join([]string{
+		"[WS-UNIQUE]",
+		"host = https://ws-unique.example.com",
+		"token = w",
+		"",
+		"[ACCT-UNIQUE]",
+		"host = https://accounts-unique.cloud.databricks.com",
+		"account_id = 11111111-1111-1111-1111-111111111111",
+		"token = a",
+		"",
+	}, "\n"))
+	err := os.WriteFile(filepath.Join(tempHomeDir, ".databrickscfg"), cfg, 0o644)
+	require.NoError(t, err)
+
+	t.Setenv("DATABRICKS_CONFIG_FILE", "")
+	t.Setenv(homeEnvVar, tempHomeDir)
+}
+
+func TestMustAccountClient_ResolvesFromYamlAccountHost(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	if runtime.GOOS == "windows" {
+		t.Setenv("PATH", `C:\Windows\System32`)
+	} else {
+		t.Setenv("PATH", "/usr/bin:/bin")
+	}
+	setupAccountDatabricksCfg(t)
+
+	rootPath := t.TempDir()
+	t.Chdir(rootPath)
+
+	y := "ucm:\n  name: t\n\nworkspace:\n" +
+		"  host: https://ws-unique.example.com\n" +
+		"  account_host: https://accounts-unique.cloud.databricks.com\n"
+	require.NoError(t, os.WriteFile(filepath.Join(rootPath, "ucm.yml"), []byte(y), 0o644))
+
+	cmd := &cobra.Command{Use: "metastore"}
+	cmd.PersistentFlags().String("target", "", "")
+	cmd.PersistentFlags().String("profile", "", "")
+	cmd.SetContext(cmdio.MockDiscard(t.Context()))
+
+	err := MustAccountClient(cmd, nil)
+
+	require.NoError(t, err)
+	require.False(t, logdiag.HasError(cmd.Context()))
+	a := cmdctx.AccountClient(cmd.Context())
+	assert.Equal(t, "ACCT-UNIQUE", a.Config.Profile)
+	assert.Equal(t, "https://accounts-unique.cloud.databricks.com", a.Config.Host)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", a.Config.AccountID)
+}
+
+func TestMustAccountClient_NoAccountProfileSurfacesError(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	if runtime.GOOS == "windows" {
+		t.Setenv("PATH", `C:\Windows\System32`)
+	} else {
+		t.Setenv("PATH", "/usr/bin:/bin")
+	}
+	// Use the workspace-only databrickscfg helper: there are no account
+	// profiles to resolve, so MustAccountClient must surface a clean error
+	// rather than dropping into the picker (PATH is locked down so external
+	// auth helpers can't rescue the resolution either).
+	setupDatabricksCfg(t)
+
+	rootPath := t.TempDir()
+	t.Chdir(rootPath)
+
+	// No account_host configured and no account profiles in databrickscfg.
+	y := "ucm:\n  name: t\n\nworkspace:\n  host: https://nobody.example.com\n"
+	require.NoError(t, os.WriteFile(filepath.Join(rootPath, "ucm.yml"), []byte(y), 0o644))
+
+	cmd := &cobra.Command{Use: "metastore"}
+	cmd.PersistentFlags().String("target", "", "")
+	cmd.PersistentFlags().String("profile", "", "")
+	cmd.SetContext(cmdio.MockDiscard(t.Context()))
+
+	err := MustAccountClient(cmd, nil)
+	require.Error(t, err)
+}

--- a/ucm/account_client.go
+++ b/ucm/account_client.go
@@ -1,0 +1,92 @@
+package ucm
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/databricks/cli/libs/databrickscfg"
+	"github.com/databricks/databricks-sdk-go"
+	sdkconfig "github.com/databricks/databricks-sdk-go/config"
+)
+
+// accountClientConfig builds the SDK config used to construct an account
+// client for this Ucm. The account host is sourced from
+// Config.Workspace.AccountHost (workspace Host alone is insufficient because
+// the SDK routes account vs workspace by host).
+func (u *Ucm) accountClientConfig() *sdkconfig.Config {
+	return &sdkconfig.Config{
+		Host:    u.Config.Workspace.AccountHost,
+		Profile: u.Config.Workspace.Profile,
+	}
+}
+
+// buildAccountClient resolves auth configuration and constructs an account
+// client. Mirrors buildWorkspaceClient: when only the host is set, install
+// the ResolveProfileFromHost loader so the SDK picks up a unique matching
+// profile from ~/.databrickscfg. On ambiguity the loader returns the
+// errMultipleProfiles error detected by databrickscfg.AsMultipleProfiles.
+func (u *Ucm) buildAccountClient() (*databricks.AccountClient, error) {
+	cfg := u.accountClientConfig()
+
+	if cfg.Host != "" && cfg.Profile == "" {
+		cfg.Loaders = []sdkconfig.Loader{
+			sdkconfig.ConfigAttributes,
+			databrickscfg.ResolveProfileFromHost,
+		}
+	}
+
+	if err := cfg.EnsureResolved(); err != nil {
+		return nil, err
+	}
+
+	if cfg.Host != "" && cfg.Profile != "" {
+		if err := databrickscfg.ValidateConfigAndProfileHost(cfg, cfg.Profile); err != nil {
+			return nil, err
+		}
+	}
+
+	return databricks.NewAccountClient((*databricks.Config)(cfg))
+}
+
+func (u *Ucm) initAccountClientOnce() {
+	u.getAccountClient = sync.OnceValues(func() (*databricks.AccountClient, error) {
+		a, err := u.buildAccountClient()
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve ucm account auth configuration: %w", err)
+		}
+		return a, nil
+	})
+}
+
+// AccountClientE returns the memoized account client, building it from
+// Config.Workspace on first call.
+func (u *Ucm) AccountClientE() (*databricks.AccountClient, error) {
+	if u.getAccountClient == nil {
+		u.initAccountClientOnce()
+	}
+	return u.getAccountClient()
+}
+
+// AccountClient is the panicking convenience wrapper around AccountClientE.
+// Prefer AccountClientE in new code so callers can surface auth errors.
+func (u *Ucm) AccountClient() *databricks.AccountClient {
+	client, err := u.AccountClientE()
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// SetAccountClient injects a pre-built client, primarily for tests.
+func (u *Ucm) SetAccountClient(a *databricks.AccountClient) {
+	u.getAccountClient = func() (*databricks.AccountClient, error) {
+		return a, nil
+	}
+}
+
+// ClearAccountClient resets the memoized client so the next AccountClientE
+// call rebuilds it. Used after Config.Workspace is mutated (e.g. when a
+// profile is selected via the ambiguity picker).
+func (u *Ucm) ClearAccountClient() {
+	u.initAccountClientOnce()
+}

--- a/ucm/account_client_test.go
+++ b/ucm/account_client_test.go
@@ -1,0 +1,114 @@
+package ucm
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupAccountDatabricksCfg writes a .databrickscfg with account-shaped
+// profiles and points the SDK at it. Account profiles are matched by the
+// presence of account_id in the SDK profile loader.
+func setupAccountDatabricksCfg(t *testing.T) {
+	t.Helper()
+	tempHomeDir := t.TempDir()
+	homeEnvVar := "HOME"
+	if runtime.GOOS == "windows" {
+		homeEnvVar = "USERPROFILE"
+	}
+
+	cfg := []byte(strings.Join([]string{
+		"[ACCT-UNIQUE]",
+		"host = https://accounts-unique.cloud.databricks.com",
+		"account_id = 11111111-1111-1111-1111-111111111111",
+		"token = a",
+		"",
+		"[ACCT-OTHER]",
+		"host = https://accounts-other.cloud.databricks.com",
+		"account_id = 22222222-2222-2222-2222-222222222222",
+		"token = b",
+		"",
+	}, "\n"))
+	err := os.WriteFile(filepath.Join(tempHomeDir, ".databrickscfg"), cfg, 0o644)
+	require.NoError(t, err)
+
+	t.Setenv("DATABRICKS_CONFIG_FILE", "")
+	t.Setenv(homeEnvVar, tempHomeDir)
+}
+
+func TestAccountClientE_BuildsFromConfig(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	setupAccountDatabricksCfg(t)
+
+	u := &Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				AccountHost: "https://accounts-unique.cloud.databricks.com",
+			},
+		},
+	}
+
+	client, err := u.AccountClientE()
+	require.NoError(t, err)
+	assert.Equal(t, "ACCT-UNIQUE", client.Config.Profile)
+	assert.Equal(t, "https://accounts-unique.cloud.databricks.com", client.Config.Host)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", client.Config.AccountID)
+}
+
+func TestAccountClientE_Memoizes(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	setupAccountDatabricksCfg(t)
+
+	u := &Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				AccountHost: "https://accounts-unique.cloud.databricks.com",
+			},
+		},
+	}
+
+	c1, err := u.AccountClientE()
+	require.NoError(t, err)
+	c2, err := u.AccountClientE()
+	require.NoError(t, err)
+	assert.Same(t, c1, c2, "expected AccountClientE to memoize")
+}
+
+func TestAccountClientE_ClearReResolves(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+	setupAccountDatabricksCfg(t)
+
+	u := &Ucm{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				AccountHost: "https://accounts-unique.cloud.databricks.com",
+			},
+		},
+	}
+
+	c1, err := u.AccountClientE()
+	require.NoError(t, err)
+
+	u.ClearAccountClient()
+	c2, err := u.AccountClientE()
+	require.NoError(t, err)
+	assert.NotSame(t, c1, c2, "expected ClearAccountClient to reset memoization")
+}
+
+func TestSetAccountClient_OverridesBuilder(t *testing.T) {
+	u := &Ucm{}
+	injected := &databricks.AccountClient{}
+	u.SetAccountClient(injected)
+
+	got, err := u.AccountClientE()
+	require.NoError(t, err)
+	assert.Same(t, injected, got, "expected SetAccountClient to inject the given client")
+}

--- a/ucm/config/workspace.go
+++ b/ucm/config/workspace.go
@@ -14,6 +14,13 @@ type Workspace struct {
 	Host    string `json:"host,omitempty"`
 	Profile string `json:"profile,omitempty"`
 
+	// AccountHost is the Databricks accounts endpoint used to construct the
+	// account client (e.g. "https://accounts.cloud.databricks.com"). UCM
+	// resolves account-scoped resources (metastores, metastore assignments)
+	// via this host while Host stays workspace-scoped — see
+	// ucm/account_client.go.
+	AccountHost string `json:"account_host,omitempty"`
+
 	// RootPath is the workspace filesystem root for this deployment. Defaults
 	// to "~/databricks/ucm/<name>/<target>" via DefineDefaultWorkspaceRoot and
 	// is expanded to "/Workspace/Users/<user>/..." by ExpandWorkspaceRoot.

--- a/ucm/ucm.go
+++ b/ucm/ucm.go
@@ -64,6 +64,11 @@ type Ucm struct {
 	// Initialized lazily by WorkspaceClientE via initClientOnce.
 	getClient func() (*databricks.WorkspaceClient, error)
 
+	// getAccountClient memoizes the account client built from
+	// Config.Workspace. Initialized lazily by AccountClientE via
+	// initAccountClientOnce.
+	getAccountClient func() (*databricks.AccountClient, error)
+
 	Metrics Metrics
 }
 


### PR DESCRIPTION
Closes #99

## Summary
- Add `ucm.AccountClientE/AccountClient/SetAccountClient/ClearAccountClient` (parallel to the workspace client).
- Add `Config.Workspace.AccountHost` field for the account-side endpoint.
- Add `cmd/ucm/utils.MustAccountClient` PreRunE hook (mirrors `MustWorkspaceClient`).
- Remove the `TODO(#99)` comment from the workspace-client hook's doc.
- Unit tests at engine and CLI layers.
- Metastore-verb demonstration filed as follow-up #165.

## Why
UCM's v1 design requires both clients (workspace for catalog/schema/grant; account for metastores). Sub-project A.iii.1 (PR #98) shipped workspace-only; this fills the gap. Future metastore verbs (filed at #165) will exercise the account client end-to-end.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`