### PR TITLE
ucm: Deterministic tfdyn output + nil-Ucm guard (close #26, #27)

### DIFF
--- a/cmd/ucm/utils/options.go
+++ b/cmd/ucm/utils/options.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 
 	"github.com/databricks/cli/ucm"
 	"github.com/databricks/cli/ucm/deploy"
@@ -28,6 +29,9 @@ var BuildPhaseOptionsHook = DefaultBuildPhaseOptions
 // constructor is expensive (binary resolution + working dir) and we only
 // stand it up on first invocation.
 func DefaultBuildPhaseOptions(ctx context.Context, u *ucm.Ucm) (phases.Options, error) {
+	if u == nil {
+		return phases.Options{}, errors.New("ucm: cannot build phase options — ProcessUcm did not return a *ucm.Ucm; ensure the verb's PreRunE chain ran successfully before calling BuildPhaseOptionsHook")
+	}
 	w, err := u.WorkspaceClientE()
 	if err != nil {
 		return phases.Options{}, err

--- a/cmd/ucm/utils/options_test.go
+++ b/cmd/ucm/utils/options_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultBuildPhaseOptions_NilUcmReturnsCleanError covers the defensive
+// guard added for #27. Production callers gate on a non-nil *ucm.Ucm before
+// invoking BuildPhaseOptionsHook, but library-mode embeddings or test
+// shortcuts that skip the harness can reach this path with u == nil.
+// Without the guard the function would panic on `u.WorkspaceClientE()`.
+func TestDefaultBuildPhaseOptions_NilUcmReturnsCleanError(t *testing.T) {
+	_, err := DefaultBuildPhaseOptions(t.Context(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ucm:")
+	assert.Contains(t, err.Error(), "ProcessUcm")
+}

--- a/ucm/deploy/terraform/tfdyn/convert_catalog_test.go
+++ b/ucm/deploy/terraform/tfdyn/convert_catalog_test.go
@@ -1,8 +1,10 @@
 package tfdyn
 
 import (
-	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"encoding/json"
 	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/catalog"
 
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/dyn/convert"
@@ -75,5 +77,40 @@ func TestConvertCatalog(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, tc.want, got.AsAny())
 		})
+	}
+}
+
+// TestConvertCatalog_DeterministicProperties asserts that converting a
+// catalog with multi-key tags produces byte-identical JSON across many
+// iterations. Without explicit key-sorting the underlying Go map's
+// randomized iteration leaks into the emitted properties block.
+func TestConvertCatalog_DeterministicProperties(t *testing.T) {
+	src := resources.Catalog{
+		CreateCatalog: catalog.CreateCatalog{Name: "sales_prod"},
+		Tags: map[string]string{
+			"team": "sales",
+			"env":  "prod",
+			"cost": "alpha",
+			"tier": "gold",
+			"zone": "us-west",
+		},
+	}
+
+	var first []byte
+	for i := range 100 {
+		vin, err := convert.FromTyped(src, dyn.NilValue)
+		require.NoError(t, err)
+
+		out := NewResources()
+		require.NoError(t, catalogConverter{}.Convert(t.Context(), "sales", vin, out))
+
+		buf, err := json.Marshal(out.Catalog["sales"].AsAny())
+		require.NoError(t, err)
+
+		if i == 0 {
+			first = buf
+			continue
+		}
+		require.Equal(t, string(first), string(buf), "iteration %d diverged", i)
 	}
 }

--- a/ucm/deploy/terraform/tfdyn/convert_connection.go
+++ b/ucm/deploy/terraform/tfdyn/convert_connection.go
@@ -31,7 +31,7 @@ func convertConnectionResource(_ context.Context, key string, vin dyn.Value) (dy
 	}
 	pairs = append(pairs, dyn.Pair{
 		Key:   dyn.NewValue("options", optsVal.Locations()),
-		Value: optsVal,
+		Value: sortMapByKeys(optsVal),
 	})
 
 	appendStringIfSet(&pairs, vin, "comment")

--- a/ucm/deploy/terraform/tfdyn/helpers.go
+++ b/ucm/deploy/terraform/tfdyn/helpers.go
@@ -1,6 +1,10 @@
 package tfdyn
 
-import "github.com/databricks/cli/libs/dyn"
+import (
+	"sort"
+
+	"github.com/databricks/cli/libs/dyn"
+)
 
 // appendString adds key=fallback to pairs when vin does not already define
 // the field. If vin sets the field, the caller's value wins and its
@@ -49,13 +53,33 @@ func appendBoolIfSet(pairs *[]dyn.Pair, vin dyn.Value, key string) {
 	})
 }
 
-// mapFromValue returns v as a map-typed dyn.Value when it holds at least
-// one key; otherwise the second return is false so callers can skip
-// emitting an empty map.
+// mapFromValue returns v as a map-typed dyn.Value with pairs sorted by key
+// when v holds at least one entry; otherwise the second return is false so
+// callers can skip emitting an empty map. Sorting matters because typed
+// config Tags / Properties / Options are Go maps (`map[string]string`)
+// whose iteration order leaks into convert.Normalize. Without it the
+// generated tf.json drifts byte-for-byte across runs.
 func mapFromValue(v dyn.Value) (dyn.Value, bool) {
 	m, ok := v.AsMap()
 	if !ok || m.Len() == 0 {
 		return dyn.InvalidValue, false
 	}
-	return v, true
+	return sortMapByKeys(v), true
+}
+
+// sortMapByKeys returns a copy of v whose pairs are sorted lexicographically
+// by key. Non-map values are returned unchanged. The sort is stable and
+// deterministic so callers can build byte-identical tf.json across runs.
+func sortMapByKeys(v dyn.Value) dyn.Value {
+	m, ok := v.AsMap()
+	if !ok {
+		return v
+	}
+	pairs := m.Pairs()
+	sorted := make([]dyn.Pair, len(pairs))
+	copy(sorted, pairs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Key.MustString() < sorted[j].Key.MustString()
+	})
+	return dyn.NewValue(dyn.NewMappingFromPairs(sorted), v.Locations())
 }


### PR DESCRIPTION
Closes #26
Closes #27

## Summary
- **#26**: Sort resource property map keys in tfdyn converters so generated `tf.json` is byte-stable across runs. New `sortMapByKeys` helper in `ucm/deploy/terraform/tfdyn/helpers.go`; `mapFromValue` now returns the sorted view. `convert_connection.go` applies it explicitly to `options` (which uses `AsMap()` directly). 100-iteration determinism test added.
- **#27**: Defensive nil-Ucm guard in `cmd/ucm/utils.DefaultBuildPhaseOptions` so library-mode / test-shortcut callers get a clean error instead of a panic.

## Why
**#26**: `Catalog.Tags`, `Schema.Tags`, `Connection.Options`, and `Connection.Properties` are typed Go maps. After `convert.Normalize` the iteration order leaks into emitted `properties`, causing tf.json byte drift. Sorting at the converter boundary is the smallest blast radius.

**#27**: Today, every production verb gates on `u != nil` before calling `BuildPhaseOptionsHook`, but a future library-mode embedding or test that skipped `ProcessUcm` would reach this path with `u == nil` and panic. Cheap defensive fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/ucm/... ./ucm/...`
- [x] `go test -count=1 ./cmd/ucm/... ./ucm/...`
- [x] `go test ./acceptance -run '^TestAccept/ucm' -timeout=10m`