### PR TITLE
ucm: Recreate volumes/connections on immutable-field drift (close #62)

### DIFF
--- a/ucm/direct/dresources/config_test.go
+++ b/ucm/direct/dresources/config_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestMustLoadConfig(t *testing.T) {
-	// Resources start empty until the resource-struct migration lands.
 	cfg := MustLoadConfig()
 	assert.NotNil(t, cfg)
 }
@@ -15,4 +14,39 @@ func TestMustLoadConfig(t *testing.T) {
 func TestGetResourceConfig(t *testing.T) {
 	// Nonexistent resources return an empty config without panicking.
 	assert.Empty(t, GetResourceConfig("nonexistent").RecreateOnChanges)
+}
+
+// TestVolumeRecreateOnImmutableFields covers #62: UpdateVolumeRequestContent
+// only accepts {comment, new_name, owner}, so any change to a volume's
+// catalog_name, schema_name, storage_location, or volume_type would be
+// silently dropped on Update — without recreate_on_changes the planner loops.
+func TestVolumeRecreateOnImmutableFields(t *testing.T) {
+	cfg := GetResourceConfig("volumes")
+	got := make([]string, 0, len(cfg.RecreateOnChanges))
+	for _, r := range cfg.RecreateOnChanges {
+		got = append(got, r.Field.String())
+	}
+	assert.ElementsMatch(t, []string{
+		"catalog_name",
+		"schema_name",
+		"storage_location",
+		"volume_type",
+	}, got)
+}
+
+// TestConnectionRecreateOnImmutableFields covers #62 for connections:
+// UpdateConnection accepts only {new_name, options, owner}, so changes to
+// connection_type / comment / properties / read_only must trigger recreate.
+func TestConnectionRecreateOnImmutableFields(t *testing.T) {
+	cfg := GetResourceConfig("connections")
+	got := make([]string, 0, len(cfg.RecreateOnChanges))
+	for _, r := range cfg.RecreateOnChanges {
+		got = append(got, r.Field.String())
+	}
+	assert.ElementsMatch(t, []string{
+		"connection_type",
+		"comment",
+		"properties",
+		"read_only",
+	}, got)
 }

--- a/ucm/direct/dresources/connection.go
+++ b/ucm/direct/dresources/connection.go
@@ -59,3 +59,27 @@ func (r *ResourceConnection) DoUpdate(ctx context.Context, id string, config *ca
 func (r *ResourceConnection) DoDelete(ctx context.Context, id string) error {
 	return r.client.Connections.DeleteByName(ctx, id)
 }
+
+// DoUpdateWithID renames a connection in place via the UpdateConnection
+// API's NewName field. Triggered by update_id_on_changes on the name
+// field — without this method the planner would unnecessarily recreate
+// the connection just to rename it.
+func (r *ResourceConnection) DoUpdateWithID(ctx context.Context, id string, config *catalog.CreateConnection) (string, *catalog.ConnectionInfo, error) {
+	updateRequest := catalog.UpdateConnection{
+		Name:            id,
+		Options:         config.Options,
+		Owner:           "",
+		ForceSendFields: utils.FilterFields[catalog.UpdateConnection](config.ForceSendFields, "Owner"),
+	}
+
+	if config.Name != id {
+		updateRequest.NewName = config.Name
+	}
+
+	response, err := r.client.Connections.Update(ctx, updateRequest)
+	if err != nil || response == nil {
+		return "", nil, err
+	}
+
+	return response.Name, response, nil
+}

--- a/ucm/direct/dresources/resources.yml
+++ b/ucm/direct/dresources/resources.yml
@@ -11,7 +11,45 @@
 # Each field entry has:
 #   field: the field path
 #   reason: why this field is in this category
-#
-# Empty until UCM resources are migrated to the embedded-SDK-type pattern.
 
 resources:
+
+  volumes:
+    # Mirrors bundle/direct/dresources/resources.yml's volumes block.
+    # UpdateVolumeRequestContent only accepts {comment, new_name, owner};
+    # every other field is server-side immutable and a change must trigger
+    # recreate (else the planner loops forever silently dropping the field
+    # on Update).
+    recreate_on_changes:
+      - field: catalog_name
+        reason: immutable
+      - field: schema_name
+        reason: immutable
+      - field: storage_location
+        reason: immutable
+      - field: volume_type
+        reason: immutable
+    update_id_on_changes:
+      - field: name
+        reason: id_changes
+    backend_defaults:
+      # storage_location is computed by the backend for managed volumes.
+      - field: storage_location
+
+  connections:
+    # UCM-specific (bundle has no connection support). UpdateConnection
+    # accepts only {new_name, options, owner}; comment/connection_type/
+    # properties/read_only must trigger recreate to avoid the silent-drop
+    # infinite-loop.
+    recreate_on_changes:
+      - field: connection_type
+        reason: immutable
+      - field: comment
+        reason: not_in_update_api
+      - field: properties
+        reason: not_in_update_api
+      - field: read_only
+        reason: not_in_update_api
+    update_id_on_changes:
+      - field: name
+        reason: id_changes

--- a/ucm/direct/dresources/volume.go
+++ b/ucm/direct/dresources/volume.go
@@ -81,6 +81,35 @@ func (r *ResourceVolume) DoDelete(ctx context.Context, id string) error {
 	return r.client.Volumes.DeleteByName(ctx, id)
 }
 
+// DoUpdateWithID renames a volume in place via the UpdateVolume API's
+// NewName field. Mirrors bundle/direct/dresources/volume.go::DoUpdateWithID.
+// Triggered by update_id_on_changes on the name field — without this method
+// the planner would unnecessarily recreate the volume just to rename it.
+func (r *ResourceVolume) DoUpdateWithID(ctx context.Context, id string, config *catalog.CreateVolumeRequestContent) (string, *catalog.VolumeInfo, error) {
+	updateRequest := catalog.UpdateVolumeRequestContent{
+		Comment:         config.Comment,
+		Name:            id,
+		Owner:           "",
+		ForceSendFields: utils.FilterFields[catalog.UpdateVolumeRequestContent](config.ForceSendFields, "Owner"),
+	}
+
+	nameFromID, err := volumeNameFromID(id)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if config.Name != nameFromID {
+		updateRequest.NewName = config.Name
+	}
+
+	response, err := r.client.Volumes.Update(ctx, updateRequest)
+	if err != nil || response == nil {
+		return "", nil, err
+	}
+
+	return response.FullName, response, nil
+}
+
 // volumeNameFromID extracts the bare volume name from a fully-qualified id
 // (catalog.schema.name).
 func volumeNameFromID(id string) (string, error) {


### PR DESCRIPTION
Closes #62

## Summary
- Populate \`ucm/direct/dresources/resources.yml\` for volumes and connections so the planner correctly emits \`Recreate\` (delete + create) instead of silently looping on Update.
  - **volumes**: mirrors \`bundle/direct/dresources/resources.yml\` exactly — \`catalog_name\`, \`schema_name\`, \`storage_location\`, \`volume_type\` → \`recreate_on_changes\`; \`name\` → \`update_id_on_changes\`; \`storage_location\` → \`backend_defaults\`.
  - **connections**: UCM-specific (bundle has no connection support) — \`connection_type\`, \`comment\`, \`properties\`, \`read_only\` → \`recreate_on_changes\`; \`name\` → \`update_id_on_changes\`.
- Add \`DoUpdateWithID\` on both \`ResourceVolume\` and \`ResourceConnection\` so renames go through the API's \`new_name\` field instead of forcing a destructive recreate.
- Unit tests assert the lifecycle rules load correctly.

## Why
\`UpdateVolumeRequestContent\` accepts only \`{comment, new_name, owner}\`. Without \`recreate_on_changes\` on the immutable fields, the planner sees drift, schedules Update, the API silently drops the field, and the next plan sees the same drift — infinite no-op loop. Same shape for \`UpdateConnection\` ({new_name, options, owner}). The lifecycle infrastructure already existed (consumed by \`bundle_plan.go:438\`); it just had to be populated.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./cmd/ucm/... ./ucm/...\`
- [x] \`go test -count=1 ./cmd/ucm/... ./ucm/...\`
- [x] \`go test ./acceptance -run '^TestAccept/ucm' -timeout=10m\`