### PR TITLE
ucm: Tabwriter-aligned columns + header for metastore list

### DIFF
--- a/cmd/ucm/metastore/list.go
+++ b/cmd/ucm/metastore/list.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"text/tabwriter"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/cmd/ucm/utils"
@@ -51,12 +52,16 @@ func renderText(out io.Writer, metastores []catalog.MetastoreInfo) error {
 		_, err := fmt.Fprintln(out, "No metastores found.")
 		return err
 	}
+	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ID\tNAME\tREGION"); err != nil {
+		return err
+	}
 	for _, m := range metastores {
-		if _, err := fmt.Fprintf(out, "%s\t%s\t%s\n", m.MetastoreId, m.Name, m.Region); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", m.MetastoreId, m.Name, m.Region); err != nil {
 			return err
 		}
 	}
-	return nil
+	return tw.Flush()
 }
 
 func renderJSON(out io.Writer, metastores []catalog.MetastoreInfo) error {

--- a/cmd/ucm/metastore/list_test.go
+++ b/cmd/ucm/metastore/list_test.go
@@ -29,7 +29,7 @@ func TestRenderMetastoresText(t *testing.T) {
 				{MetastoreId: "id-1", Name: "primary", Region: "us-west-2"},
 				{MetastoreId: "id-2", Name: "secondary", Region: "us-east-1"},
 			},
-			want: "id-1\tprimary\tus-west-2\nid-2\tsecondary\tus-east-1\n",
+			want: "ID    NAME       REGION\nid-1  primary    us-west-2\nid-2  secondary  us-east-1\n",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- `ucm metastore list` now writes a header row `ID  NAME  REGION` and aligns columns via `text/tabwriter` (padding=2, padchar=' ').
- JSON output (`-o json`) unchanged.
- Test updated to match the new column-aligned shape.

## Why
The verb landed in #168 with raw tab-separated rows and no header. With realistic account metastore counts (often 100+) the output was hard to read. The bundle/account list verbs already use a tabwriter convention; UCM matches it now.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/metastore/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm/metastore' -timeout=10m`