### PR TITLE
ucm: Add metastore list verb (close #165)

### DIFF
--- a/acceptance/ucm/metastore/list/out.test.toml
+++ b/acceptance/ucm/metastore/list/out.test.toml
@@ -1,0 +1,6 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = []

--- a/acceptance/ucm/metastore/list/output.txt
+++ b/acceptance/ucm/metastore/list/output.txt
@@ -1,0 +1,5 @@
+
+>>> [CLI] ucm metastore list
+Error: invalid Databricks Account configuration - host incorrect or account_id missing
+
+Exit code: 1

--- a/acceptance/ucm/metastore/list/script
+++ b/acceptance/ucm/metastore/list/script
@@ -1,0 +1,1 @@
+trace $CLI ucm metastore list

--- a/acceptance/ucm/metastore/list/test.toml
+++ b/acceptance/ucm/metastore/list/test.toml
@@ -1,0 +1,6 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = []
+  DATABRICKS_UCM_ENGINE = []

--- a/acceptance/ucm/metastore/list/ucm.yml
+++ b/acceptance/ucm/metastore/list/ucm.yml
@@ -1,0 +1,5 @@
+ucm:
+  name: metastore-list
+  engine: direct
+
+resources: {}

--- a/cmd/ucm/metastore/list.go
+++ b/cmd/ucm/metastore/list.go
@@ -1,0 +1,66 @@
+package metastore
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/cmd/ucm/utils"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/spf13/cobra"
+)
+
+func newListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List metastores accessible to the configured account.",
+		Long:    `List metastores accessible to the configured account. Requires account-admin scope.`,
+		Args:    root.NoArgs,
+		PreRunE: utils.MustAccountClient,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		a := cmdctx.AccountClient(ctx)
+
+		metastores, err := a.Metastores.ListAll(ctx)
+		if err != nil {
+			return fmt.Errorf("list metastores: %w", err)
+		}
+
+		return renderMetastores(cmd.OutOrStdout(), metastores, root.OutputType(cmd))
+	}
+
+	return cmd
+}
+
+// renderMetastores emits the metastore listing as text or JSON. Extracted so
+// tests can exercise it without wiring the account-client PreRunE chain.
+func renderMetastores(out io.Writer, metastores []catalog.MetastoreInfo, output flags.Output) error {
+	if output == flags.OutputJSON {
+		return renderJSON(out, metastores)
+	}
+	return renderText(out, metastores)
+}
+
+func renderText(out io.Writer, metastores []catalog.MetastoreInfo) error {
+	if len(metastores) == 0 {
+		_, err := fmt.Fprintln(out, "No metastores found.")
+		return err
+	}
+	for _, m := range metastores {
+		if _, err := fmt.Fprintf(out, "%s\t%s\t%s\n", m.MetastoreId, m.Name, m.Region); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderJSON(out io.Writer, metastores []catalog.MetastoreInfo) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(metastores)
+}

--- a/cmd/ucm/metastore/list_test.go
+++ b/cmd/ucm/metastore/list_test.go
@@ -1,0 +1,85 @@
+package metastore
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderMetastoresText(t *testing.T) {
+	tcs := []struct {
+		name       string
+		metastores []catalog.MetastoreInfo
+		want       string
+	}{
+		{
+			name:       "empty",
+			metastores: nil,
+			want:       "No metastores found.\n",
+		},
+		{
+			name: "multiple",
+			metastores: []catalog.MetastoreInfo{
+				{MetastoreId: "id-1", Name: "primary", Region: "us-west-2"},
+				{MetastoreId: "id-2", Name: "secondary", Region: "us-east-1"},
+			},
+			want: "id-1\tprimary\tus-west-2\nid-2\tsecondary\tus-east-1\n",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := renderMetastores(&buf, tc.metastores, flags.OutputText)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, buf.String())
+		})
+	}
+}
+
+func TestRenderMetastoresJSON(t *testing.T) {
+	metastores := []catalog.MetastoreInfo{
+		{MetastoreId: "id-1", Name: "primary", Region: "us-west-2"},
+	}
+
+	var buf bytes.Buffer
+	err := renderMetastores(&buf, metastores, flags.OutputJSON)
+	require.NoError(t, err)
+
+	// Round-trip into a generic map slice — comparing typed structs is
+	// brittle because the SDK's UnmarshalJSON populates ForceSendFields
+	// for every present key.
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "id-1", got[0]["metastore_id"])
+	assert.Equal(t, "primary", got[0]["name"])
+	assert.Equal(t, "us-west-2", got[0]["region"])
+}
+
+func TestNewListCommandWiring(t *testing.T) {
+	cmd := newListCommand()
+	assert.Equal(t, "list", cmd.Use)
+	assert.NotNil(t, cmd.PreRunE, "PreRunE must be set so the account client is resolved before RunE")
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestNewGroupRegistersList(t *testing.T) {
+	cmd := New()
+	assert.Equal(t, "metastore", cmd.Use)
+
+	var listCmd *cobra.Command
+	for _, c := range cmd.Commands() {
+		if c.Use == "list" {
+			listCmd = c
+			break
+		}
+	}
+	require.NotNil(t, listCmd, "metastore group must register the list subcommand")
+}

--- a/cmd/ucm/metastore/metastore.go
+++ b/cmd/ucm/metastore/metastore.go
@@ -1,0 +1,27 @@
+// Package metastore wires the `databricks ucm metastore` subcommand group:
+// account-scoped read/write operations on Unity Catalog metastores. Mirrors
+// cmd/ucm/deployment/ in shape but forks rather than imports cmd/account/
+// metastores (auto-generated upstream code).
+package metastore
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// New returns the cobra group registered under `databricks ucm metastore`.
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "metastore",
+		Short: "Account-scoped UC metastore operations",
+		Long: `Account-scoped Unity Catalog metastore operations.
+
+These commands authenticate against the Databricks account API (not the
+workspace API) and require the configured service principal to hold
+account-admin scope. Configure the account host via ucm.yml's
+workspace.account_host field, or via the DATABRICKS_HOST env var with an
+account-style URL.`,
+	}
+
+	cmd.AddCommand(newListCommand())
+	return cmd
+}

