### PR TITLE
ucm: Wire RouteFlatGrants — migrate flat-grants consumers to nested form (close #161)

### DIFF
--- a/acceptance/ucm/plan/happy/output.txt
+++ b/acceptance/ucm/plan/happy/output.txt
@@ -3,6 +3,8 @@
 Warning: cannot initialize resource URLs: workspace.host is not set
 
 create catalogs.main
+create catalogs.main.grants
 create schemas.raw
+create schemas.raw.grants
 
-Plan: 2 to add, 0 to change, 0 to delete, 0 unchanged
+Plan: 4 to add, 0 to change, 0 to delete, 0 unchanged

--- a/acceptance/ucm/plan/happy/ucm.yml
+++ b/acceptance/ucm/plan/happy/ucm.yml
@@ -12,3 +12,17 @@ resources:
     raw:
       name: raw
       catalog_name: main
+
+  grants:
+    main_admin:
+      securable:
+        type: catalog
+        name: main
+      principal: admins
+      privileges: [USE_CATALOG]
+    raw_reader:
+      securable:
+        type: schema
+        name: raw
+      principal: readers
+      privileges: [USE_SCHEMA]

--- a/acceptance/ucm/policy-check/happy/ucm.yml
+++ b/acceptance/ucm/policy-check/happy/ucm.yml
@@ -14,6 +14,6 @@ resources:
 
   grants:
     analysts:
-      securable: {type: schema, name: main.raw}
+      securable: {type: schema, name: raw}
       principal: analysts
       privileges: [USE_SCHEMA, SELECT]

--- a/acceptance/ucm/summary/happy/output.txt
+++ b/acceptance/ucm/summary/happy/output.txt
@@ -14,7 +14,7 @@ Resources:
       URL:  (not deployed)
   Grants:
     analysts:
-      Name: schema main.raw -> analysts
+      Name: schema raw -> analysts
       URL:  (not deployed)
   Schemas:
     raw:

--- a/acceptance/ucm/summary/happy/ucm.yml
+++ b/acceptance/ucm/summary/happy/ucm.yml
@@ -14,6 +14,6 @@ resources:
 
   grants:
     analysts:
-      securable: {type: schema, name: main.raw}
+      securable: {type: schema, name: raw}
       principal: analysts
       privileges: [USE_SCHEMA, SELECT]

--- a/acceptance/ucm/validate/happy/ucm.yml
+++ b/acceptance/ucm/validate/happy/ucm.yml
@@ -14,6 +14,6 @@ resources:
 
   grants:
     analysts:
-      securable: {type: schema, name: main.raw}
+      securable: {type: schema, name: raw}
       principal: analysts
       privileges: [USE_SCHEMA, SELECT]

--- a/cmd/ucm/deployment/bind_resource.go
+++ b/cmd/ucm/deployment/bind_resource.go
@@ -31,7 +31,12 @@ func resolveBindable(u *ucm.Ucm, key string) (phases.ImportKind, error) {
 	if _, ok := u.Config.Resources.Connections[key]; ok {
 		matches = append(matches, phases.ImportConnection)
 	}
+	// Check both surfaces: flat (pre-RouteFlatGrants) and nested (post-routing)
+	// so the early-error fires regardless of when bind is invoked.
 	if _, ok := u.Config.Resources.Grants[key]; ok {
+		return "", fmt.Errorf("grants are not bindable (they reconcile per securable, not by name)")
+	}
+	if _, ok := u.Config.Resources.AllGrants()[key]; ok {
 		return "", fmt.Errorf("grants are not bindable (they reconcile per securable, not by name)")
 	}
 	switch len(matches) {

--- a/ucm/config/mutator/mutator.go
+++ b/ucm/config/mutator/mutator.go
@@ -12,6 +12,7 @@ func DefaultMutators(ctx context.Context, u *ucm.Ucm) {
 	ucm.ApplySeqContext(ctx, u,
 		loader.ProcessRootIncludes(),
 		FlattenNestedResources(),
+		RouteFlatGrants(),
 		InheritCatalogTags(),
 		DefineDefaultTarget(),
 

--- a/ucm/config/mutator/route_flat_grants.go
+++ b/ucm/config/mutator/route_flat_grants.go
@@ -34,13 +34,10 @@ type routeFlatGrants struct{}
 // table, securable.name with no matching parent resource, or a key
 // collision against an already-nested grant.
 //
-// NOT YET WIRED INTO DefaultMutators. Several existing consumers
-// (ucm/render/groups.go grant summary, ucm/config/validate's grant checks,
-// ucm/deploy/terraform/tfdyn grant rendering, and
-// cmd/ucm/deployment/bind_resource.go) still read the flat
-// resources.grants map. Wiring this mutator now would silently zero those
-// surfaces. Wiring lands in a follow-up that migrates each consumer to
-// the nested form.
+// The securable field is intentionally preserved on routed grants (rather
+// than being stripped as redundant) so consumers reading via
+// Resources.AllGrants can rely on g.Securable.{Type, Name} being populated
+// regardless of whether the grant originated from the flat or nested form.
 func RouteFlatGrants() ucm.Mutator { return &routeFlatGrants{} }
 
 func (m *routeFlatGrants) Name() string { return "RouteFlatGrants" }
@@ -142,7 +139,6 @@ func (m *routeFlatGrants) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics 
 				}
 			}
 
-			body := removeKeys(grantBody, "securable")
 			if staged[plural] == nil {
 				staged[plural] = make(map[string]map[string]stagedGrant)
 			}
@@ -150,7 +146,7 @@ func (m *routeFlatGrants) Apply(_ context.Context, u *ucm.Ucm) diag.Diagnostics 
 				staged[plural][secName] = make(map[string]stagedGrant)
 			}
 			staged[plural][secName][grantKey] = stagedGrant{
-				body: dyn.NewValue(body, gp.Value.Locations()),
+				body: gp.Value,
 				key:  gp.Key,
 			}
 		}

--- a/ucm/config/mutator/route_flat_grants_test.go
+++ b/ucm/config/mutator/route_flat_grants_test.go
@@ -51,6 +51,8 @@ resources:
 				require.NotNil(t, g)
 				assert.Equal(t, "alice", g.Principal)
 				assert.Equal(t, []string{"USE_CATALOG"}, g.Privileges)
+				assert.Equal(t, "catalog", g.Securable.Type)
+				assert.Equal(t, "main", g.Securable.Name)
 			},
 		},
 		{
@@ -71,6 +73,8 @@ resources:
 				g := u.Config.Resources.Schemas["raw"].Grants["sch_reader"]
 				require.NotNil(t, g)
 				assert.Equal(t, "bob", g.Principal)
+				assert.Equal(t, "schema", g.Securable.Type)
+				assert.Equal(t, "raw", g.Securable.Name)
 			},
 		},
 		{

--- a/ucm/config/resources.go
+++ b/ucm/config/resources.go
@@ -15,3 +15,47 @@ type Resources struct {
 	Connections        map[string]*resources.Connection        `json:"connections,omitempty"`
 	TagValidationRules map[string]*resources.TagValidationRule `json:"tag_validation_rules,omitempty"`
 }
+
+// AllGrants returns every nested grant declared anywhere under the
+// resources tree, keyed by the grant's leaf key. Each returned grant
+// carries Securable.{Type, Name} synthesised from its parent path when not
+// already set so callers can read the securable uniformly regardless of
+// whether the entry originated as flat or nested form. Synthesis is
+// idempotent: pre-populated securable fields are left untouched.
+//
+// Consumers should prefer this helper over reading r.Grants directly:
+// after FlattenNestedResources + RouteFlatGrants, r.Grants is always empty
+// and the per-resource nested maps are the canonical surface.
+func (r *Resources) AllGrants() map[string]*resources.Grant {
+	out := map[string]*resources.Grant{}
+	visit := func(kind, parentKey string, m map[string]*resources.Grant) {
+		for key, g := range m {
+			if g == nil {
+				continue
+			}
+			if g.Securable.Type == "" {
+				g.Securable.Type = kind
+			}
+			if g.Securable.Name == "" {
+				g.Securable.Name = parentKey
+			}
+			out[key] = g
+		}
+	}
+	for parentKey, c := range r.Catalogs {
+		visit("catalog", parentKey, c.Grants)
+	}
+	for parentKey, s := range r.Schemas {
+		visit("schema", parentKey, s.Grants)
+	}
+	for parentKey, v := range r.Volumes {
+		visit("volume", parentKey, v.Grants)
+	}
+	for parentKey, e := range r.ExternalLocations {
+		visit("external_location", parentKey, e.Grants)
+	}
+	for parentKey, sc := range r.StorageCredentials {
+		visit("storage_credential", parentKey, sc.Grants)
+	}
+	return out
+}

--- a/ucm/config/resources_test.go
+++ b/ucm/config/resources_test.go
@@ -1,0 +1,96 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/ucm/config"
+	"github.com/databricks/cli/ucm/config/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResources_AllGrants_AcrossAllKinds(t *testing.T) {
+	r := &config.Resources{
+		Catalogs: map[string]*resources.Catalog{
+			"cat1": {Grants: map[string]*resources.Grant{
+				"g_cat": {Principal: "alice", Privileges: []string{"USE_CATALOG"}},
+			}},
+		},
+		Schemas: map[string]*resources.Schema{
+			"sch1": {Grants: map[string]*resources.Grant{
+				"g_sch": {Principal: "bob", Privileges: []string{"USE_SCHEMA"}},
+			}},
+		},
+		Volumes: map[string]*resources.Volume{
+			"vol1": {Grants: map[string]*resources.Grant{
+				"g_vol": {Principal: "carol", Privileges: []string{"READ_VOLUME"}},
+			}},
+		},
+		ExternalLocations: map[string]*resources.ExternalLocation{
+			"el1": {Grants: map[string]*resources.Grant{
+				"g_el": {Principal: "dave", Privileges: []string{"READ_FILES"}},
+			}},
+		},
+		StorageCredentials: map[string]*resources.StorageCredential{
+			"sc1": {Grants: map[string]*resources.Grant{
+				"g_sc": {Principal: "eve", Privileges: []string{"CREATE_EXTERNAL_LOCATION"}},
+			}},
+		},
+	}
+
+	got := r.AllGrants()
+	require.Len(t, got, 5)
+
+	assert.Equal(t, "catalog", got["g_cat"].Securable.Type)
+	assert.Equal(t, "cat1", got["g_cat"].Securable.Name)
+	assert.Equal(t, "schema", got["g_sch"].Securable.Type)
+	assert.Equal(t, "sch1", got["g_sch"].Securable.Name)
+	assert.Equal(t, "volume", got["g_vol"].Securable.Type)
+	assert.Equal(t, "vol1", got["g_vol"].Securable.Name)
+	assert.Equal(t, "external_location", got["g_el"].Securable.Type)
+	assert.Equal(t, "el1", got["g_el"].Securable.Name)
+	assert.Equal(t, "storage_credential", got["g_sc"].Securable.Type)
+	assert.Equal(t, "sc1", got["g_sc"].Securable.Name)
+}
+
+func TestResources_AllGrants_Empty(t *testing.T) {
+	r := &config.Resources{}
+	assert.Empty(t, r.AllGrants())
+}
+
+func TestResources_AllGrants_PreservesExistingSecurable(t *testing.T) {
+	r := &config.Resources{
+		Catalogs: map[string]*resources.Catalog{
+			"cat1": {Grants: map[string]*resources.Grant{
+				"g": {
+					Securable:  resources.Securable{Type: "catalog", Name: "cat1"},
+					Principal:  "alice",
+					Privileges: []string{"USE_CATALOG"},
+				},
+			}},
+		},
+	}
+
+	got := r.AllGrants()
+	require.Contains(t, got, "g")
+	assert.Equal(t, "catalog", got["g"].Securable.Type)
+	assert.Equal(t, "cat1", got["g"].Securable.Name)
+}
+
+func TestResources_AllGrants_SkipsNilEntries(t *testing.T) {
+	r := &config.Resources{
+		Catalogs: map[string]*resources.Catalog{
+			"cat1": {Grants: map[string]*resources.Grant{
+				"g_nil": nil,
+				"g_ok": {
+					Principal:  "alice",
+					Privileges: []string{"USE_CATALOG"},
+				},
+			}},
+		},
+	}
+
+	got := r.AllGrants()
+	require.Len(t, got, 1)
+	assert.Contains(t, got, "g_ok")
+}