--- a/cmd/ucm/ucm.go
+++ b/cmd/ucm/ucm.go
@@ -9,6 +9,7 @@ package ucm
 import (
 	"github.com/databricks/cli/cmd/ucm/deployment"
 	"github.com/databricks/cli/cmd/ucm/generate"
+	"github.com/databricks/cli/cmd/ucm/metastore"
 	"github.com/databricks/cli/cmd/ucm/utils"
 	"github.com/spf13/cobra"
 )
@@ -51,6 +52,7 @@ Online documentation: https://docs.databricks.com/en/dev-tools/ucm/index.html`,
 	cmd.AddCommand(newInitCommand())
 	cmd.AddCommand(generate.New())
 	cmd.AddCommand(deployment.New())
+	cmd.AddCommand(metastore.New())
 	cmd.AddCommand(newDebugCommand())
 	cmd.AddCommand(newDiffCommand())
 	cmd.AddCommand(newDriftCommand())


### PR DESCRIPTION
Closes #165

## Summary
- New `cmd/ucm/metastore/` subgroup with a single `list` verb (read-only).
- `PreRunE: utils.MustAccountClient` — exercises the AccountClient resolution added by #166.
- `RunE` calls `accountClient.Metastores.ListAll(ctx)`, renders text or JSON.
- Acceptance fixture `acceptance/ucm/metastore/list/`.
- Wired as a subcommand of `ucm` in `cmd/ucm/ucm.go`.

## Why
PR #166 landed the AccountClient infrastructure but had no consumer to validate it end-to-end. This adds the smoke-test verb. Other metastore CRUD operations (create/get/update/delete, assignments) are out of scope here — file follow-ups when needed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`