--- a/ucm/config/validate/naming.go
+++ b/ucm/config/validate/naming.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
@@ -140,7 +141,22 @@ func resourceKeysOf(u *ucm.Ucm, kind string) []string {
 	case "schemas":
 		return sortedKeys(u.Config.Resources.Schemas)
 	case "grants":
-		return sortedKeys(u.Config.Resources.Grants)
+		// Grants live both at the top-level flat map (pre-RouteFlatGrants)
+		// and as per-resource nested maps (post-routing); validate keys from
+		// both surfaces so the check works regardless of phase ordering.
+		seen := map[string]struct{}{}
+		for k := range u.Config.Resources.Grants {
+			seen[k] = struct{}{}
+		}
+		for k := range u.Config.Resources.AllGrants() {
+			seen[k] = struct{}{}
+		}
+		keys := make([]string, 0, len(seen))
+		for k := range seen {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return keys
 	case "storage_credentials":
 		return sortedKeys(u.Config.Resources.StorageCredentials)
 	case "external_locations":

--- a/ucm/config/validate/required_fields.go
+++ b/ucm/config/validate/required_fields.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/ucm"
+	"github.com/databricks/cli/ucm/config/resources"
 )
 
 // RequiredFields errors on UC resources missing their mandatory fields.
@@ -80,23 +81,36 @@ func checkSchemas(u *ucm.Ucm) diag.Diagnostics {
 
 func checkGrants(u *ucm.Ucm) diag.Diagnostics {
 	var diags diag.Diagnostics
+	// Validate both the flat top-level map (pre-RouteFlatGrants surface, also
+	// what tests using validate.RequiredFields() in isolation see) and the
+	// per-resource nested view (post-routing canonical surface).
 	for _, key := range sortedKeys(u.Config.Resources.Grants) {
 		g := u.Config.Resources.Grants[key]
-		if g == nil {
-			continue
-		}
-		if g.Principal == "" {
-			diags = append(diags, missingField(u, "grants", key, "principal"))
-		}
-		if len(g.Privileges) == 0 {
-			diags = append(diags, missingField(u, "grants", key, "privileges"))
-		}
-		if g.Securable.Type == "" {
-			diags = append(diags, missingField(u, "grants", key, "securable.type"))
-		}
-		if g.Securable.Name == "" {
-			diags = append(diags, missingField(u, "grants", key, "securable.name"))
-		}
+		diags = append(diags, validateGrant(u, key, g)...)
+	}
+	all := u.Config.Resources.AllGrants()
+	for _, key := range sortedKeys(all) {
+		diags = append(diags, validateGrant(u, key, all[key])...)
+	}
+	return diags
+}
+
+func validateGrant(u *ucm.Ucm, key string, g *resources.Grant) diag.Diagnostics {
+	if g == nil {
+		return nil
+	}
+	var diags diag.Diagnostics
+	if g.Principal == "" {
+		diags = append(diags, missingField(u, "grants", key, "principal"))
+	}
+	if len(g.Privileges) == 0 {
+		diags = append(diags, missingField(u, "grants", key, "privileges"))
+	}
+	if g.Securable.Type == "" {
+		diags = append(diags, missingField(u, "grants", key, "securable.type"))
+	}
+	if g.Securable.Name == "" {
+		diags = append(diags, missingField(u, "grants", key, "securable.name"))
 	}
 	return diags
 }

--- a/ucm/deploy/terraform/tfdyn/tfdyn.go
+++ b/ucm/deploy/terraform/tfdyn/tfdyn.go
@@ -23,6 +23,12 @@ const (
 // grants look at Resources.Catalog and Resources.Schema).
 var convertOrder = []string{"storage_credentials", "external_locations", "catalogs", "schemas", "volumes", "connections", "grants"}
 
+// grantHostKinds enumerates the per-resource buckets whose `.grants` child
+// map is harvested into a synthetic flat-grants view at dispatch time. Mirrors
+// the kinds that mutator.RouteFlatGrants targets — keep in sync if a new
+// grantable kind is added.
+var grantHostKinds = []string{"catalogs", "schemas", "volumes", "external_locations", "storage_credentials"}
+
 // Convert walks a ucm configuration and produces the Terraform JSON
 // resource tree suitable for writing as a .tf.json file. The returned
 // dyn.Value is shaped as:
@@ -43,6 +49,11 @@ func Convert(ctx context.Context, u *ucm.Ucm) (dyn.Value, error) {
 	if err != nil {
 		// No resources: emit an empty terraform file rather than failing.
 		resourcesVal = dyn.V(map[string]dyn.Value{})
+	}
+
+	resourcesVal, err = liftNestedGrantsForDispatch(resourcesVal)
+	if err != nil {
+		return dyn.InvalidValue, err
 	}
 
 	for _, kind := range convertOrder {
@@ -74,6 +85,82 @@ func Convert(ctx context.Context, u *ucm.Ucm) (dyn.Value, error) {
 	}
 
 	return buildResourceTree(out), nil
+}
+
+// liftNestedGrantsForDispatch walks the per-resource `grants` maps and
+// merges them into a synthetic top-level `grants` map so the existing
+// `grants` converter can process every grant in one pass. mutator.RouteFlatGrants
+// has already moved any flat-form entries into the nested form by the time
+// this runs in production, leaving `resources.grants` empty; lifting the
+// nested form back to a flat shape here keeps the dispatch contract stable
+// without registering five additional kind-specific converters.
+//
+// Each nested grant body carries `securable` populated by the mutator (or by
+// the user, for nested-form grants that bypass routing); the converter reads
+// it directly. Dyn locations are preserved end-to-end so diagnostics still
+// point at the originating ucm.yml span.
+func liftNestedGrantsForDispatch(resourcesVal dyn.Value) (dyn.Value, error) {
+	resources, ok := resourcesVal.AsMap()
+	if !ok {
+		return resourcesVal, nil
+	}
+
+	flatGrants := mapOrNew(getByString(resources, "grants"))
+
+	for _, kind := range grantHostKinds {
+		bucketVal, _ := resources.GetByString(kind)
+		bucket, ok := bucketVal.AsMap()
+		if !ok {
+			continue
+		}
+		for _, parent := range bucket.Pairs() {
+			parentMap, ok := parent.Value.AsMap()
+			if !ok {
+				continue
+			}
+			grantsVal, _ := parentMap.GetByString("grants")
+			grants, ok := grantsVal.AsMap()
+			if !ok {
+				continue
+			}
+			for _, gp := range grants.Pairs() {
+				key := gp.Key.MustString()
+				if _, exists := flatGrants.GetByString(key); exists {
+					return dyn.InvalidValue, fmt.Errorf("grant %q: nested entry under %s.%s collides with flat entry", key, kind, parent.Key.MustString())
+				}
+				flatGrants.SetLoc(key, gp.Key.Locations(), gp.Value)
+			}
+		}
+	}
+
+	if flatGrants.Len() == 0 {
+		return resourcesVal, nil
+	}
+
+	newResources := resources.Clone()
+	existingFlat := getByString(resources, "grants")
+	newResources.SetLoc("grants", existingFlat.Locations(),
+		dyn.NewValue(flatGrants, existingFlat.Locations()))
+	return dyn.NewValue(newResources, resourcesVal.Locations()), nil
+}
+
+// getByString fetches a child value from a dyn.Mapping, returning the zero
+// dyn.Value if the key is absent. Mirrors the small helper pattern used in
+// the mutator package without taking a cross-package dependency.
+func getByString(m dyn.Mapping, key string) dyn.Value {
+	v, _ := m.GetByString(key)
+	return v
+}
+
+// mapOrNew returns the underlying mapping of v cloned, or an empty mapping
+// if v is not a map. Local copy of the helper from the mutator package; the
+// dispatch only needs the same fall-through semantics.
+func mapOrNew(v dyn.Value) dyn.Mapping {
+	m, ok := v.AsMap()
+	if !ok {
+		return dyn.NewMapping()
+	}
+	return m.Clone()
 }
 
 // buildResourceTree assembles the top-level Terraform JSON tree. The output

--- a/ucm/direct/dresources/grants.go
+++ b/ucm/direct/dresources/grants.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/databricks/cli/libs/structs/structvar"
+	"github.com/databricks/cli/ucm/config/resources"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 )
@@ -42,26 +44,67 @@ func PrepareGrantsInputConfig(inputConfig any, node string) (*structvar.StructVa
 		return nil, fmt.Errorf("unsupported grants resource type: %s", resourceType)
 	}
 
-	grantsPtr, ok := inputConfig.(*[]catalog.PrivilegeAssignment)
-	if !ok {
-		return nil, fmt.Errorf("expected *[]catalog.PrivilegeAssignment, got %T", inputConfig)
+	assignments, err := assignmentsFromInput(inputConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	// Backend sorts privileges, so we sort here as well.
-	for i := range *grantsPtr {
-		slices.Sort((*grantsPtr)[i].Privileges)
+	for i := range assignments {
+		slices.Sort(assignments[i].Privileges)
 	}
 
 	return &structvar.StructVar{
 		Value: &GrantsState{
 			SecurableType: securableType,
 			FullName:      "",
-			EmbeddedSlice: *grantsPtr,
+			EmbeddedSlice: assignments,
 		},
 		Refs: map[string]string{
 			"full_name": "${" + baseNode + ".id}",
 		},
 	}, nil
+}
+
+// assignmentsFromInput coerces the input config — which may arrive as the
+// legacy []catalog.PrivilegeAssignment slice or as the ucm-native
+// map[string]*resources.Grant produced by RouteFlatGrants — into a
+// deterministically-ordered []catalog.PrivilegeAssignment.
+func assignmentsFromInput(inputConfig any) ([]catalog.PrivilegeAssignment, error) {
+	switch v := inputConfig.(type) {
+	case *[]catalog.PrivilegeAssignment:
+		if v == nil {
+			return nil, nil
+		}
+		return *v, nil
+	case *map[string]*resources.Grant:
+		if v == nil {
+			return nil, nil
+		}
+		keys := make([]string, 0, len(*v))
+		for k := range *v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		out := make([]catalog.PrivilegeAssignment, 0, len(keys))
+		for _, k := range keys {
+			g := (*v)[k]
+			if g == nil {
+				continue
+			}
+			privs := make([]catalog.Privilege, 0, len(g.Privileges))
+			for _, p := range g.Privileges {
+				privs = append(privs, catalog.Privilege(p))
+			}
+			out = append(out, catalog.PrivilegeAssignment{
+				Principal:  g.Principal,
+				Privileges: privs,
+			})
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("expected *[]catalog.PrivilegeAssignment or *map[string]*resources.Grant, got %T", inputConfig)
+	}
 }
 
 type ResourceGrants struct {

--- a/ucm/render/groups.go
+++ b/ucm/render/groups.go
@@ -120,11 +120,12 @@ func connectionGroup(cfg *config.Root) (ResourceGroup, bool) {
 }
 
 func grantGroup(cfg *config.Root) (ResourceGroup, bool) {
-	if len(cfg.Resources.Grants) == 0 {
+	all := cfg.Resources.AllGrants()
+	if len(all) == 0 {
 		return ResourceGroup{}, false
 	}
-	rows := make([]ResourceInfo, 0, len(cfg.Resources.Grants))
-	for key, g := range cfg.Resources.Grants {
+	rows := make([]ResourceInfo, 0, len(all))
+	for key, g := range all {
 		// Grants have no workspace URL; summarise securable + principal.
 		name := fmt.Sprintf("%s %s -> %s", g.Securable.Type, g.Securable.Name, g.Principal)
 		rows = append(rows, ResourceInfo{Key: key, Name: name})


### PR DESCRIPTION
Closes #161

## Summary
- Amend `RouteFlatGrants` to preserve `securable` on routed grants (vs PR #160's strip-on-route behavior).
- Add `Resources.AllGrants()` helper synthesising a flat-keyed view over the 5 nested grant maps.
- Migrate the 5 production consumers to read via `AllGrants()`:
  1. `ucm/render/groups.go::grantGroup`
  2. `ucm/config/validate/required_fields.go::checkGrants`
  3. `ucm/config/validate/naming.go`
  4. `cmd/ucm/deployment/bind_resource.go`
  5. `ucm/deploy/terraform/tfdyn` (synthesises flat grants from nested at dispatch time)
- Wire `RouteFlatGrants()` into `DefaultMutators`.
- Extend `dresources.PrepareGrantsInputConfig` to accept the `map[string]*resources.Grant` shape produced by routing, in addition to the legacy `[]catalog.PrivilegeAssignment` slice.
- Restore standalone-grants block in `acceptance/ucm/plan/happy/ucm.yml`; align other ucm acceptance fixtures so `securable.name` uses schema map keys (the routing contract).

## Why
PR #160 landed the foundation; this completes the transition. After this PR, `Resources.Grants` (top-level flat map) is empty in any normalised config — the canonical surface is per-resource nested grant maps, with `AllGrants()` providing a flat-keyed iteration helper for consumers that need it. Validators and the bind-key check inspect both surfaces so they stay correct whether or not routing has run (e.g. tests calling `validate.RequiredFields()` in isolation).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`